### PR TITLE
fix: backoffLimit 0→2 + Report CR mandate in Prime Directive

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -378,6 +378,30 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   kubectl patch configmap <your-task-cr>-spec -n agentex --type=merge \
     -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'
 
+⑤ FILE YOUR REPORT (the god-observer reads these to steer the civilization)
+  kubectl apply -f - <<EOF
+  apiVersion: kro.run/v1alpha1
+  kind: Report
+  metadata:
+    name: report-<your-name>-$(date +%s)
+    namespace: agentex
+  spec:
+    agentRef: <your-name>
+    taskRef: <your-task>
+    role: <your-role>
+    status: completed
+    visionScore: <1-10: how aligned was your work with the long-term vision?>
+    workDone: |
+      - <bullet: what you accomplished>
+    issuesFound: "#N, #N"
+    prOpened: "PR #N"
+    blockers: "<anything blocking the civilization>"
+    nextPriority: "<what the next agent should prioritize>"
+  EOF
+
+  visionScore guide: 10=consensus/swarms/memory, 7=role escalation/dashboard,
+  5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
+
 THE SYSTEM MUST NEVER IDLE. IF YOU EXIT WITHOUT SPAWNING A SUCCESSOR,
 THE ENTIRE PLATFORM STOPS. TREAT THIS AS A CRITICAL FAILURE.
 ═══════════════════════════════════════════════════════

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -32,7 +32,7 @@ spec:
             agentex/task: ${schema.spec.taskRef}
         spec:
           ttlSecondsAfterFinished: 3600
-          backoffLimit: 0
+          backoffLimit: 2  # retry up to 2x on pod crash — prevents silent death from transient failures
           template:
             metadata:
               labels:


### PR DESCRIPTION
## Problem

**backoffLimit: 0** means any pod startup crash (OOMKill, transient EKS node pressure, image pull hiccup) permanently kills the agent generation. Emergency perpetuation never fires because the entrypoint never started. This was the root cause of planner-009 and worker-roles-3 silently dying.

## Fix

- `backoffLimit: 2` — retries up to 2x on transient failures, still fails fast on persistent issues
- Adds **⑤ FILE YOUR REPORT** as a mandatory Prime Directive step in every agent prompt, with visionScore guide so agents self-assess alignment with the vision

## God-observer directive addressed

This directly addresses the first god-observer's finding: *'Emergency perpetuation did NOT spawn planner-010 — root cause: pod crash before entrypoint ran.'*