### PR TITLE
Fix: Message inbox filtering checks status.read instead of spec.read

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -132,11 +132,11 @@ INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" -o json 2>/dev/null || echo '{
 
 DIRECT_MSGS=$(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[] | select(.spec.to == $name and (.spec.read == false or .spec.read == null)) |
+  '.items[] | select(.spec.to == $name and (.status.read == "false" or .status.read == null)) |
    "FROM:\(.spec.from) TYPE:\(.spec.messageType)\n\(.spec.body)\n---"' 2>/dev/null || true)
 
 BROADCAST_MSGS=$(echo "$INBOX_JSON" | jq -r \
-  '.items[] | select(.spec.to == "broadcast" and (.spec.read == false or .spec.read == null)) |
+  '.items[] | select(.spec.to == "broadcast" and (.status.read == "false" or .status.read == null)) |
    "FROM:\(.spec.from) TYPE:\(.spec.messageType)\n\(.spec.body)\n---"' 2>/dev/null || true)
 
 if [ -n "$DIRECT_MSGS" ] || [ -n "$BROADCAST_MSGS" ]; then


### PR DESCRIPTION
## Problem

The inbox processing in `images/runner/entrypoint.sh` was checking `.spec.read` but Message CRs only have `.status.read` (see message-graph.yaml:18).

## Impact

**Before**: Agents re-processed ALL messages on every run because the filter always matched null values from the non-existent field. This wasted context and processing time.

**After**: Agents only process unread messages, then mark them as read. Deduplication works correctly.

## Changes

- Line 135: `.spec.read` → `.status.read` (DIRECT_MSGS filter)
- Line 139: `.spec.read` → `.status.read` (BROADCAST_MSGS filter)
- Also fixed comparison: `== false` → `== "false"` (ConfigMap data values are strings)

## Testing

After merge, the next agent run should:
1. Only show unread messages in inbox
2. Not re-show previously read messages
3. Mark messages as read in ConfigMap backing (existing logic still correct)

## Related Issues

- Fixes #44
- Similar pattern to #35 (Thought read tracking)
- Related to #33 (Message read patching)

This is the FOURTH instance of the "check the right field" pattern in agent state tracking.