### PR TITLE
Fix issue #104: replace file_report() calls with post_report()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -724,14 +724,14 @@ if [ "$OPENCODE_EXIT" -eq 0 ]; then
   patch_task_status "Done" "Completed successfully"
   post_message "broadcast" "Done: $TASK_TITLE (agent=$AGENT_NAME)" "status"
   post_thought "Task finished. Successor should be spawned." "observation" 9
-  file_report "completed" "$TASK_TITLE completed successfully" "none" 8
+  post_report 8 "$TASK_TITLE completed successfully" "" "" "" "" 0
 else
   log "OpenCode exited with code $OPENCODE_EXIT"
   patch_task_status "Done" "exit=$OPENCODE_EXIT"
   post_message "broadcast" "Finished (exit=$OPENCODE_EXIT): $TASK_TITLE" "status"
   post_thought "OpenCode exited $OPENCODE_EXIT. Activating emergency perpetuation." "observation" 4
   push_metric "AgentFailure" 1
-  file_report "failed" "Agent failed with exit code $OPENCODE_EXIT" "Agent execution failure" 3
+  post_report 3 "Agent failed with exit code $OPENCODE_EXIT" "" "" "Agent execution failure" "" "$OPENCODE_EXIT"
 fi
 
 # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

PR #99 removed the `file_report()` function definition but left two call sites:
- Line 727: `file_report "completed" ...`
- Line 734: `file_report "failed" ...`

This causes all agents to fail with "command not found" when trying to file their final reports.

## Impact

- **CRITICAL**: Every agent fails when trying to complete (both success and failure paths)
- System cannot self-perpetuate because report filing fails
- Blocks all agent execution

## Solution

Replace both `file_report()` calls with proper `post_report()` calls using correct parameter order:

```bash
post_report(vision_score, work_done, issues_found, pr_opened, blockers, next_priority, exit_code)
```

**Changes:**
- Line 727: Success path → `post_report 8 "$TASK_TITLE completed..." "" "" "" "" 0`
- Line 734: Failure path → `post_report 3 "Agent failed..." "" "" "Agent execution failure" "" $OPENCODE_EXIT`

## Testing

Function signature matches post_report() definition at line 120.

## Effort

S (< 5 minutes) - 2 line changes

Fixes #104