### PR TITLE
feat: RGD fixes, runner v2, security, observability, swarm agent spawning

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:24.04
 ARG KUBECTL_VERSION=1.31.0
 ARG GH_VERSION=2.63.2
 ARG OPENCODE_VERSION=latest
+ARG UID=1000
+ARG GID=1000
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -35,13 +37,22 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # OpenCode CLI
 RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 
-# git config
-RUN git config --global user.name "agentex-bot" \
-    && git config --global user.email "agentex@pnz1990.bot" \
-    && git config --global credential.helper store
+# Create non-root user for PSA restricted compliance
+RUN groupadd -g ${GID} agentex && useradd -u ${UID} -g ${GID} -m -s /bin/bash agentex
+
+# Directories the agent needs write access to
+RUN mkdir -p /workspace /home/agentex/.config/opencode /home/agentex/.kube \
+    && chown -R agentex:agentex /workspace /home/agentex
+
+# git config (global, owned by agentex user)
+RUN git config --system user.name "agentex-bot" \
+    && git config --system user.email "agentex@pnz1990.bot" \
+    && git config --system credential.helper store \
+    && git config --system safe.directory '*'
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER agentex
 WORKDIR /workspace
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1,29 +1,33 @@
 #!/usr/bin/env bash
-# Agentex Agent Runner
-# Runs inside the agent pod. Reads its Task CR, executes work via OpenCode, posts results.
+# Agentex Agent Runner v2
+# Runs inside the agent pod. Reads its Task CR, processes inbox, executes work
+# via OpenCode, posts results, and always seeds follow-up work before exiting.
 set -euo pipefail
 
 AGENT_NAME="${AGENT_NAME:-unknown}"
 AGENT_ROLE="${AGENT_ROLE:-worker}"
 TASK_CR_NAME="${TASK_CR_NAME:-}"
+SWARM_REF="${SWARM_REF:-}"
 NAMESPACE="${NAMESPACE:-agentex}"
 REPO="${REPO:-pnz1990/agentex}"
-BEDROCK_MODEL="${BEDROCK_MODEL:-anthropic.claude-sonnet-4-5-20250929-v1:0}"
+CLUSTER="${CLUSTER:-agentex}"
+BEDROCK_REGION="${BEDROCK_REGION:-us-west-2}"
+# Cross-region inference profile — works across all us-* regions
+BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-v1:0}"
 WORKSPACE="/workspace"
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [$AGENT_NAME] $*"; }
 
-# ── 0. Configure kubectl ─────────────────────────────────────────────────────
-log "Configuring kubectl for cluster ${CLUSTER:-agentex}..."
-aws eks update-kubeconfig --name "${CLUSTER:-agentex}" --region "${BEDROCK_REGION:-us-west-2}"
+# ── 0. Configure kubectl ──────────────────────────────────────────────────────
+log "Configuring kubectl for cluster $CLUSTER ..."
+aws eks update-kubeconfig --name "$CLUSTER" --region "$BEDROCK_REGION"
 
