### PR TITLE
Add report-graph.yaml RGD to manifests/rgds/ (issue #71)

### DIFF
--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -1,0 +1,52 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: report-graph
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Report
+    spec:
+      agentRef: string | required=true
+      taskRef: string | default=""
+      role: string | default="worker"
+      generation: integer | default=0
+      status: string | default="completed"
+      exitCode: integer | default=0
+      workDone: string | default=""
+      issuesFound: string | default=""
+      prOpened: string | default=""
+      blockers: string | default=""
+      nextPriority: string | default=""
+      visionScore: integer | default=5
+    status:
+      configMapName: ${reportConfigMap.metadata.name}
+  
+  resources:
+    - id: reportConfigMap
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-data
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/agent: ${schema.spec.agentRef}
+            agentex/report: ${schema.metadata.name}
+            agentex/role: ${schema.spec.role}
+            agentex/status: ${schema.spec.status}
+        data:
+          agentRef: ${schema.spec.agentRef}
+          taskRef: ${schema.spec.taskRef}
+          role: ${schema.spec.role}
+          generation: ${string(schema.spec.generation)}
+          status: ${schema.spec.status}
+          exitCode: ${string(schema.spec.exitCode)}
+          workDone: ${schema.spec.workDone}
+          issuesFound: ${schema.spec.issuesFound}
+          prOpened: ${schema.spec.prOpened}
+          blockers: ${schema.spec.blockers}
+          nextPriority: ${schema.spec.nextPriority}
+          visionScore: ${string(schema.spec.visionScore)}
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}


### PR DESCRIPTION
## Summary

- Adds missing `report-graph.yaml` RGD to version control
- RGD has been live in cluster for 21+ minutes but wasn't in repo
- S-effort fix (< 10 minutes)

## Details

The report-graph RGD defines the Report CR kind used by agents (especially god-observer) to file structured completion reports. The RGD has been deployed to the cluster but was never committed to the repository, causing drift between live infrastructure and version control.

This PR adds the cleaned-up RGD definition extracted from the cluster.

**Report CR fields:**
- `agentRef`, `taskRef`, `role`, `generation`
- `status`, `exitCode`, `workDone`
- `issuesFound`, `prOpened`, `blockers`
- `nextPriority`, `visionScore`

**What the RGD does:**
- Creates a backing ConfigMap (`<report-name>-data`) with all Report spec fields
- Adds labels for easy querying: `agentex/agent`, `agentex/report`, `agentex/role`, `agentex/status`
- Status includes `configMapName` for lookups

Closes #71