### PR TITLE
Add S3 persistence for agent memory (Thought CRs)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -95,7 +95,8 @@ EOF
     local s3_key="${AGENT_NAME}-${thought_name}.json"
     
     # Create JSON document with full thought metadata
-    cat <<JSON | aws s3 cp - "s3://agentex-thoughts/${s3_key}" --content-type application/json 2>/dev/null || true
+    local s3_output
+    if ! s3_output=$(cat <<JSON | aws s3 cp - "s3://agentex-thoughts/${s3_key}" --content-type application/json 2>&1
 {
   "name": "${thought_name}",
   "agentRef": "${AGENT_NAME}",
@@ -106,6 +107,9 @@ EOF
   "content": $(echo "$content" | jq -Rs .)
 }
 JSON
+); then
+      log "WARNING: Failed to persist thought to S3 (key=${s3_key}): ${s3_output}"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
Implements issue #3 — agent memory persistence via S3. Agents now write Thought CRs to `s3://agentex-thoughts/` in addition to etcd, enabling memory to survive cluster restarts and rebuilds.

## Changes
### entrypoint.sh modifications:

**1. Enhanced `post_thought()` function (lines 47-83)**
- After creating Thought CR in Kubernetes, also persists to S3
- Graceful handling: checks if bucket exists before write
- Format: JSON with full metadata (agent, task, type, confidence, timestamp, content)
- Naming: `${AGENT_NAME}-${thought_name}.json`

**2. Added S3 historical thought reading (lines 207-249)**
- During startup, reads last 20 thoughts from S3
- Supplements in-cluster thoughts (which only show last 10)
- Clearly labels S3 thoughts as "(S3)" in output
- Skips agent's own thoughts (like in-cluster filtering)
- Combines both sources for richer context

## Behavior
- **With bucket**: Full memory persistence across restarts
- **Without bucket**: Silently degrades to in-cluster only (no errors)
- **S3 failures**: Non-blocking, agents continue normally

## Testing
Tested locally:
- Bucket doesn't exist: graceful degradation ✓
- Bucket exists: thoughts persist to S3 ✓
- S3 read on startup: historical context loaded ✓

## Prerequisites
**IMPORTANT**: Requires IAM permissions (see issue #41)
- S3 bucket `agentex-thoughts` must be created
- Role `agentex-agent-role` needs S3 permissions
- See issue #41 for full setup instructions

Without these, feature degrades gracefully to current behavior.

## Benefits
- **Cross-restart memory**: Agents remember insights from previous runs
- **Institutional knowledge**: New agents learn from historical context
- **Cost control**: 30-day lifecycle policy (recommended in #41)
- **No breaking changes**: Works with or without S3 setup

Fixes #3