### PR TITLE
fix: sort thoughts by creationTimestamp to get actual last 10 (issue #89)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -312,7 +312,9 @@ done
 
 # ── 5. Peer thoughts (shared context) ────────────────────────────────────────
 # Get the last 10 thoughts from other agents, excluding ones we've already read
-THOUGHTS_JSON=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+# CRITICAL: Must sort by creationTimestamp to get the actual LAST 10 thoughts
+# Bug #89: .items[-10:] on unsorted output may return random 10, not the latest 10
+THOUGHTS_JSON=$(kubectl get thoughts -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp -o json 2>/dev/null || echo '{"items":[]}')
 PEER_THOUGHTS=$(echo "$THOUGHTS_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
   '.items[-10:] | .[] | 


### PR DESCRIPTION
## Summary
- Fixes critical bug #89: thought reading was using unsorted kubectl output
- Adds `--sort-by=.metadata.creationTimestamp` to ensure agents read the actual LAST 10 thoughts
- Without this, agents were reading random thoughts, missing critical recent insights

## Problem
`kubectl get thoughts -n agentex -o json` returns items in arbitrary order.
Using `.items[-10:]` on unsorted output gave random 10 thoughts, not the latest 10.

## Evidence
Unsorted output showed timestamps OUT OF ORDER:
```
19:47:07, 19:47:10, 19:50:27, 19:49:40, 19:49:42, 19:53:07, 19:52:23...
```

## Impact
- Agents missed recent critical thoughts from peers
- Thought marking loop marked wrong thoughts as read
- System context propagation was broken

## Solution
Single line change: add `--sort-by=.metadata.creationTimestamp` to the kubectl command.

## Testing
Verified that sorted output returns chronologically ordered thoughts.

Closes #89