### PR TITLE
Add report-graph.yaml RGD to version control (issue #71)

### DIFF
--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -1,0 +1,52 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: report-graph
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Report
+    spec:
+      agentRef: string | required=true
+      taskRef: string | default=""
+      role: string | default="worker"
+      status: string | default="completed"
+      visionScore: integer | default=5
+      workDone: string | default=""
+      issuesFound: string | default=""
+      prOpened: string | default=""
+      blockers: string | default=""
+      nextPriority: string | default=""
+      generation: integer | default=0
+      exitCode: integer | default=0
+    status:
+      configMapName: ${reportConfigMap.metadata.name}
+  
+  resources:
+    - id: reportConfigMap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-data
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/agent: ${schema.spec.agentRef}
+            agentex/role: ${schema.spec.role}
+            agentex/status: ${schema.spec.status}
+            agentex/report: ${schema.metadata.name}
+        data:
+          agentRef: ${schema.spec.agentRef}
+          taskRef: ${schema.spec.taskRef}
+          role: ${schema.spec.role}
+          status: ${schema.spec.status}
+          visionScore: ${string(schema.spec.visionScore)}
+          workDone: ${schema.spec.workDone}
+          issuesFound: ${schema.spec.issuesFound}
+          prOpened: ${schema.spec.prOpened}
+          blockers: ${schema.spec.blockers}
+          nextPriority: ${schema.spec.nextPriority}
+          generation: ${string(schema.spec.generation)}
+          exitCode: ${string(schema.spec.exitCode)}
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}


### PR DESCRIPTION
## Problem

The report-graph ResourceGraphDefinition exists in the cluster (deployed by PR #51) but is **not tracked in the git repository** under `manifests/rgds/`.

## Evidence

- RGD exists: `kubectl get rgd report-graph` ✓
- Report CRD created: `kubectl get crd reports.kro.run` ✓
- File exists in repo: `manifests/rgds/report-graph.yaml` ✗

## Impact

- **Version control gap**: RGD changes aren't tracked
- **Reproducibility**: Can't recreate the RGD from git alone
- **Documentation**: New contributors can't see the RGD schema
- **Disaster recovery**: If cluster is recreated, RGD definition would be lost

## Solution

Exported the live RGD from the cluster, cleaned up metadata/status fields, and saved to `manifests/rgds/report-graph.yaml`.

## Verification

```bash
# Verify RGD structure matches live cluster
kubectl get rgd report-graph -o yaml | grep -A 30 "spec:"
```

Fixes #71