### PR TITLE
Fix issue #100: spawn_task_and_agent should fail fast if Task creation fails

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -368,8 +368,10 @@ spec:
   priority: 5
 EOF
 ) || {
-    log "ERROR: Failed to create Task CR $task_name: $err_output"
-    log "ERROR: Will still attempt to spawn Agent (may fail without Task)"
+    log "CRITICAL: Failed to create Task CR $task_name: $err_output"
+    log "CRITICAL: Cannot spawn Agent without Task. Perpetuation chain broken."
+    push_metric "AgentFailure" 1
+    return 1
   }
   push_metric "TaskCreated" 1
   spawn_agent "$agent_name" "$role" "$task_name" "$title"


### PR DESCRIPTION
## Summary

Fixes a critical bug in `spawn_task_and_agent()` where Task CR creation failure didn't prevent Agent spawning, leading to broken references and incorrect metrics.

## Problem

In `images/runner/entrypoint.sh` lines 351-376, when Task CR creation fails:
- ❌ Agent CR is still spawned with broken `taskRef`
- ❌ `TaskCreated` metric increments even on failure
- ❌ Agent may start but cannot read its task properly
- ❌ Perpetuation chain continues silently with invalid state

Example scenario:
1. kubectl apply fails (API server down, RBAC issue, invalid YAML)
2. Error is logged but function continues
3. Agent CR is created referencing non-existent Task
4. kro creates Job for broken Agent
5. Agent pod starts, reads TASK_CR_NAME from env, but Task doesn't exist

## Solution

Fail fast when Task creation fails:
- ✅ Return early with `return 1` (don't spawn Agent)
- ✅ Don't increment `TaskCreated` metric on failure
- ✅ Increment `AgentFailure` metric instead
- ✅ Upgrade log level from ERROR to CRITICAL
- ✅ Clear message: "Cannot spawn Agent without Task. Perpetuation chain broken."

## Changes

```diff
 ) || {
-    log "ERROR: Failed to create Task CR $task_name: $err_output"
-    log "ERROR: Will still attempt to spawn Agent (may fail without Task)"
+    log "CRITICAL: Failed to create Task CR $task_name: $err_output"
+    log "CRITICAL: Cannot spawn Agent without Task. Perpetuation chain broken."
+    push_metric "AgentFailure" 1
+    return 1
   }
   push_metric "TaskCreated" 1
   spawn_agent "$agent_name" "$role" "$task_name" "$title"
```

## Impact

- **Correctness**: Prevents Agent CRs with broken taskRef
- **Observability**: Accurate metrics (TaskCreated only on success, AgentFailure on error)
- **Reliability**: Clear signal when perpetuation chain is broken
- **Pattern**: Similar to issues #31, #33, #35, #37 (CR dependency ordering)

## Testing

- ✓ Reviewed all callers of spawn_task_and_agent() in entrypoint.sh
- ✓ Confirmed emergency_perpetuation (line 788) calls this function
- ✓ Verified return 1 will stop execution and emergency logic will detect failure

## Effort

S (< 15 minutes) - 4 line change

Closes #100