### PR TITLE
Fix agent generation tracking to increment numerically (issue #64)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -110,7 +110,17 @@ push_metric() {
 # kro agent-graph turns this into a Job automatically.
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
-  log "Spawning successor: name=$name role=$role task=$task_ref reason=$reason"
+  
+  # Calculate next generation number by reading current agent's generation label
+  local my_generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  # Handle non-numeric generation (e.g., "next" from old code) by defaulting to 0
+  if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
+    my_generation=0
+  fi
+  local next_generation=$((my_generation + 1))
+  
+  log "Spawning successor: name=$name role=$role task=$task_ref gen=$next_generation reason=$reason"
   kubectl apply -f - <<EOF 2>/dev/null || true
 apiVersion: kro.run/v1alpha1
 kind: Agent
@@ -119,7 +129,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     agentex/spawned-by: ${AGENT_NAME}
-    agentex/generation: "next"
+    agentex/generation: "${next_generation}"
 spec:
   role: "${role}"
   taskRef: "${task_ref}"


### PR DESCRIPTION
## Summary
Fixes issue #64 — agent generation labels now increment numerically instead of being hardcoded to "next".

## Problem
The `spawn_agent()` function hardcoded the generation label to `"next"` for all spawned agents, breaking lineage tracking.

## Changes
**entrypoint.sh lines 109-138:**

### Before
```bash
spawn_agent() {
  local name="$1" role="$2" task_ref="$3" reason="$4"
  log "Spawning successor: ..."
  kubectl apply -f - <<EOF
  ...
  labels:
    agentex/generation: "next"  # ← Hardcoded!
```

### After
```bash
spawn_agent() {
  local name="$1" role="$2" task_ref="$3" reason="$4"
  
  # Calculate next generation number
  local my_generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
  if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
    my_generation=0  # Handle non-numeric (e.g., "next" from old code)
  fi
  local next_generation=$((my_generation + 1))
  
  log "Spawning successor: ... gen=$next_generation ..."
  kubectl apply -f - <<EOF
  ...
  labels:
    agentex/generation: "${next_generation}"  # ← Incremented!
```

## Key Improvements

1. **Proper lineage tracking**: Generations now increment properly (0→1→2→3...)
2. **Graceful fallback**: Non-numeric generation values default to 0
3. **Better logging**: Generation number included in spawn log message
4. **Backward compatible**: Handles agents with old "next" label

## Benefits

- Can track agent lineage depth
- Can query agents by generation: `kubectl get agents -l 'agentex/generation>10'`
- Better observability of system evolution
- Foundation for generation-based metrics (e.g., "avg agent lifespan by generation")

## Testing

- [x] Numeric increment logic
- [x] Non-numeric fallback ("next" → 0)
- [x] Missing label fallback (empty → 0)
- [x] Log message includes generation

## Impact

- Effort: S (< 15 minutes, 11 lines added)
- Risk: Low (only affects labels, graceful fallback)
- Observability: High (enables generation-based queries and metrics)

Closes #64