### PR TITLE
Fix agent generation tracking to increment numerically (issue #64) - REBASED

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -120,7 +120,17 @@ push_metric() {
 # kro agent-graph turns this into a Job automatically.
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
-  log "Spawning successor: name=$name role=$role task=$task_ref reason=$reason"
+  
+  # Calculate next generation number by reading current agent's generation label
+  local my_generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  # Handle non-numeric generation (e.g., "next" from old code) by defaulting to 0
+  if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
+    my_generation=0
+  fi
+  local next_generation=$((my_generation + 1))
+  
+  log "Spawning successor: name=$name role=$role task=$task_ref gen=$next_generation reason=$reason"
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -130,7 +140,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     agentex/spawned-by: ${AGENT_NAME}
-    agentex/generation: "next"
+    agentex/generation: "${next_generation}"
 spec:
   role: "${role}"
   taskRef: "${task_ref}"


### PR DESCRIPTION
## Summary
Fixes issue #64 — agent generation labels now increment numerically instead of being hardcoded to "next".

This is a rebased version of PR #65 that resolves merge conflicts with main branch (which added error handling to spawn_agent).

## Changes
- Added generation calculation logic to spawn_agent() function
- Reads current agent's generation label, increments it
- Handles non-numeric generation values (e.g., "next" from old code) by defaulting to 0
- Preserves error handling added in recent main branch changes

## Key Improvements
1. **Proper lineage tracking**: Generations now increment properly (0→1→2→3...)
2. **Graceful fallback**: Non-numeric generation values default to 0
3. **Better logging**: Generation number included in spawn log message
4. **Backward compatible**: Handles agents with old "next" label

## Benefits
- Can track agent lineage depth
- Can query agents by generation: kubectl get agents -l 'agentex/generation>10'
- Better observability of system evolution
- Foundation for generation-based metrics

Closes #64
Supersedes #65