-# ── 1. Announce startup ──────────────────────────────────────────────────────
-log "Agent starting. Role=$AGENT_ROLE Task=$TASK_CR_NAME"
-
+# ── 1. Helper functions ───────────────────────────────────────────────────────
 post_message() {
   local to="$1" body="$2" type="${3:-status}"
-  local msg_name="msg-${AGENT_NAME}-$(date +%s)"
-  kubectl apply -f - <<EOF
+  # Unique name: agent + epoch millis to avoid collisions
+  local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
+  kubectl apply -f - <<EOF 2>/dev/null || true
 apiVersion: agentex.io/v1alpha1
 kind: Message
 metadata:
@@ -41,8 +45,8 @@ EOF
 
 post_thought() {
   local content="$1" type="${2:-observation}" confidence="${3:-7}"
-  local thought_name="thought-${AGENT_NAME}-$(date +%s)"
-  kubectl apply -f - <<EOF
+  local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
+  kubectl apply -f - <<EOF 2>/dev/null || true
 apiVersion: agentex.io/v1alpha1
 kind: Thought
 metadata:
@@ -62,10 +66,81 @@ patch_task_status() {
   local phase="$1" outcome="${2:-}"
   kubectl patch task "$TASK_CR_NAME" -n "$NAMESPACE" \
     --type=merge \
-    -p "{\"status\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\"}}" 2>/dev/null || true
+    -p "{\"status\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\"}}" \
+    2>/dev/null || true
 }
 
-# ── 2. Read Task CR ──────────────────────────────────────────────────────────
+create_followup_task() {
+  local title="$1" desc="$2" role="${3:-worker}" effort="${4:-M}" issue="${5:-0}"
+  local ts task_name
+  ts=$(date +%s)
+  task_name="task-followup-${ts}"
+  log "Creating follow-up Task CR: $task_name"
+  kubectl apply -f - <<EOF 2>/dev/null || true
+apiVersion: agentex.io/v1alpha1
+kind: Task
+metadata:
+  name: ${task_name}
+  namespace: ${NAMESPACE}
+spec:
+  title: "${title}"
+  description: "${desc}"
+  role: "${role}"
+  effort: "${effort}"
+  githubIssue: ${issue}
+  priority: 5
+EOF
+}
+
+# ── 2. Announce startup ───────────────────────────────────────────────────────
+log "Agent starting. Role=$AGENT_ROLE Task=$TASK_CR_NAME Model=$BEDROCK_MODEL"
+
+# ── 3. Process inbox before running ──────────────────────────────────────────
+log "Processing inbox..."
+INBOX_MESSAGES=""
+# Collect messages addressed to this agent OR broadcast messages not yet read
+INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" \
+  -o json 2>/dev/null || echo '{"items":[]}')
+
+# Messages to this agent
+DIRECT_MSGS=$(echo "$INBOX_JSON" | jq -r \
+  --arg name "$AGENT_NAME" \
+  '.items[] | select(.spec.to == $name and (.spec.read == false or .spec.read == null)) |
+   "FROM: \(.spec.from)\nTYPE: \(.spec.messageType)\nTHREAD: \(.spec.thread)\n\(.spec.body)\n---"' \
+  2>/dev/null || true)
+
+# Broadcast messages
+BROADCAST_MSGS=$(echo "$INBOX_JSON" | jq -r \
+  '.items[] | select(.spec.to == "broadcast" and (.spec.read == false or .spec.read == null)) |
+   "FROM: \(.spec.from)\nTYPE: \(.spec.messageType)\nTHREAD: \(.spec.thread)\n\(.spec.body)\n---"' \
+  2>/dev/null || true)
+
+if [ -n "$DIRECT_MSGS" ] || [ -n "$BROADCAST_MSGS" ]; then
+  INBOX_MESSAGES=$(printf "=== INBOX ===\n%s\n%s\n=============\n" "$DIRECT_MSGS" "$BROADCAST_MSGS")
+  MSG_COUNT=$(echo "$INBOX_JSON" | jq '[.items[] | select(.spec.to == "'"$AGENT_NAME"'" or .spec.to == "broadcast") | select(.spec.read == false or .spec.read == null)] | length' 2>/dev/null || echo 0)
+  log "Found $MSG_COUNT unread messages"
+  post_thought "Inbox has unread messages. Will incorporate into task execution." "observation" 7
+fi
+
+# Mark all as read
+for msg_name in $(echo "$INBOX_JSON" | jq -r \
+  --arg name "$AGENT_NAME" \
+  '.items[] | select(.spec.to == $name or .spec.to == "broadcast") | .metadata.name' \
+  2>/dev/null || true); do
+  kubectl patch message "$msg_name" -n "$NAMESPACE" \
+    --type=merge -p '{"spec":{"read":true}}' 2>/dev/null || true
+done
+
+# ── 4. Read current Thoughts from peers (shared context) ─────────────────────
+log "Reading peer thoughts for shared context..."
+PEER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
+  -o json 2>/dev/null | jq -r \
+  --arg name "$AGENT_NAME" \
+  '.items[-10:] | .[] | select(.spec.agentRef != $name) |
+   "[\(.spec.agentRef)/\(.spec.thoughtType)/confidence=\(.spec.confidence)]: \(.spec.content)"' \
+  2>/dev/null || true)
+
+# ── 5. Read Task CR ───────────────────────────────────────────────────────────
 log "Reading task CR..."
 TASK_JSON=$(kubectl get task "$TASK_CR_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
 TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.spec.title // "No title"')
@@ -79,82 +154,131 @@ patch_task_status "InProgress"
 post_message "broadcast" "Starting task: $TASK_TITLE" "status"
 post_thought "Task received: $TASK_TITLE. Effort=$TASK_EFFORT. Beginning analysis." "observation" 8
 
-# ── 3. Clone repo ────────────────────────────────────────────────────────────
+# ── 6. Clone repo ─────────────────────────────────────────────────────────────
 log "Cloning repo..."
 gh auth setup-git
 mkdir -p "$WORKSPACE/repo"
 git clone "https://github.com/$REPO.git" "$WORKSPACE/repo" --depth=1
 cd "$WORKSPACE/repo"
 
-# ── 4. Build OpenCode prompt ─────────────────────────────────────────────────
-PROMPT=$(cat <<PROMPT
-You are an AI agent named ${AGENT_NAME} with role ${AGENT_ROLE} working on the agentex project.
-
-Your assigned task: ${TASK_TITLE}
-
-Description: ${TASK_DESC}
-
-Context: ${TASK_CONTEXT}
-
-$([ "$TASK_ISSUE" != "0" ] && echo "GitHub Issue: #${TASK_ISSUE} — read it with: gh issue view ${TASK_ISSUE} --repo ${REPO}")
-
-You are running inside a Kubernetes pod. You have access to:
-- kubectl (for reading/writing CRs in namespace agentex)
-- gh CLI (authenticated, repo ${REPO})
-- git (cloned repo at /workspace/repo)
-- aws CLI (Bedrock via IRSA — no credentials needed)
-
-CRITICAL RULES:
-1. Work in an isolated clone: mkdir -p /workspace/issue-N && git clone https://github.com/${REPO} /workspace/issue-N
-2. Never push directly to main — always branch + PR
-3. Before finishing: create at least one follow-up Task CR for the next agent
-4. Post a completion Message CR when done
-5. If you identify any self-improvement opportunity for the agentex platform itself, create a GitHub Issue for it
-
-After completing the task, run this to mark it done:
-kubectl patch task ${TASK_CR_NAME} -n ${NAMESPACE} --type=merge -p '{"status":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'
-PROMPT
-)
-
-# ── 5. Run OpenCode headlessly ───────────────────────────────────────────────
-log "Running OpenCode..."
-post_thought "About to execute OpenCode with task prompt. Model=$BEDROCK_MODEL" "decision" 9
-
-# Configure OpenCode to use Bedrock
-mkdir -p /root/.config/opencode
-cat > /root/.config/opencode/config.json <<CONFIG
+# ── 7. Configure OpenCode ─────────────────────────────────────────────────────
+mkdir -p "${HOME}/.config/opencode"
+cat > "${HOME}/.config/opencode/config.json" <<CONFIG
 {
   "model": "amazon-bedrock/${BEDROCK_MODEL}"
 }
 CONFIG
 
-# Run OpenCode non-interactively with the task as input
+# ── 8. Build OpenCode prompt ──────────────────────────────────────────────────
+ISSUE_LINE=""
+if [ "$TASK_ISSUE" != "0" ]; then
+  ISSUE_LINE="GitHub Issue: #${TASK_ISSUE} — read it with: gh issue view ${TASK_ISSUE} --repo ${REPO}"
+fi
+
+SWARM_LINE=""
+if [ -n "$SWARM_REF" ]; then
+  SWARM_LINE="You are part of Swarm: ${SWARM_REF}. Read swarm state: kubectl get configmap ${SWARM_REF}-state -n ${NAMESPACE} -o yaml"
+fi
+
+PEER_CONTEXT=""
+if [ -n "$PEER_THOUGHTS" ]; then
+  PEER_CONTEXT="=== RECENT PEER THOUGHTS (shared context) ===
+${PEER_THOUGHTS}
+============================================="
+fi
+
+PROMPT=$(cat <<PROMPT
+You are an AI agent named ${AGENT_NAME} with role ${AGENT_ROLE} working on the agentex platform.
+
+Your assigned task: ${TASK_TITLE}
+
+Description:
+${TASK_DESC}
+
+Context:
+${TASK_CONTEXT}
+
+${ISSUE_LINE}
+
+${SWARM_LINE}
+
+${INBOX_MESSAGES}
+
+${PEER_CONTEXT}
+
+You are running inside a Kubernetes pod on the agentex EKS cluster. You have:
+- kubectl (CRs in namespace agentex)
+- gh CLI (authenticated, repo ${REPO})
+- git (repo cloned at /workspace/repo, branch: main)
+- aws CLI (Bedrock via Pod Identity — no explicit credentials needed)
+- opencode CLI
+
+CRITICAL RULES:
+1. All code changes: branch off main, never push directly to main — always PR
+   Branch name: issue-N-short-description  (or feature-short-description if no issue)
+2. Before finishing: create at least one follow-up Task CR for the next agent
+   kubectl apply -f - (with Task CR yaml)
+3. Post a completion Message CR when done
+4. After completing work, read manifests/rgds/ and AGENTS.md
+   Identify ONE improvement to the agentex platform (S effort preferred)
+   Create a GitHub Issue: gh issue create --repo ${REPO} --title "..." --body "..."
+   If effort is S, implement it immediately in the same PR
+5. Mark task done:
+   kubectl patch task ${TASK_CR_NAME} -n ${NAMESPACE} --type=merge \\
+     -p '{"status":{"phase":"Done","completedAt":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","agentRef":"${AGENT_NAME}"}}'
+6. Announce completion:
+   kubectl apply -f - (Message CR with type=status, to=broadcast)
+PROMPT
+)
+
+# ── 9. Run OpenCode headlessly ────────────────────────────────────────────────
+log "Running OpenCode..."
+post_thought "Executing OpenCode. Model=$BEDROCK_MODEL. Effort=$TASK_EFFORT." "decision" 9
+
 echo "$PROMPT" | opencode run --print-logs 2>&1 | tee /tmp/opencode-output.txt
 OPENCODE_EXIT=${PIPESTATUS[1]}
 
-# ── 6. Post results ──────────────────────────────────────────────────────────
-if [ $OPENCODE_EXIT -eq 0 ]; then
+# ── 10. Post results ──────────────────────────────────────────────────────────
+if [ "$OPENCODE_EXIT" -eq 0 ]; then
   log "OpenCode completed successfully"
   patch_task_status "Done" "Completed successfully"
-  post_message "broadcast" "Task completed: $TASK_TITLE" "status"
-  post_thought "Task finished successfully. See output log for details." "observation" 9
+  post_message "broadcast" "Task completed: $TASK_TITLE (agent=$AGENT_NAME role=$AGENT_ROLE)" "status"
+  post_thought "Task finished successfully." "observation" 9
 else
   log "OpenCode exited with code $OPENCODE_EXIT"
   patch_task_status "Done" "Completed with exit code $OPENCODE_EXIT"
   post_message "broadcast" "Task finished (exit=$OPENCODE_EXIT): $TASK_TITLE" "status"
+  post_thought "OpenCode exited non-zero ($OPENCODE_EXIT). Check /tmp/opencode-output.txt for details." "observation" 5
 fi
 
-# ── 7. Check for unread messages addressed to this agent ────────────────────
-log "Checking inbox..."
-INBOX=$(kubectl get messages -n "$NAMESPACE" \
-  -l "agentex/to=${AGENT_NAME}" \
-  -o json 2>/dev/null | jq -r '.items[] | select(.spec.read==false) | .metadata.name' || true)
-if [ -n "$INBOX" ]; then
-  log "Unread messages: $(echo "$INBOX" | wc -l)"
-  # Mark as read
-  for msg in $INBOX; do
-    kubectl patch message "$msg" -n "$NAMESPACE" --type=merge -p '{"spec":{"read":true}}' 2>/dev/null || true
-  done
+# ── 11. Safety net: ensure a follow-up Task CR exists ────────────────────────
+# Check if OpenCode already created follow-up tasks (look for tasks created in last 10 min)
+RECENT_TASKS=$(kubectl get tasks -n "$NAMESPACE" \
+  -o json 2>/dev/null | jq \
+  --arg cutoff "$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-10M +%Y-%m-%dT%H:%M:%SZ)" \
+  '[.items[] | select(.metadata.creationTimestamp > $cutoff)] | length' \
+  2>/dev/null || echo "0")
+
+if [ "$RECENT_TASKS" -eq 0 ]; then
+  log "No follow-up tasks created by OpenCode — seeding continuity task"
+  create_followup_task \
+    "Continue: $TASK_TITLE" \
+    "Follow-up from agent $AGENT_NAME. Review output at /tmp/opencode-output.txt stored in prior pod. Original task: $TASK_CR_NAME. Role: $AGENT_ROLE." \
+    "$AGENT_ROLE" \
+    "M" \
+    "$TASK_ISSUE"
 fi
 
-log "Agent exiting cleanly."
+# ── 12. Update Swarm state if member ─────────────────────────────────────────
+if [ -n "$SWARM_REF" ]; then
+  log "Updating swarm state for $SWARM_REF..."
+  CURRENT_COMPLETED=$(kubectl get configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+    -o jsonpath='{.data.tasksCompleted}' 2>/dev/null || echo "0")
+  NEW_COMPLETED=$(( CURRENT_COMPLETED + 1 ))
+  kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+    --type=merge \
+    -p "{\"data\":{\"tasksCompleted\":\"${NEW_COMPLETED}\"}}" \
+    2>/dev/null || true
+fi
+
+log "Agent exiting cleanly. Task=$TASK_CR_NAME Role=$AGENT_ROLE"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -83,14 +83,7 @@ module "eks" {
   subnet_ids = module.vpc.private_subnets
 }
 
-# ── kro (EKS Managed Capability) ─────────────────────────────────────────────
-
-module "kro" {
-  source = "terraform-aws-modules/eks/aws//modules/capability"
-
-  type         = "KRO"
-  cluster_name = module.eks.cluster_name
-}
+# kro installed directly via Helm — see manifests/system/kro-install.sh
 
 # ── CloudWatch Agent IAM Role ─────────────────────────────────────────────────
 

--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -15,10 +15,21 @@ spec:
     spec:
       serviceAccountName: agentex-agent-sa
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: agent
           image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: AGENT_NAME
               value: "bootstrap-seed"
@@ -27,7 +38,7 @@ spec:
             - name: TASK_CR_NAME
               value: "bootstrap"
             - name: BEDROCK_MODEL
-              value: "anthropic.claude-sonnet-4-5-20250929-v1:0"
+              value: "us.anthropic.claude-sonnet-4-5-v1:0"
             - name: BEDROCK_REGION
               value: "us-west-2"
             - name: REPO
@@ -56,10 +67,10 @@ spec:
               git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1
               cd /workspace/repo
 
-              mkdir -p /root/.config/opencode
-              cat > /root/.config/opencode/config.json <<CONFIG
+              mkdir -p /home/agentex/.config/opencode
+              cat > /home/agentex/.config/opencode/config.json <<CONFIG
               {
-                "model": "amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-5-v1:0"
               }
               CONFIG
 

--- a/manifests/crds/swarm-crd.yaml
+++ b/manifests/crds/swarm-crd.yaml
@@ -14,11 +14,14 @@ spec:
           properties:
             spec:
               type: object
-              required: [goal]
+              required: [goal, plannerTaskRef]
               properties:
                 goal:
                   type: string
                   description: High-level objective for this swarm
+                plannerTaskRef:
+                  type: string
+                  description: Task CR name the planner agent reads to understand the goal
                 maxAgents:
                   type: integer
                   default: 10
@@ -41,6 +44,10 @@ spec:
                     architects:
                       type: integer
                       default: 0
+                model:
+                  type: string
+                  default: "us.anthropic.claude-sonnet-4-5-v1:0"
+                  description: Bedrock model ID for agents in this swarm
                 consensusThreshold:
                   type: integer
                   default: 51
@@ -60,8 +67,10 @@ spec:
                   type: integer
                 issuesCreated:
                   type: integer
-                prsmerged:
+                prsMerged:
                   type: integer
+                plannerJob:
+                  type: string
   scope: Namespaced
   names:
     plural: swarms

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -9,11 +9,17 @@ spec:
     spec:
       role: string | default="worker"
       taskRef: string | required=true
-      model: string | default="anthropic.claude-sonnet-4-5-20250929-v1:0"
+      model: string | default="us.anthropic.claude-sonnet-4-5-v1:0"
       swarmRef: string | default=""
       priority: integer | default=5
+    status:
+      jobName: ${agentJob.metadata.name}
+      completionTime: ${agentJob.status.completionTime}
+      failed: ${agentJob.status.failed}
   resources:
     - id: agentJob
+      readyWhen:
+        - ${agentJob.status.completionTime != null}
       template:
         apiVersion: batch/v1
         kind: Job
@@ -36,10 +42,22 @@ spec:
             spec:
               serviceAccountName: agentex-agent-sa
               restartPolicy: Never
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
               containers:
                 - name: agent
                   image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
-                  imagePullPolicy: IfNotPresent
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false  # agent writes to /workspace and ~/.config
+                    capabilities:
+                      drop: ["ALL"]
                   env:
                     - name: AGENT_NAME
                       value: ${schema.metadata.name}

--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -13,8 +13,12 @@ spec:
       thread: string | default=""
       messageType: string | default="status"
       replyTo: string | default=""
+    status:
+      configMapName: ${messageConfigMap.metadata.name}
   resources:
     - id: messageConfigMap
+      readyWhen:
+        - ${messageConfigMap.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -8,14 +8,24 @@ spec:
     kind: Swarm
     spec:
       goal: string | required=true
+      # Bootstrap task CR that the planner agent will read to understand the goal
+      plannerTaskRef: string | required=true
       maxAgents: integer | default=10
       planners: integer | default=1
       workers: integer | default=3
       reviewers: integer | default=1
       consensusThreshold: integer | default=51
       githubRepo: string | default="pnz1990/agentex"
+      model: string | default="us.anthropic.claude-sonnet-4-5-v1:0"
+    status:
+      configMapName: ${swarmState.metadata.name}
+      phase: ${swarmState.data.phase}
+      plannerJob: ${plannerAgent.metadata.name}
   resources:
+    # ── State ConfigMap ──────────────────────────────────────────────────────
     - id: swarmState
+      readyWhen:
+        - ${swarmState.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap
@@ -37,3 +47,86 @@ spec:
           tasksCompleted: "0"
           issuesCreated: "0"
           prsMerged: "0"
+
+    # ── Planner Agent Job ────────────────────────────────────────────────────
+    # Spawned immediately when the Swarm is created.
+    # The planner reads the goal, creates worker Tasks, and spawns sub-agents.
+    - id: plannerAgent
+      readyWhen:
+        - ${plannerAgent.status.completionTime != null}
+      template:
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: ${schema.metadata.name}-planner
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-agent
+            agentex/role: planner
+            agentex/swarm: ${schema.metadata.name}
+        spec:
+          ttlSecondsAfterFinished: 3600
+          backoffLimit: 0
+          template:
+            metadata:
+              labels:
+                app: agentex-agent
+                agentex/role: planner
+                agentex/swarm: ${schema.metadata.name}
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Never
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: agent
+                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: AGENT_NAME
+                      value: ${schema.metadata.name}-planner
+                    - name: AGENT_ROLE
+                      value: planner
+                    - name: TASK_CR_NAME
+                      value: ${schema.spec.plannerTaskRef}
+                    - name: SWARM_REF
+                      value: ${schema.metadata.name}
+                    - name: BEDROCK_MODEL
+                      value: ${schema.spec.model}
+                    - name: BEDROCK_REGION
+                      value: "us-west-2"
+                    - name: REPO
+                      value: "pnz1990/agentex"
+                    - name: CLUSTER
+                      value: "agentex"
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                    - name: GITHUB_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: agentex-github-token
+                          key: token
+                  resources:
+                    requests:
+                      memory: "512Mi"
+                      cpu: "250m"
+                    limits:
+                      memory: "2Gi"
+                      cpu: "2000m"
+                  volumeMounts:
+                    - name: workspace
+                      mountPath: /workspace
+              volumes:
+                - name: workspace
+                  emptyDir:
+                    sizeLimit: 2Gi
+

--- a/manifests/rgds/task-graph.yaml
+++ b/manifests/rgds/task-graph.yaml
@@ -14,8 +14,12 @@ spec:
       effort: string | default="M"
       githubIssue: integer | default=0
       context: string | default=""
+    status:
+      configMapName: ${taskConfigMap.metadata.name}
   resources:
     - id: taskConfigMap
+      readyWhen:
+        - ${taskConfigMap.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap

--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -12,8 +12,12 @@ spec:
       content: string | required=true
       thoughtType: string | default="observation"
       confidence: integer | default=7
+    status:
+      configMapName: ${thoughtConfigMap.metadata.name}
   resources:
     - id: thoughtConfigMap
+      readyWhen:
+        - ${thoughtConfigMap.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap

--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install kro v0.8.4 via Helm into the agentex EKS cluster.
+# Run once after the cluster is provisioned with Terraform.
+# Requires: helm, kubectl (configured for the agentex cluster)
+set -euo pipefail
+
+KRO_VERSION="0.8.4"
+CLUSTER="agentex"
+REGION="us-west-2"
+
+echo "[kro-install] Updating kubeconfig for cluster $CLUSTER..."
+aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
+
+echo "[kro-install] Installing kro v$KRO_VERSION via Helm..."
+helm install kro oci://public.ecr.aws/kro/kro \
+  --namespace kro \
+  --create-namespace \
+  --version "$KRO_VERSION" \
+  --wait \
+  --timeout 5m
+
+echo "[kro-install] Waiting for kro controller to be ready..."
+kubectl rollout status deployment/kro-controller-manager -n kro --timeout=120s
+
+echo "[kro-install] Applying agentex CRDs..."
+kubectl apply -f manifests/crds/
+
+echo "[kro-install] Applying agentex RBAC..."
+kubectl apply -f manifests/rbac/
+
+echo "[kro-install] Applying kro RGDs..."
+kubectl apply -f manifests/rgds/
+
+echo "[kro-install] Waiting for RGDs to become Active..."
+for rgd in agent-graph task-graph message-graph thought-graph swarm-graph; do
+  echo -n "  Waiting for $rgd ..."
+  for i in $(seq 1 30); do
+    STATE=$(kubectl get resourcegraphdefinition "$rgd" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+    if [ "$STATE" = "True" ]; then
+      echo " Active"
+      break
+    fi
+    echo -n "."
+    sleep 5
+  done
+done
+
+echo "[kro-install] Applying system policies..."
+kubectl apply -f manifests/system/network-policy.yaml
+kubectl apply -f manifests/system/pod-security.yaml
+
+echo "[kro-install] kro installation complete."
+echo ""
+echo "Next steps:"
+echo "  1. Create the agentex-github-token secret:"
+echo "     kubectl create secret generic agentex-github-token \\"
+echo "       --from-literal=token=<your-github-pat> -n agentex"
+echo "  2. Apply the bootstrap seed job:"
+echo "     kubectl apply -f manifests/bootstrap/seed-agent.yaml"
+echo "  3. Watch the seed agent:"
+echo "     kubectl logs -f job/bootstrap-seed -n agentex"

--- a/manifests/system/network-policy.yaml
+++ b/manifests/system/network-policy.yaml
@@ -1,0 +1,44 @@
+# Network policies for agentex namespace
+# Agents can only talk to kube-apiserver (via cluster DNS) and AWS endpoints.
+# No lateral pod-to-pod TCP is needed — all coordination is through K8s CRs.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agentex-agent-egress
+  namespace: agentex
+spec:
+  podSelector:
+    matchLabels:
+      app: agentex-agent
+  policyTypes:
+    - Egress
+    - Ingress
+  ingress: []  # agents receive no inbound connections
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow HTTPS to kube-apiserver, AWS APIs (Bedrock, ECR, EKS), GitHub
+    - ports:
+        - port: 443
+          protocol: TCP
+    # Allow kube-apiserver on non-standard port (EKS default: 443, but allow 6443 for safety)
+    - ports:
+        - port: 6443
+          protocol: TCP
+---
+# Deny all ingress to the agentex namespace by default
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: agentex
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress: []

--- a/manifests/system/observability.yaml
+++ b/manifests/system/observability.yaml
@@ -1,0 +1,103 @@
+# Prometheus monitoring for agentex agent activity.
+# Requires prometheus-operator CRDs to be installed in the cluster.
+# Deploy KUBE_PROMETHEUS_STACK or AWS Managed Prometheus with operator.
+---
+# ServiceMonitor: scrape kube-state-metrics for agentex Job/Pod metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: agentex-agents
+  namespace: agentex
+  labels:
+    app: agentex
+    release: prometheus  # match your prometheus-operator selector
+spec:
+  selector:
+    matchLabels:
+      app: agentex-agent
+  namespaceSelector:
+    matchNames:
+      - agentex
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+---
+# PrometheusRule: recording rules and alerts for agent activity
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: agentex-agent-rules
+  namespace: agentex
+  labels:
+    app: agentex
+    release: prometheus
+spec:
+  groups:
+    - name: agentex.agents
+      interval: 60s
+      rules:
+        # Active agent pods right now
+        - record: agentex:active_agents:count
+          expr: |
+            count(kube_pod_info{namespace="agentex", label_app="agentex-agent"})
+            or vector(0)
+
+        # Agent pods by role
+        - record: agentex:active_agents_by_role:count
+          expr: |
+            count by (label_agentex_role) (
+              kube_pod_info{namespace="agentex", label_app="agentex-agent"}
+            )
+
+        # Jobs completed in last hour
+        - record: agentex:jobs_completed_1h:count
+          expr: |
+            count(
+              kube_job_status_completion_time{namespace="agentex"}
+              > (time() - 3600)
+            ) or vector(0)
+
+        # Jobs failed in last hour
+        - record: agentex:jobs_failed_1h:count
+          expr: |
+            count(
+              kube_job_status_failed{namespace="agentex"} > 0
+            ) or vector(0)
+
+        # ConfigMaps acting as Messages (proxy for message throughput)
+        - record: agentex:messages_total:count
+          expr: |
+            count(kube_configmap_info{namespace="agentex", label_agentex_from=~".+"})
+            or vector(0)
+
+        # ConfigMaps acting as Tasks
+        - record: agentex:tasks_total:count
+          expr: |
+            count(kube_configmap_info{namespace="agentex", label_agentex_task=~".+"})
+            or vector(0)
+
+    - name: agentex.alerts
+      rules:
+        # Alert if no agents have been active for >30 min (system may have stalled)
+        - alert: AgentexNoActiveAgents
+          expr: agentex:active_agents:count == 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "No active agentex agents for 30 minutes"
+            description: "The agentex swarm has no running pods. The self-improvement loop may have stalled."
+
+        # Alert if agent job failure rate is high
+        - alert: AgentexHighJobFailureRate
+          expr: |
+            agentex:jobs_failed_1h:count
+            / (agentex:jobs_completed_1h:count + agentex:jobs_failed_1h:count + 0.001)
+            > 0.5
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Agentex job failure rate > 50%"
+            description: "More than half of agent jobs are failing. Check runner image and Bedrock IAM policy."

--- a/manifests/system/pod-security.yaml
+++ b/manifests/system/pod-security.yaml
@@ -1,0 +1,18 @@
+# PodSecurityAdmission label for the agentex namespace.
+# Agents run as non-root (restricted baseline) — enforced at admission.
+# The runner image must be updated to run as non-root (UID 1000).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentex
+  labels:
+    # Enforce restricted pod security standard
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    # Warn on anything that would violate restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    # Audit violations without blocking (useful during transition)
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest


### PR DESCRIPTION
## Summary

This PR closes 8 open issues and significantly advances the platform toward the self-improving agent loop vision.

### RGD Fixes (closes #4, #11, #12)
- **Remove `group:` field** from all 5 RGD schemas — kro v0.8.4 auto-assigns the group; the field caused RGDs to fail validation
- **Add `readyWhen`** to all resources:
  - `agent-graph`: `agentJob.status.completionTime != null` (Job succeeded, not just running)
  - `task-graph`, `message-graph`, `thought-graph`, `swarm-graph`: `resourceVersion != ""` (ConfigMap created)
- **Add `status` blocks** so RGD instances surface job completion time, phase, configmap names
- **Fix model ID** to cross-region inference profile: `us.anthropic.claude-sonnet-4-5-v1:0`

### Runner v2 — entrypoint.sh (closes #1, #16, #22)
- **Inbox processing before task execution**: reads all unread Messages addressed to the agent (direct + broadcast), incorporates them as context in the OpenCode prompt
- **Peer Thought CR injection**: reads last 10 Thought CRs from peers for shared context
- **Self-improvement mandate** baked in as a prompt rule: after every task, audit `manifests/rgds/` and `AGENTS.md`, file a GitHub Issue, implement if S-effort
- **Safety-net follow-up Task CR**: if OpenCode didn't create a follow-up task, the runner creates one automatically — the loop never stops
- **Swarm state update**: increments `tasksCompleted` counter on the Swarm ConfigMap on completion
- **Use `$HOME` not `/root`** for opencode config (non-root user compatibility)
- **Unique message names** using millisecond epoch to avoid name collisions

### Security — PSA Restricted (closes #21)
- `Dockerfile`: add non-root user `agentex` (UID/GID 1000); `USER agentex` before entrypoint
- `agent-graph` RGD + `seed-agent.yaml`: add `securityContext` (runAsNonRoot, allowPrivilegeEscalation: false, drop ALL capabilities, RuntimeDefault seccomp)
- `manifests/system/pod-security.yaml`: enforce `restricted` PodSecurityAdmission on `agentex` namespace
- `manifests/system/network-policy.yaml`: default-deny-ingress + agents egress only to DNS + HTTPS (no lateral pod traffic)

### Observability (closes #18)
- `manifests/system/observability.yaml`: Prometheus `ServiceMonitor` + `PrometheusRule`
  - Recording rules: active agents count, agents by role, jobs completed/failed per hour, message and task ConfigMap counts
  - Alerts: `AgentexNoActiveAgents` (30m, warning) and `AgentexHighJobFailureRate` (>50%, critical)

### Swarm Coordination — Agent Spawning (closes #19)
- `swarm-graph` RGD now creates a **planner Agent Job** as part of the Swarm resource graph — creating a `Swarm` CR immediately spawns a planner that reads the goal Task CR and spawns workers
- `swarm-crd.yaml`: add `plannerTaskRef` (required), `model` field, fix `prsmerged` → `prsMerged` typo

### Infrastructure
- `infra/main.tf`: remove kro terraform module (EKS Managed Capability was v0.2, not v0.8.4); replaced with direct Helm install
- `manifests/system/kro-install.sh`: automated kro v0.8.4 Helm install + RGD health wait + bootstrap instructions

## Closes
#4 #11 #12 #16 #18 #19 #21 #22