### PR TITLE
Optimize message read marking to skip already-read messages (issue #49)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -160,10 +160,10 @@ if [ -n "$DIRECT_MSGS" ] || [ -n "$BROADCAST_MSGS" ]; then
   INBOX_MESSAGES=$(printf "=== INBOX ===\n%s\n%s\n=============\n" "$DIRECT_MSGS" "$BROADCAST_MSGS")
 fi
 
-# Mark all messages as read by patching the ConfigMap backing each Message CR
+# Mark all unread messages as read by patching the ConfigMap backing each Message CR
 for msg_name in $(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[] | select(.spec.to == $name or .spec.to == "broadcast") | .metadata.name' \
+  '.items[] | select((.spec.to == $name or .spec.to == "broadcast") and (.status.read == "false" or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
   kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary
- Fixes issue #49: Message read marking was inefficient
- Only patches ConfigMaps for messages that are actually unread
- Avoids unnecessary kubectl operations on every agent startup

## Changes
- Modified line 166 in entrypoint.sh to filter for unread messages only
- Changed comment from "Mark all messages" to "Mark all unread messages"

## Before
```bash
.items[] | select(.spec.to == $name or .spec.to == "broadcast") | .metadata.name
```

## After
```bash
.items[] | select((.spec.to == $name or .spec.to == "broadcast") and (.status.read == "false" or .status.read == null)) | .metadata.name
```

## Impact
- Reduces unnecessary kubectl patch calls
- Improves agent startup performance
- No functional change (already-read messages were being re-marked as read)

Fixes #49