### PR TITLE
fix: swarm dissolution timestamp reset bug (issue #106)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -918,6 +918,7 @@ if [ -n "$SWARM_REF" ]; then
   CURRENT_TASKS=$(echo "$SWARM_STATE" | jq -r '.data.tasksCompleted // "0"')
   CURRENT_PHASE=$(echo "$SWARM_STATE" | jq -r '.data.phase // "Forming"')
   CURRENT_MEMBERS=$(echo "$SWARM_STATE" | jq -r '.data.memberAgents // ""')
+  CURRENT_TIMESTAMP=$(echo "$SWARM_STATE" | jq -r '.data.lastActivityTimestamp // ""')
   
   # Add this agent to member list if not already present
   if ! echo "$CURRENT_MEMBERS" | grep -q "$AGENT_NAME"; then
@@ -933,8 +934,32 @@ if [ -n "$SWARM_REF" ]; then
   # Increment tasks completed
   NEW_TASKS=$(( CURRENT_TASKS + 1 ))
   
-  # Update last activity timestamp
-  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  # Check task completion status BEFORE updating timestamp
+  # This prevents resetting the idle timer when all tasks are already done
+  SWARM_TASKS=$(kubectl get tasks -n "$NAMESPACE" -l "agentex/swarm=${SWARM_REF}" -o json 2>/dev/null || echo '{"items":[]}')
+  TOTAL_TASKS=$(echo "$SWARM_TASKS" | jq '.items | length')
+  DONE_TASKS=$(echo "$SWARM_TASKS" | jq '[.items[] | select(.status.phase == "Done")] | length')
+  PENDING_TASKS=$(( TOTAL_TASKS - DONE_TASKS ))
+  
+  log "Swarm $SWARM_REF: $DONE_TASKS/$TOTAL_TASKS tasks done, $PENDING_TASKS pending"
+  
+  # Only update timestamp if there are pending tasks
+  # If all tasks are done, preserve the existing timestamp so idle timer can accumulate
+  if [ "$PENDING_TASKS" -gt 0 ]; then
+    TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    log "Swarm still has pending tasks - updating activity timestamp"
+  else
+    # All tasks done - preserve timestamp to allow dissolution
+    if [ -z "$CURRENT_TIMESTAMP" ]; then
+      # First time all tasks are done - set timestamp to mark completion
+      TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      log "All swarm tasks complete - setting final activity timestamp"
+    else
+      # Keep existing timestamp so idle counter accumulates
+      TIMESTAMP="$CURRENT_TIMESTAMP"
+      log "All tasks already complete - preserving timestamp for dissolution check"
+    fi
+  fi
   
   # Patch swarm state
   kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
@@ -943,19 +968,10 @@ if [ -n "$SWARM_REF" ]; then
   
   # Check for dissolution condition (only if not already disbanded)
   if [ "$CURRENT_PHASE" != "Disbanded" ]; then
-    # Get all tasks associated with this swarm
-    SWARM_TASKS=$(kubectl get tasks -n "$NAMESPACE" -l "agentex/swarm=${SWARM_REF}" -o json 2>/dev/null || echo '{"items":[]}')
-    TOTAL_TASKS=$(echo "$SWARM_TASKS" | jq '.items | length')
-    DONE_TASKS=$(echo "$SWARM_TASKS" | jq '[.items[] | select(.status.phase == "Done")] | length')
-    PENDING_TASKS=$(( TOTAL_TASKS - DONE_TASKS ))
-    
-    log "Swarm $SWARM_REF: $DONE_TASKS/$TOTAL_TASKS tasks done, $PENDING_TASKS pending"
-    
     # Dissolution condition: all tasks done AND no activity for 5 minutes
     if [ "$PENDING_TASKS" -eq 0 ] && [ "$TOTAL_TASKS" -gt 0 ]; then
-      LAST_ACTIVITY=$(echo "$SWARM_STATE" | jq -r '.data.lastActivityTimestamp // ""')
-      if [ -n "$LAST_ACTIVITY" ]; then
-        LAST_EPOCH=$(date -d "$LAST_ACTIVITY" +%s 2>/dev/null || echo 0)
+      if [ -n "$TIMESTAMP" ]; then
+        LAST_EPOCH=$(date -d "$TIMESTAMP" +%s 2>/dev/null || echo 0)
         NOW_EPOCH=$(date +%s)
         IDLE_SECONDS=$(( NOW_EPOCH - LAST_EPOCH ))
         
@@ -972,6 +988,8 @@ if [ -n "$SWARM_REF" ]; then
           
           # Post thought about dissolution
           post_thought "Swarm $SWARM_REF dissolved. Goal achieved. All $TOTAL_TASKS tasks completed." "insight" 9
+        else
+          log "All tasks complete but only ${IDLE_SECONDS}s idle (need 300s for dissolution)"
         fi
       fi
     fi


### PR DESCRIPTION
## Summary
Fixes critical bug that prevented swarm dissolution from ever triggering.

## Problem
Every agent completing a task would update `lastActivityTimestamp` to NOW, even when all tasks were already done. This meant the 5-minute idle threshold could never be reached because the timer was constantly reset.

## Solution
Reordered logic in `images/runner/entrypoint.sh` step 13:
1. Check task completion status FIRST
2. Only update timestamp to NOW if there are pending tasks
3. If all tasks done, preserve existing timestamp to let idle counter accumulate
4. On first completion, set timestamp to mark when all tasks finished

## Changes
- Lines 912-979: Swarm state update logic refactored
- Added `CURRENT_TIMESTAMP` variable to preserve timestamp
- Added conditional logic to only update timestamp when appropriate
- Added logging to show timestamp behavior for debugging

## Testing
To test:
1. Create a swarm with 2 tasks
2. Complete both tasks
3. Wait 5+ minutes
4. Verify: swarm disbands and broadcasts dissolution message

## Impact
- HIGH: Enables swarm dissolution feature to actually work
- Prevents accumulation of zombie swarms in namespace
- Makes swarms self-cleaning as designed

## Vision Score
8/10 - Critical bug fix for foundational swarm coordination feature

Closes #106