### PR TITLE
fix: use kro.run/v1alpha1 for Agent CRs (agentex.io does not trigger Jobs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Every agent MUST do all four of these before exiting:
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
 ```bash
-# Task CR (defines the work)
+# Task CR (defines the work) — use agentex.io/v1alpha1
 kubectl apply -f - <<EOF
 apiVersion: agentex.io/v1alpha1
 kind: Task
@@ -33,9 +33,10 @@ spec:
   priority: 5
 EOF
 
-# Agent CR (triggers the Job via kro)
+# Agent CR (triggers the Job via kro) — MUST use kro.run/v1alpha1 (NOT agentex.io)
+# kro watches kro.run group. Using agentex.io will NOT trigger a Job.
 kubectl apply -f - <<EOF
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
   name: <next-agent>
@@ -105,6 +106,7 @@ Five RGDs form the agent coordination layer:
 - No `group:` field in schema — kro auto-assigns it
 - CEL expressions unquoted: `${schema.spec.x}` not `"${schema.spec.x}"`
 - `readyWhen` per resource: `${agentJob.status.completionTime != null}`
+- **Agent CRs MUST use `kro.run/v1alpha1`** — kro watches this group to trigger Jobs. `agentex.io/v1alpha1` is a legacy CRD and will NOT create a Job.
 
 ---
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -77,7 +77,7 @@ spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   log "Spawning successor: name=$name role=$role task=$task_ref reason=$reason"
   kubectl apply -f - <<EOF 2>/dev/null || true
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
   name: ${name}
@@ -234,8 +234,10 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     priority: 5
   EOF
 
+  # IMPORTANT: Agent CRs must use kro.run/v1alpha1 (NOT agentex.io/v1alpha1)
+  # kro watches kro.run group to trigger Jobs. agentex.io is a dead CRD.
   kubectl apply -f - <<EOF
-  apiVersion: agentex.io/v1alpha1
+  apiVersion: kro.run/v1alpha1
   kind: Agent
   metadata:
     name: <next-name>
@@ -360,7 +362,7 @@ fi
 # If OpenCode failed to spawn a successor Agent CR, do it here unconditionally.
 # This is the last line of defense against the system going dark.
 
-SPAWNED_AFTER=$(kubectl get agents -n "$NAMESPACE" \
+SPAWNED_AFTER=$(kubectl get agents.kro.run -n "$NAMESPACE" \
   -o json 2>/dev/null | jq \
   --arg since "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-15M +%Y-%m-%dT%H:%M:%SZ)" \
   '[.items[] | select(.metadata.creationTimestamp > $since)] | length' \

--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -141,10 +141,12 @@ data:
       For each of the top 3 create BOTH a Task CR AND an Agent CR.
       The Agent CR is what triggers a new Job via kro. A Task alone does nothing.
       Example Agent CR (fill in your values):
-        apiVersion: agentex.io/v1alpha1 / kind: Agent / namespace: agentex
+        apiVersion: kro.run/v1alpha1 / kind: Agent / namespace: agentex
         spec.role: worker / spec.taskRef: task-issue-N
         spec.model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
         metadata.labels: agentex/spawned-by=bootstrap-seed
+      NOTE: Agent CRs MUST use apiVersion: kro.run/v1alpha1 (NOT agentex.io/v1alpha1)
+      kro watches kro.run group to trigger Jobs. Using agentex.io will NOT work.
 
     STEP 4 - Spawn planner-001 (THE HEARTBEAT OF THE SYSTEM)
       Create task-planner-001 (role: planner, effort: L, priority: 10).


### PR DESCRIPTION
## Problem

Agent CRs created with `apiVersion: agentex.io/v1alpha1` land on a legacy manually-applied CRD that kro does not watch. kro only watches `kro.run/v1alpha1` resources to reconcile them into Jobs. This meant every agent that spawned a successor — including the emergency perpetuation fallback in `entrypoint.sh` — was silently creating inert CRs, and no Jobs were ever triggered. The planner loop appeared to work but was completely broken.

Discovered by: checking `kubectl get agents.kro.run -n agentex` (empty) vs `kubectl get agents.agentex.io -n agentex` (had planner-001 with no corresponding Job).

## Fix

- `entrypoint.sh`: `spawn_agent()` and `spawn_task_and_agent()` now use `kro.run/v1alpha1` for Agent CRs
- `entrypoint.sh`: PERPETUATION_MANIFEST (embedded in every agent prompt) updated with correct API group
- `entrypoint.sh`: Emergency perpetuation check queries `agents.kro.run` (not bare `agents`)
- `AGENTS.md`: Prime Directive example updated; kro DSL rules section now explicitly notes the API group requirement
- `manifests/bootstrap/seed-agent.yaml`: Seed prompt example updated

## Verification

After applying these changes and restarting the kro controller (to pick up RBAC changes), `planner-002` was spawned using `kro.run/v1alpha1` and a Job was immediately created and ran successfully.