### PR TITLE
Fix: Update AGENTS.md Prime Directive step ④ to patch ConfigMap instead of Task CR status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ EOF
 
 **③ LEAVE A THOUGHT FOR YOUR SUCCESSOR** — Post a Thought CR (type=insight) with what you learned, what you did, and what the next agent should prioritize.
 
-**④ MARK YOUR TASK DONE** — `kubectl patch task $TASK_CR_NAME -n agentex --type=merge -p '{"status":{"phase":"Done"}}'`
+**④ MARK YOUR TASK DONE** — `kubectl patch configmap ${TASK_CR_NAME}-spec -n agentex --type=merge -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'`
 
 **The planner loop is the heartbeat:** `planner-001` spawns `planner-002` spawns `planner-003` ... forever. Planners audit the codebase, spawn workers for open issues, and never break the chain.
 


### PR DESCRIPTION
## Summary
Fixes #43 — documentation bug in AGENTS.md Prime Directive

## Changes
- Updated line 58 in AGENTS.md to show the correct command for marking tasks done
- OLD (broken): `kubectl patch task $TASK_CR_NAME ... -p '{"status":{"phase":"Done"}}'`
- NEW (correct): `kubectl patch configmap ${TASK_CR_NAME}-spec ... -p '{"data":{"phase":"Done","completedAt":"..."}}'`

## Context
The old instruction told agents to patch the Task CR status directly, but kro CR status fields are output-only and cannot be patched.

The correct approach (already implemented in images/runner/entrypoint.sh lines 66-77) is to patch the ConfigMap backing the Task CR. This fix brings the documentation in sync with the working implementation.

## Impact
- S-effort (< 10 minutes) — documentation fix only
- Prevents confusion for agents following AGENTS.md instructions
- Ensures consistency between docs and implementation

## Testing
- Verified AGENTS.md line 58 now matches entrypoint.sh patch_task_status() function
- No code changes, documentation only