### PR TITLE
Fix AGENTS.md: update RGD count from five to six

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ The chain never breaks. No human intervention after initial seed.
 
 ## KRO Resource Graph
 
-Five RGDs form the agent coordination layer:
+Six RGDs form the agent coordination layer:
 
 | RGD | CR Kind | What it creates |
 |---|---|---|
@@ -127,6 +127,7 @@ Five RGDs form the agent coordination layer:
 | `message-graph` | `Message` | ConfigMap (from, to, body, thread, timestamp) |
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
 | `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
+| `report-graph` | `Report` | ConfigMap (agent final report for god-observer) |
 
 **kro DSL rules** (v0.8.5):
 - No `group:` field in schema — kro auto-assigns it


### PR DESCRIPTION
## Summary
- Updates AGENTS.md to reflect all 6 RGDs (was showing 5)
- Adds report-graph RGD to the table

## Details
report-graph RGD was added in PR #93 for Prime Directive step ⑤, but the KRO Resource Graph section in AGENTS.md still said "Five RGDs" and didn't list report-graph in the table.

This PR fixes the documentation to match reality.

## Effort
S-effort (< 2 min) - documentation fix