### PR TITLE
Add report-graph RGD to version control (issue #71)

### DIFF
--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -1,0 +1,52 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: report-graph
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Report
+    spec:
+      agentRef: string | required=true
+      taskRef: string | default=""
+      role: string | default="worker"
+      status: string | default="completed"
+      exitCode: integer | default=0
+      generation: integer | default=0
+      visionScore: integer | default=5
+      workDone: string | default=""
+      issuesFound: string | default=""
+      prOpened: string | default=""
+      blockers: string | default=""
+      nextPriority: string | default=""
+    status:
+      configMapName: ${reportConfigMap.metadata.name}
+
+  resources:
+    - id: reportConfigMap
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-data
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/agent: ${schema.spec.agentRef}
+            agentex/report: ${schema.metadata.name}
+            agentex/role: ${schema.spec.role}
+            agentex/status: ${schema.spec.status}
+        data:
+          agentRef: ${schema.spec.agentRef}
+          taskRef: ${schema.spec.taskRef}
+          role: ${schema.spec.role}
+          status: ${schema.spec.status}
+          exitCode: ${string(schema.spec.exitCode)}
+          generation: ${string(schema.spec.generation)}
+          visionScore: ${string(schema.spec.visionScore)}
+          workDone: ${schema.spec.workDone}
+          issuesFound: ${schema.spec.issuesFound}
+          prOpened: ${schema.spec.prOpened}
+          blockers: ${schema.spec.blockers}
+          nextPriority: ${schema.spec.nextPriority}


### PR DESCRIPTION
## Summary
Fixes issue #71 — adds the missing report-graph.yaml RGD to version control.

## Problem
The report-graph ResourceGraphDefinition exists in the cluster (deployed by PR #51) but was not tracked in `manifests/rgds/`. This creates:
- Version control gap (RGD changes not tracked)
- Reproducibility issues (can't recreate cluster from git alone)
- Documentation gap (contributors can't see RGD schema)
- Disaster recovery risk (RGD lost if cluster recreated)

## Solution
Exported the live RGD from cluster and saved to `manifests/rgds/report-graph.yaml`:
- Cleaned up metadata fields (resourceVersion, uid, timestamps, status)
- Formatted to match existing RGD files (agent-graph, task-graph, etc.)
- Ready for kubectl apply

## Verification
```bash
kubectl get rgd report-graph -o yaml  # matches file
ls manifests/rgds/report-graph.yaml   # now exists
```

## Effort
S-effort (10 minutes)

Closes #71