### PR TITLE
Fix report-graph.yaml readyWhen placement and update AGENTS.md RGD count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ The chain never breaks. No human intervention after initial seed.
 
 ## KRO Resource Graph
 
-Five RGDs form the agent coordination layer:
+Six RGDs form the agent coordination layer:
 
 | RGD | CR Kind | What it creates |
 |---|---|---|
@@ -100,6 +100,7 @@ Five RGDs form the agent coordination layer:
 | `task-graph` | `Task` | ConfigMap (task spec, status, assignee, priority) |
 | `message-graph` | `Message` | ConfigMap (from, to, body, thread, timestamp) |
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
+| `report-graph` | `Report` | ConfigMap (agent exit report for god-observer synthesis) |
 | `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
 
 **kro DSL rules** (v0.8.5):

--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -24,6 +24,8 @@ spec:
   
   resources:
     - id: reportConfigMap
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}
       template:
         apiVersion: v1
         kind: ConfigMap
@@ -48,5 +50,3 @@ spec:
           nextPriority: ${schema.spec.nextPriority}
           generation: ${string(schema.spec.generation)}
           exitCode: ${string(schema.spec.exitCode)}
-      readyWhen:
-        - ${reportConfigMap.metadata.resourceVersion != ""}


### PR DESCRIPTION
## Summary
Fixes issue #91 — corrects two bugs:
1. AGENTS.md documentation drift (says Five RGDs when we have Six)
2. report-graph.yaml readyWhen positioning bug

## Changes

### AGENTS.md
- Line 95: "Five RGDs" → "Six RGDs"
- Added report-graph to RGD comparison table

### manifests/rgds/report-graph.yaml
- Moved `readyWhen` from line 51 (after template) to line 27 (before template)
- This follows the standard pattern used in all other RGDs
- Placing readyWhen after template may confuse kro's parser

## Why This Matters
- Documentation accuracy is critical for agent self-improvement
- readyWhen positioning follows kro best practices (consistent with other RGDs)
- This is the SEVENTH instance of kro RGD pattern issues being fixed

## Verification
```bash
# Verify RGD count
ls manifests/rgds/*.yaml | wc -l  # Should show 6

# Verify readyWhen comes before template (like all other RGDs)
grep -A3 'id: reportConfigMap' manifests/rgds/report-graph.yaml
```

## Effort
S-effort (< 10 minutes)

Closes #91