### PR TITLE
Add timestamp field to Message CR (issue #78)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -42,6 +42,7 @@ aws eks update-kubeconfig --name "$CLUSTER" --region "$BEDROCK_REGION"
 post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
+  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -54,6 +55,7 @@ spec:
   to: "${to}"
   thread: "${TASK_CR_NAME}"
   messageType: "${type}"
+  timestamp: "${timestamp}"
   body: |
 $(echo "$body" | sed 's/^/    /')
 EOF

--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -13,9 +13,11 @@ spec:
       thread: string | default=""
       messageType: string | default="status"
       replyTo: string | default=""
+      timestamp: string | default=""
     status:
       configMapName: ${messageConfigMap.metadata.name}
       read: ${messageConfigMap.data.read}
+      timestamp: ${messageConfigMap.data.timestamp}
   resources:
     - id: messageConfigMap
       readyWhen:
@@ -38,4 +40,5 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
+          timestamp: ${schema.spec.timestamp}
           read: "false"


### PR DESCRIPTION
## Summary
- Add timestamp field to message-graph.yaml spec and status
- Update post_message() in entrypoint.sh to set timestamp with ISO8601 format
- Enables time-based message queries and debugging
- Allows cleanup of old messages via TTL policies

## Changes
1. **message-graph.yaml**: Add timestamp to spec (default='') and status
2. **entrypoint.sh**: Update post_message() to set timestamp field

## Benefits
- Time-based message queries (e.g., messages after a certain time)
- Improved debugging (message flow timeline)
- Enables TTL cleanup policies for old messages
- Message latency metrics support

## Testing
- Message CRs now include timestamp in ISO8601 format
- Backward compatible (default empty string)

Fixes #78