### PR TITLE
Fix: Add read tracking to Thought CRs for deduplication

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -153,11 +153,35 @@ for msg_name in $(echo "$INBOX_JSON" | jq -r \
 done
 
 # ── 4. Peer thoughts (shared context) ────────────────────────────────────────
-PEER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null | jq -r \
+# Get the last 10 thoughts from other agents, excluding ones we've already read
+THOUGHTS_JSON=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+PEER_THOUGHTS=$(echo "$THOUGHTS_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[-10:] | .[] | select(.spec.agentRef != $name) |
+  '.items[-10:] | .[] | 
+   select(.spec.agentRef != $name) |
+   select((.status.readBy // "" | contains($name)) == false) |
    "[\(.spec.agentRef)/\(.spec.thoughtType)/c=\(.spec.confidence)]: \(.spec.content)"' \
   2>/dev/null || true)
+
+# Mark thoughts as read by this agent (patch ConfigMap backing the Thought CR)
+for thought_name in $(echo "$THOUGHTS_JSON" | jq -r \
+  --arg name "$AGENT_NAME" \
+  '.items[-10:] | .[] | 
+   select(.spec.agentRef != $name) |
+   select((.status.readBy // "" | contains($name)) == false) |
+   .metadata.name' \
+  2>/dev/null || true); do
+  # Get current readBy value from ConfigMap and append this agent's name
+  CURRENT_READ_BY=$(kubectl get configmap "${thought_name}-thought" -n "$NAMESPACE" \
+    -o jsonpath='{.data.readBy}' 2>/dev/null || echo "")
+  if [ -z "$CURRENT_READ_BY" ]; then
+    NEW_READ_BY="$AGENT_NAME"
+  else
+    NEW_READ_BY="${CURRENT_READ_BY},${AGENT_NAME}"
+  fi
+  kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"readBy\":\"${NEW_READ_BY}\"}}" 2>/dev/null || true
+done
 
 # ── 5. Read Task CR ───────────────────────────────────────────────────────────
 log "Reading task CR..."

--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -14,6 +14,7 @@ spec:
       confidence: integer | default=7
     status:
       configMapName: ${thoughtConfigMap.metadata.name}
+      readBy: ${thoughtConfigMap.data.readBy}
   resources:
     - id: thoughtConfigMap
       readyWhen:
@@ -34,3 +35,4 @@ spec:
           content: ${schema.spec.content}
           thoughtType: ${schema.spec.thoughtType}
           confidence: ${string(schema.spec.confidence)}
+          readBy: ""


### PR DESCRIPTION
## Summary

Adds read tracking to Thought CRs to prevent agents from repeatedly processing the same thoughts on every execution.

## Problem

Currently, agents re-read the same 10 peer thoughts on every run with no deduplication (entrypoint.sh lines 156-160). This causes:
- Inefficient re-processing of already-seen insights
- Wasted context in agent prompts
- No way to track which thoughts have been consumed

## Solution

Added `readBy` field to Thought CRs (similar to Message CR `read` field from PR #34):

1. **thought-graph.yaml**: Added `readBy` to ConfigMap data and exposed in CR status
2. **entrypoint.sh**: 
   - Filter thoughts where `status.readBy` contains current agent name
   - After reading, patch ConfigMap to append agent name to `readBy`
   - Uses comma-separated list: `"planner-001,worker-003,planner-002"`

## Pattern

Follows the same pattern as PR #34 (Message CR read field fix):
- Query CR status field (kro exposes ConfigMap data via status)
- Patch backing ConfigMap (kro status fields are output-only)
- Agents cannot patch CR spec/status directly

## Testing

After this PR merges, subsequent agents will:
1. Only see NEW thoughts they haven't read before
2. Automatically mark thoughts as read after processing
3. Skip thoughts already in their readBy list

Fixes #35