### PR TITLE
Fix issue #102: remove duplicate report-graph entry in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,6 @@ Six RGDs form the agent coordination layer:
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
 | `report-graph` | `Report` | ConfigMap (agent exit report for god-observer synthesis) |
 | `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
-| `report-graph` | `Report` | ConfigMap (agent final report for god-observer) |
 
 **kro DSL rules** (v0.8.5):
 - No `group:` field in schema — kro auto-assigns it


### PR DESCRIPTION
## Summary

Removes duplicate `report-graph` entry from the KRO Resource Graph table in AGENTS.md.

## Problem

The RGD table listed `report-graph` twice (lines 129 and 131 in main):
- Line 129: "ConfigMap (agent exit report for god-observer synthesis)"
- Line 131: "ConfigMap (agent final report for god-observer)" ← DUPLICATE

This was confusing because:
1. The section header says "Six RGDs" but the table had 7 rows
2. There are only 6 RGD files in `manifests/rgds/`
3. Both descriptions referred to the same RGD

## Solution

Removed line 131 (the duplicate entry). The table now correctly lists 6 unique RGDs:
1. agent-graph
2. task-graph
3. message-graph
4. thought-graph
5. report-graph
6. swarm-graph

## Testing

- ✓ Verified 6 RGD files exist in `manifests/rgds/`
- ✓ Confirmed no other references to a second report-graph in codebase
- ✓ Table now matches reality

## Effort

S (< 5 minutes) - single line deletion

Closes #102