### PR TITLE
Replace file_report() with post_report() helper (issue #77)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -91,11 +91,16 @@ EOF
 
 # File a Report CR for god-observer to synthesize system state.
 # This provides structured feedback for vision alignment tracking.
-file_report() {
-  local status="$1" work_done="$2" blockers="${3:-none}" vision_score="${4:-7}"
-  local report_name="report-${AGENT_NAME}"
+post_report() {
+  local vision_score="$1" work_done="$2" issues_found="${3:-}" pr_opened="${4:-}" blockers="${5:-}" next_priority="${6:-}" exit_code="${7:-0}"
+  local report_name="report-${AGENT_NAME}-$(date +%s)"
   
-  log "Filing Report CR: status=$status vision_score=$vision_score"
+  # Get agent's generation from Agent CR
+  local generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  if ! [[ "$generation" =~ ^[0-9]+$ ]]; then
+    generation=0
+  fi
   
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
@@ -108,20 +113,23 @@ spec:
   agentRef: "${AGENT_NAME}"
   taskRef: "${TASK_CR_NAME}"
   role: "${AGENT_ROLE}"
-  status: "${status}"
+  status: "completed"
   visionScore: ${vision_score}
   workDone: |
 $(echo "$work_done" | sed 's/^/    /')
-  issuesFound: "See GitHub issues and PRs opened by ${AGENT_NAME}"
-  prOpened: "See GitHub PRs opened by ${AGENT_NAME}"
+  issuesFound: "${issues_found}"
+  prOpened: "${pr_opened}"
   blockers: "${blockers}"
-  nextPriority: "Continue self-improvement loop"
+  nextPriority: "${next_priority}"
+  generation: ${generation}
+  exitCode: ${exit_code}
 EOF
 ) || {
     log "ERROR: Failed to create Report CR $report_name: $err_output"
     return 0  # Don't fail the agent, but log the error
   }
-  push_metric "ReportFiled" 1
+  push_metric "ReportCreated" 1
+  log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
 }
 
 patch_task_status() {
@@ -507,14 +515,14 @@ if [ "$OPENCODE_EXIT" -eq 0 ]; then
   patch_task_status "Done" "Completed successfully"
   post_message "broadcast" "Done: $TASK_TITLE (agent=$AGENT_NAME)" "status"
   post_thought "Task finished. Successor should be spawned." "observation" 9
-  file_report "completed" "$TASK_TITLE completed successfully" "none" 8
+  post_report 8 "$TASK_TITLE completed successfully" "" "" "" "Continue self-improvement loop" 0
 else
   log "OpenCode exited with code $OPENCODE_EXIT"
   patch_task_status "Done" "exit=$OPENCODE_EXIT"
   post_message "broadcast" "Finished (exit=$OPENCODE_EXIT): $TASK_TITLE" "status"
   post_thought "OpenCode exited $OPENCODE_EXIT. Activating emergency perpetuation." "observation" 4
   push_metric "AgentFailure" 1
-  file_report "failed" "Agent failed with exit code $OPENCODE_EXIT" "Agent execution failure" 3
+  post_report 3 "Agent failed with exit code $OPENCODE_EXIT" "" "" "Agent execution failure" "Emergency investigation needed" "$OPENCODE_EXIT"
 fi
 
 # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the incomplete `file_report()` function with the better `post_report()` helper function from PR #80, resolving merge conflicts.

## Changes

- **Replaced** `file_report()` with `post_report()` in entrypoint.sh
- **Updated** all call sites to use new signature
- **Better signature**: `post_report(vision_score, work_done, issues_found, pr_opened, blockers, next_priority, exit_code)`
- **Automatic generation tracking**: fetches generation from Agent CR labels
- **Unique report names**: uses timestamp suffix to prevent conflicts
- **Proper metrics**: uses `ReportCreated` metric name

## Why

PR #80 had merge conflicts because `file_report()` was added to main independently. The `post_report()` version from #80 is superior:
- Matches Report CR schema exactly (generation, exitCode fields)
- Better parameter naming and order
- Automatic generation fetching
- More detailed logging

## Testing

Function signature matches report-graph.yaml schema. All calls updated to new signature.

Closes #77
Supersedes #80