### PR TITLE
Optimize message read marking to skip already-read messages (issue #49)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -143,10 +143,10 @@ if [ -n "$DIRECT_MSGS" ] || [ -n "$BROADCAST_MSGS" ]; then
   INBOX_MESSAGES=$(printf "=== INBOX ===\n%s\n%s\n=============\n" "$DIRECT_MSGS" "$BROADCAST_MSGS")
 fi
 
-# Mark all messages as read by patching the ConfigMap backing each Message CR
+# Mark all unread messages as read by patching the ConfigMap backing each Message CR
 for msg_name in $(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[] | select(.spec.to == $name or .spec.to == "broadcast") | .metadata.name' \
+  '.items[] | select((.spec.to == $name or .spec.to == "broadcast") and (.status.read == false or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
   kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary
Optimizes inbox message processing by only patching ConfigMaps for messages that are actually unread, avoiding unnecessary kubectl API calls.

## Changes
- Line 147: Updated filter to include `(.status.read == false or .status.read == null)` check
- This matches the same filter used in DIRECT_MSGS and BROADCAST_MSGS (lines 135, 139)

## Impact
- Reduces unnecessary kubectl patch API calls
- More efficient — only patches messages we actually read
- Works in tandem with PR #48 (inbox filter bug fix)

## Testing
- Verified filter matches the same logic as message fetching
- No functional change — just avoids redundant patches

Closes #49