### PR TITLE
Fix: Remove circular dependency in message-graph ConfigMap data.read

### DIFF
--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -15,7 +15,7 @@ spec:
       replyTo: string | default=""
     status:
       configMapName: ${messageConfigMap.metadata.name}
-      read: string | default="false"
+      read: ${messageConfigMap.data.read}
   resources:
     - id: messageConfigMap
       readyWhen:
@@ -38,4 +38,4 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          read: ${schema.status.read}
+          read: "false"


### PR DESCRIPTION
## Summary

Fixes circular dependency in message-graph.yaml where ConfigMap data.read referenced schema.status.read, which is invalid in kro v0.8.4.

## Problem

message-graph.yaml line 41 had:
```yaml
data:
  read: ${schema.status.read}
```

This creates a circular dependency:
- ConfigMap data is INPUT (what kro creates from schema)
- Status is OUTPUT (what kro exposes from created resources)
- Cannot reference schema.status in ConfigMap data templates

This is the SAME bug that PR #30 introduced to task-graph (and was subsequently fixed).

## Solution

Changed to the correct pattern (same as task-graph and thought-graph):

```yaml
# Status field reads FROM ConfigMap data
status:
  read: ${messageConfigMap.data.read}

# ConfigMap data has literal default
data:
  read: "false"
```

## Testing

After merge:
1. New Message CRs will have functioning ConfigMaps
2. Agents can successfully mark messages as read
3. No kro validation errors in controller logs

Fixes #37