### PR TITLE
CRITICAL FIX: Change all CR API groups from agentex.io to kro.run (issue #59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ Every agent MUST do all four of these before exiting:
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
 ```bash
-# Task CR (defines the work) — use agentex.io/v1alpha1
+# Task CR (defines the work) — use kro.run/v1alpha1
 kubectl apply -f - <<EOF
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
   name: task-<next-agent>
@@ -147,7 +147,7 @@ Agents can trigger automatic role escalation when they discover structural probl
 
 ### Fast (CR-based, intra-cluster)
 ```yaml
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Message
 metadata:
   name: msg-planner-001-to-worker-003

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -29,7 +29,7 @@ post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
   kubectl apply -f - <<EOF 2>/dev/null || true
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Message
 metadata:
   name: ${msg_name}
@@ -49,7 +49,7 @@ post_thought() {
   local content="$1" type="${2:-observation}" confidence="${3:-7}"
   local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
   kubectl apply -f - <<EOF 2>/dev/null || true
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
   name: ${thought_name}
@@ -121,7 +121,7 @@ spawn_task_and_agent() {
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
   kubectl apply -f - <<EOF 2>/dev/null || true
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
   name: ${task_name}
@@ -268,7 +268,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   Next agent name format: worker-$(date +%s) or planner-$(date +%s) etc.
 
   kubectl apply -f - <<EOF
-  apiVersion: agentex.io/v1alpha1
+  apiVersion: kro.run/v1alpha1
   kind: Task
   metadata:
     name: task-<next-name>
@@ -312,7 +312,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 ③ TELL YOUR SUCCESSOR WHAT YOU LEARNED
   Post a Thought CR with type=insight before exiting:
   kubectl apply -f - <<EOF
-  apiVersion: agentex.io/v1alpha1
+  apiVersion: kro.run/v1alpha1
   kind: Thought
   metadata:
     name: thought-<your-name>-insight-$(date +%s)


### PR DESCRIPTION
## Summary
Fixes #59 - All CRs were being created in the wrong API group (agentex.io instead of kro.run).

This is a **critical fix** because kro RGDs watch kro.run group, NOT agentex.io group. CRs created in the wrong group weren't triggering kro to create backing resources (ConfigMaps), breaking:
- Task status tracking
- Message read tracking  
- Thought readBy tracking

## Changes Made

### entrypoint.sh
- Line 32: `post_message()` now uses `apiVersion: kro.run/v1alpha1`
- Line 52: `post_thought()` now uses `apiVersion: kro.run/v1alpha1`
- Line 124: `spawn_task_and_agent()` now uses `apiVersion: kro.run/v1alpha1` for Task CRs
- Lines 271, 315: Prime Directive documentation updated to show correct API group

### AGENTS.md
- Line 23: Task CR example now uses `kro.run/v1alpha1`
- Line 150: Message CR example now uses `kro.run/v1alpha1`

## Testing Needed

After merge, verify:
```bash
# Create a test Task CR
kubectl apply -f - <<EOF
apiVersion: kro.run/v1alpha1
kind: Task
metadata:
  name: test-task-api-group
  namespace: agentex
spec:
  title: "Test task"
  description: "Verify ConfigMap is created"
  role: worker
EOF

# Verify ConfigMap was created by kro
kubectl get configmap test-task-api-group-spec -n agentex
```

## Follow-up

After this merges and is verified working, delete the legacy agentex.io CRDs:
```bash
kubectl delete crd tasks.agentex.io messages.agentex.io thoughts.agentex.io agents.agentex.io swarms.agentex.io
```

## Impact

**High severity** - This fixes a fundamental bug that has been silently breaking state tracking since system inception.

Fixes #59