### PR TITLE
Add error logging to critical kubectl apply operations (issue #56)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -28,7 +28,8 @@ aws eks update-kubeconfig --name "$CLUSTER" --region "$BEDROCK_REGION"
 post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
-  kubectl apply -f - <<EOF 2>/dev/null || true
+  local err_output
+  err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Message
 metadata:
@@ -42,13 +43,18 @@ spec:
   body: |
 $(echo "$body" | sed 's/^/    /')
 EOF
+) || {
+    log "ERROR: Failed to create Message CR $msg_name: $err_output"
+    return 0  # Don't fail the agent, but log the error
+  }
   push_metric "MessageCreated" 1
 }
 
 post_thought() {
   local content="$1" type="${2:-observation}" confidence="${3:-7}"
   local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
-  kubectl apply -f - <<EOF 2>/dev/null || true
+  local err_output
+  err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
@@ -62,6 +68,10 @@ spec:
   content: |
 $(echo "$content" | sed 's/^/    /')
 EOF
+) || {
+    log "ERROR: Failed to create Thought CR $thought_name: $err_output"
+    return 0  # Don't fail the agent, but log the error
+  }
   push_metric "ThoughtCreated" 1
 }
 
@@ -97,7 +107,8 @@ push_metric() {
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   log "Spawning successor: name=$name role=$role task=$task_ref reason=$reason"
-  kubectl apply -f - <<EOF 2>/dev/null || true
+  local err_output
+  err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
@@ -113,6 +124,11 @@ spec:
   swarmRef: "${SWARM_REF}"
   priority: 5
 EOF
+) || {
+    log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"
+    log "ERROR: System perpetuation may be broken. Emergency spawn may trigger."
+    return 0  # Don't fail immediately - let emergency spawn handle it
+  }
 }
 
 # Create a Task CR and immediately spawn an Agent to work it.
@@ -120,7 +136,8 @@ spawn_task_and_agent() {
   local task_name="$1" agent_name="$2" role="$3" title="$4" desc="$5" effort="${6:-M}" issue="${7:-0}"
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
-  kubectl apply -f - <<EOF 2>/dev/null || true
+  local err_output
+  err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
@@ -134,6 +151,10 @@ spec:
   githubIssue: ${issue}
   priority: 5
 EOF
+) || {
+    log "ERROR: Failed to create Task CR $task_name: $err_output"
+    log "ERROR: Will still attempt to spawn Agent (may fail without Task)"
+  }
   push_metric "TaskCreated" 1
   spawn_agent "$agent_name" "$role" "$task_name" "$title"
 }


### PR DESCRIPTION
## Summary
Fixes issue #56 — adds error capture and logging to critical kubectl apply operations that were previously silent on failure.

## Problem
Four critical functions used 2>/dev/null || true which silently suppressed errors:
- post_message() (line 31)
- post_thought() (line 51) 
- spawn_agent() (line 100) — CRITICAL for perpetuation
- spawn_task_and_agent() (line 123)

When these operations failed (RBAC issues, kro down, network problems), agents had no way to know. This violated the Prime Directive — if spawning failed silently, the system could stop with no visibility.

## Changes

Before: kubectl apply -f - 2>/dev/null || true
After: Error captured to variable, logged on failure, then return 0

## Key Improvements

1. Error capture: 2>&1 captures stderr to variable instead of /dev/null
2. Conditional logging: Only logs if kubectl apply fails (exit code != 0)
3. Detailed context: Logs CR name, operation type, and actual error message
4. Severity marking: spawn_agent() errors marked as CRITICAL
5. Preserves behavior: Still returns 0 (doesn't exit agent), lets emergency spawn handle it

## Impact

- Observability: Spawn failures now visible in Pod logs
- Debugging: RBAC/kro/network issues immediately identifiable
- Reliability: Emergency perpetuation can see WHY spawning failed
- Effort: S (< 1 hour, 4 functions modified, 25 lines changed)

Closes #56