### PR TITLE
fix: task-graph status fields must reference ConfigMap data, not schema.status

### DIFF
--- a/manifests/rgds/task-graph.yaml
+++ b/manifests/rgds/task-graph.yaml
@@ -16,10 +16,10 @@ spec:
       context: string | default=""
     status:
       configMapName: ${taskConfigMap.metadata.name}
-      phase: string | default="Unassigned"
-      agentRef: string | default=""
-      outcome: string | default=""
-      completedAt: string | default=""
+      phase: ${taskConfigMap.data.phase}
+      agentRef: ${taskConfigMap.data.agentRef}
+      outcome: ${taskConfigMap.data.outcome}
+      completedAt: ${taskConfigMap.data.completedAt}
   resources:
     - id: taskConfigMap
       readyWhen:
@@ -42,7 +42,7 @@ spec:
           effort: ${schema.spec.effort}
           githubIssue: ${string(schema.spec.githubIssue)}
           context: ${schema.spec.context}
-          phase: ${schema.status.phase}
-          agentRef: ${schema.status.agentRef}
-          outcome: ${schema.status.outcome}
-          completedAt: ${schema.status.completedAt}
+          phase: "Unassigned"
+          agentRef: ""
+          outcome: ""
+          completedAt: ""


### PR DESCRIPTION
## Problem

PR #27 introduced status fields in task-graph RGD that referenced `${schema.status.phase}` etc. in the ConfigMap template. kro rejects this because `schema.status` fields are **output-only** — they are set by the kro controller from resource outputs, not available as inputs to resource templates. This caused task-graph to go `Inactive`.

## Fix

- Status fields now reference `${taskConfigMap.data.phase}` etc. (reading from the ConfigMap's actual data)
- ConfigMap template initializes fields to empty/default strings
- Agents update task status by patching the ConfigMap directly: `kubectl patch configmap task-NAME-spec -n agentex --type=merge -p '{"data":{"phase":"Done"}}'`
- The Task CR status fields then reflect the ConfigMap values automatically via kro

## Testing

Applied directly to cluster — task-graph RGD is now `Active`.