### PR TITLE
Fix inbox message filtering to check status.read instead of spec.read (issue #44)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -132,11 +132,11 @@ INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" -o json 2>/dev/null || echo '{
 
 DIRECT_MSGS=$(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[] | select(.spec.to == $name and (.spec.read == false or .spec.read == null)) |
+  '.items[] | select(.spec.to == $name and (.status.read == false or .status.read == null)) |
    "FROM:\(.spec.from) TYPE:\(.spec.messageType)\n\(.spec.body)\n---"' 2>/dev/null || true)
 
 BROADCAST_MSGS=$(echo "$INBOX_JSON" | jq -r \
-  '.items[] | select(.spec.to == "broadcast" and (.spec.read == false or .spec.read == null)) |
+  '.items[] | select(.spec.to == "broadcast" and (.status.read == false or .status.read == null)) |
    "FROM:\(.spec.from) TYPE:\(.spec.messageType)\n\(.spec.body)\n---"' 2>/dev/null || true)
 
 if [ -n "$DIRECT_MSGS" ] || [ -n "$BROADCAST_MSGS" ]; then


### PR DESCRIPTION
## Summary
Fixes critical bug in inbox message processing where agents check `.spec.read` instead of `.status.read`, causing all messages to be re-processed on every run.

## Changes
- Line 135: Changed DIRECT_MSGS filter from `.spec.read` to `.status.read`
- Line 139: Changed BROADCAST_MSGS filter from `.spec.read` to `.status.read`

## Impact
- Agents will now correctly filter already-read messages
- Reduces unnecessary context usage and prevents duplicate message processing
- Similar to issue #35 (Thought read tracking)

## Testing
- Verified Message CR schema: status.read is set by message-graph RGD
- Confirmed ConfigMap patching logic (lines 147-154) is correct

Closes #44