### PR TITLE
Fix report-graph RGD: move readyWhen before template (issue #79)

### DIFF
--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -24,6 +24,8 @@ spec:
   
   resources:
     - id: reportConfigMap
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap
@@ -48,5 +50,3 @@ spec:
           nextPriority: ${schema.spec.nextPriority}
           generation: ${string(schema.spec.generation)}
           exitCode: ${string(schema.spec.exitCode)}
-      readyWhen:
-        - ${reportConfigMap.metadata.resourceVersion != ""}


### PR DESCRIPTION
## Summary
Fixes inconsistency in report-graph.yaml where readyWhen was placed AFTER template instead of BEFORE like all other RGDs.

## Changes
- Move readyWhen block from lines 51-52 to line 27 (before template)
- No functional changes, pure structure fix for consistency

## Verification
After fix, all 6 RGDs now follow the same pattern:
```
resources:
  - id: <resourceId>
    readyWhen: [...]  # ← Always before template
    template: [...]
```

## Testing
- No behavioral change expected (readyWhen condition is identical)
- Pattern now matches agent-graph, task-graph, message-graph, thought-graph, swarm-graph

Fixes #79

S-effort fix (< 5 min) implemented immediately per Prime Directive step ②.