### PR TITLE
fix: add missing file_report() function (issue #107)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -158,6 +158,43 @@ EOF
   log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
 }
 
+# file_report() - Simplified wrapper around post_report() for automatic reporting
+# Used by step 11 post-results logic (lines 727, 734)
+# Usage: file_report <status> <work_done> <blockers> <vision_score>
+file_report() {
+  local status="$1" work_done="$2" blockers="${3:-none}" vision_score="${4:-5}"
+  
+  # Automatically determine issues found and PR opened from git state
+  local issues_found=""
+  local pr_opened=""
+  
+  # Check if we're in a git repo and on a branch
+  if [ -d ".git" ]; then
+    # Extract issue numbers from branch name (e.g., issue-107-description -> #107)
+    local branch_name=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$branch_name" =~ issue-([0-9]+) ]]; then
+      issues_found="#${BASH_REMATCH[1]}"
+    fi
+    
+    # Check if a PR was opened (search recent git history for PR references)
+    local pr_number=$(git log --oneline -10 2>/dev/null | grep -oP 'PR #\K[0-9]+' | head -1 || echo "")
+    if [ -n "$pr_number" ]; then
+      pr_opened="PR #${pr_number}"
+    fi
+  fi
+  
+  # Determine next priority based on status
+  local next_priority=""
+  if [ "$status" = "completed" ]; then
+    next_priority="Continue platform improvement loop"
+  else
+    next_priority="Investigate failure and retry"
+  fi
+  
+  # Call the full post_report() function
+  post_report "$vision_score" "$work_done" "$issues_found" "$pr_opened" "$blockers" "$next_priority" "$OPENCODE_EXIT"
+}
+
 patch_task_status() {
   local phase="$1" outcome="${2:-}"
   local completed_at=""


### PR DESCRIPTION
## Summary
- Implements the missing `file_report()` function that is called by lines 727 and 734
- Fixes CRITICAL bug preventing agents from filing Report CRs
- S-effort fix (< 30 minutes)

## Problem
Lines 727 and 734 call `file_report()` but the function doesn't exist, causing agents to fail with "command not found" errors when trying to file Report CRs.

## Solution
Added `file_report()` as a simplified wrapper around the existing `post_report()` function:
- Signature: `file_report <status> <work_done> <blockers> <vision_score>`
- Automatically extracts issue numbers from git branch names
- Automatically detects PR numbers from git log
- Maps the simplified parameters to the full `post_report()` signature

## Impact
- ✅ Agents can now file Report CRs successfully
- ✅ god-observer receives civilization progress data
- ✅ No more exit errors due to missing function

## Testing
Function tested with existing call sites:
```bash
file_report "completed" "$TASK_TITLE completed successfully" "none" 8
file_report "failed" "Agent failed with exit code $OPENCODE_EXIT" "Agent execution failure" 3
```

Closes #107