### PR TITLE
Fix emergency perpetuation - check spawned-by label instead of timestamp

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -367,13 +367,13 @@ fi
 # If OpenCode failed to spawn a successor Agent CR, do it here unconditionally.
 # This is the last line of defense against the system going dark.
 
-SPAWNED_AFTER=$(kubectl get agents.kro.run -n "$NAMESPACE" \
-  -o json 2>/dev/null | jq \
-  --arg since "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-15M +%Y-%m-%dT%H:%M:%SZ)" \
-  '[.items[] | select(.metadata.creationTimestamp > $since)] | length' \
-  2>/dev/null || echo "0")
+# Check if THIS agent spawned a successor by filtering on the spawned-by label.
+# This is precise and avoids false positives from other agents' spawns.
+SPAWNED_BY_ME=$(kubectl get agents.kro.run -n "$NAMESPACE" \
+  -l "agentex/spawned-by=$AGENT_NAME" \
+  -o json 2>/dev/null | jq '.items | length' 2>/dev/null || echo "0")
 
-if [ "$SPAWNED_AFTER" -eq 0 ]; then
+if [ "$SPAWNED_BY_ME" -eq 0 ]; then
   log "WARNING: No successor Agent CR created. Activating emergency perpetuation."
   post_thought "Emergency perpetuation triggered — OpenCode did not spawn a successor." "blocker" 3
 
@@ -413,7 +413,7 @@ The system must never idle. You are responsible for keeping it alive." \
 
   log "Emergency successor spawned: Agent=$NEXT_AGENT Task=$NEXT_TASK Role=$NEXT_ROLE"
 else
-  log "Successor agent(s) already spawned by OpenCode ($SPAWNED_AFTER). Good."
+  log "Successor agent(s) already spawned by this agent ($SPAWNED_BY_ME). Good."
 fi
 
 # ── 12. Update Swarm state ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #28 - Emergency perpetuation logic was checking if ANY Agent CR was created recently, causing false positives in multi-agent environments.

## Changes

- Changed emergency perpetuation detection from time-based to label-based
- Now checks for Agent CRs with label `agentex/spawned-by=$AGENT_NAME`
- Updated log message to reflect the count of agents spawned by this agent

## Before

```bash
SPAWNED_AFTER=$(kubectl get agents -n "$NAMESPACE" \
  -o json 2>/dev/null | jq \
  --arg since "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-15M +%Y-%m-%dT%H:%M:%SZ)" \
  '[.items[] | select(.metadata.creationTimestamp > $since)] | length' \
  2>/dev/null || echo "0")
```

## After

```bash
SPAWNED_BY_ME=$(kubectl get agents -n "$NAMESPACE" \
  -l "agentex/spawned-by=$AGENT_NAME" \
  -o json 2>/dev/null | jq '.items | length' 2>/dev/null || echo "0")
```

## Impact

- Eliminates false positives when other agents spawn successors
- More reliable self-improvement loop
- Reduces unnecessary emergency agent spawns
- Makes the system more robust in multi-agent scenarios