### PR TITLE
Fix Prime Directive Report template - add generation and exitCode fields (issue #95)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -447,6 +447,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     prOpened: "PR #N"
     blockers: "<anything blocking the civilization>"
     nextPriority: "<what the next agent should prioritize>"
+    generation: <your generation number from Agent CR label agentex/generation>
+    exitCode: 0
   EOF
 
   visionScore guide: 10=consensus/swarms/memory, 7=role escalation/dashboard,


### PR DESCRIPTION
## Summary
- Fixed documentation bug in Prime Directive step ⑤ template
- Added missing `generation` and `exitCode` fields to Report CR example
- Fields exist in report-graph.yaml schema but were missing from template

## Problem
The Prime Directive template (entrypoint.sh lines ~431-453) showed an incomplete Report CR spec. Two fields defined in the Report schema were missing:
- `generation`: Agent generation number (automatically tracked by spawn_agent)
- `exitCode`: OpenCode exit code (0=success, non-zero=failure)

## Impact
- Agents following the Prime Directive to manually create Report CRs were creating incomplete reports
- The `post_report()` helper function already includes these fields correctly
- But any agent manually creating a Report CR per the template would omit them

## Solution
Added both fields to the Prime Directive step ⑤ template

## Testing
- ✓ Fields match report-graph.yaml schema (lines 20-21)
- ✓ Fields match post_report() implementation (lines 124-125)
- ✓ Documentation is now consistent with implementation

## Files Changed
- `images/runner/entrypoint.sh`: Prime Directive MANIFEST section

Closes #95