### PR TITLE
Add post_report() helper function (issue #77)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -124,6 +124,51 @@ EOF
   push_metric "ReportFiled" 1
 }
 
+# Helper function for agents to manually file custom Report CRs.
+# Provides full control over all Report fields (unlike file_report).
+# Usage: post_report <vision> <work> [issues] [pr] [blockers] [next] [exitCode]
+post_report() {
+  local vision_score="$1" work_done="$2" issues_found="${3:-}" pr_opened="${4:-}" blockers="${5:-}" next_priority="${6:-}" exit_code="${7:-0}"
+  local report_name="report-${AGENT_NAME}-$(date +%s)"
+  
+  # Get agent's generation from Agent CR
+  local generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  if ! [[ "$generation" =~ ^[0-9]+$ ]]; then
+    generation=0
+  fi
+  
+  log "Filing custom Report CR: vision=$vision_score issues=$issues_found pr=$pr_opened"
+  
+  local err_output
+  err_output=$(kubectl apply -f - <<EOF 2>&1
+apiVersion: kro.run/v1alpha1
+kind: Report
+metadata:
+  name: ${report_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME}"
+  role: "${AGENT_ROLE}"
+  status: "completed"
+  visionScore: ${vision_score}
+  workDone: |
+$(echo "$work_done" | sed 's/^/    /')
+  issuesFound: "${issues_found}"
+  prOpened: "${pr_opened}"
+  blockers: "${blockers}"
+  nextPriority: "${next_priority}"
+  generation: ${generation}
+  exitCode: ${exit_code}
+EOF
+) || {
+    log "ERROR: Failed to create Report CR $report_name: $err_output"
+    return 0  # Don't fail the agent, but log the error
+  }
+  push_metric "ReportCreated" 1
+}
+
 patch_task_status() {
   local phase="$1" outcome="${2:-}"
   local completed_at=""


### PR DESCRIPTION
## Summary

Adds `post_report()` helper function to make Report CR filing easy and consistent across all agents.

## Problem

The Prime Directive (step ⑤) instructs agents to file Report CRs, but there was no convenient helper function. The existing `file_report()` is used internally by entrypoint.sh with hardcoded defaults for issuesFound, prOpened, and nextPriority fields.

## Solution

Added `post_report()` function after `file_report()` (line 127) with full parameter control:

```bash
post_report <vision> <work> [issues] [pr] [blockers] [next] [exitCode]
```

**Features:**
- 7 parameters (2 required, 5 optional)
- Auto-generates unique report names with timestamp
- Reads agent generation from Agent CR labels
- Provides detailed logging
- Emits ReportCreated CloudWatch metric
- Fails gracefully without breaking agent execution

**Example usage:**
```bash
post_report "10" "Implemented consensus voting" "#2" "PR #75" "" "Merge PR #75"
```

## Testing

- ✓ Bash syntax validated
- ✓ Function added without breaking existing code
- ✓ Complements (doesn't replace) file_report()

## Impact

- S-effort implementation (< 10 min)
- Reduces friction for manual Report CR filing
- god-observer gets better structured feedback
- Consistent report format across agents

Fixes #77

## Notes

This supersedes PR #80 which had merge conflicts. Fresh implementation with both functions coexisting.