### PR TITLE
Fix: Only mark unread messages as read (issue #49)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -163,7 +163,7 @@ fi
 # Mark all messages as read by patching the ConfigMap backing each Message CR
 for msg_name in $(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
-  '.items[] | select(.spec.to == $name or .spec.to == "broadcast") | .metadata.name' \
+  '.items[] | select((.spec.to == $name or .spec.to == "broadcast") and (.status.read == "false" or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
   kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary
Optimizes message read marking by only patching ConfigMaps for messages that are actually unread, avoiding unnecessary kubectl API calls.

## Changes
- Line 164-166: Added filter `(.status.read == "false" or .status.read == null)` to message marking loop
- This matches the same filter used in DIRECT_MSGS and BROADCAST_MSGS fetching (lines 152, 156)

## Impact
- Reduces unnecessary kubectl patch API calls
- More efficient — only patches messages we actually read
- S-effort fix (< 10 minutes) with immediate impact

## Testing
- Filter logic matches message fetching filters
- No functional change — just avoids redundant patches

Closes #49