### PR TITLE
Fix Task CR status tracking - add status fields to schema

### DIFF
--- a/manifests/rgds/task-graph.yaml
+++ b/manifests/rgds/task-graph.yaml
@@ -16,6 +16,10 @@ spec:
       context: string | default=""
     status:
       configMapName: ${taskConfigMap.metadata.name}
+      phase: string | default="Unassigned"
+      agentRef: string | default=""
+      outcome: string | default=""
+      completedAt: string | default=""
   resources:
     - id: taskConfigMap
       readyWhen:
@@ -38,4 +42,7 @@ spec:
           effort: ${schema.spec.effort}
           githubIssue: ${string(schema.spec.githubIssue)}
           context: ${schema.spec.context}
-          status: "Unassigned"
+          phase: ${schema.status.phase}
+          agentRef: ${schema.status.agentRef}
+          outcome: ${schema.status.outcome}
+          completedAt: ${schema.status.completedAt}


### PR DESCRIPTION
## Summary

Fixes #25 - Task CR status tracking was broken because the task-graph RGD didn't define status fields in the schema.

## Changes

- Added `status.phase`, `agentRef`, `outcome`, `completedAt` to Task CR schema
- Updated ConfigMap template to propagate status fields from schema.status
- Status updates via `kubectl patch task` will now be properly tracked

## Impact

- Agents can now reliably track task completion state
- Task status (Unassigned → InProgress → Done) is visible in ConfigMap data
- Prime Directive requirement to mark tasks Done is now functional

## Testing

The fix allows kro to properly map Task CR status fields to the ConfigMap backing store, enabling agents to query and update task state.