### PR TITLE
Fix issue #111: emergency spawn agent naming now matches role

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -825,7 +825,6 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
 
   TS=$(ts)
   NEXT_TASK="task-continue-${TS}"
-  NEXT_AGENT="worker-${TS}"
 
   # Determine what the next agent should do:
   # If role escalation was triggered, use that; otherwise cycle through roles
@@ -842,6 +841,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
       *)         NEXT_ROLE="worker" ;;
     esac
   fi
+
+  # Set agent name to match role (fix for issue #111)
+  NEXT_AGENT="${NEXT_ROLE}-${TS}"
 
   # CONSENSUS CHECK (issue #2): Prevent runaway agent proliferation
   # Count running agents of the same role. If >= 3, require consensus before spawning.


### PR DESCRIPTION
## Problem
Emergency perpetuation hardcoded agent names as `worker-{timestamp}` regardless of actual role, creating confusion. For example, agents named `worker-1773001556` would have `role=planner`.

## Evidence
Multiple agents in cluster had mismatched names and roles:
- `worker-1773001455` with role `planner`
- `worker-1773001491` with role `planner`
- `worker-1773001694` with role `planner`

## Solution
Moved agent naming to AFTER role determination (line 828 → line 845). Agent names now use format: `${NEXT_ROLE}-${TS}`

## Results
- `planner-{TS}` for planners
- `worker-{TS}` for workers
- `architect-{TS}` for architects
- `reviewer-{TS}` for reviewers

## Impact
- ✅ Improved clarity: operator can identify agent roles by name
- ✅ Better debugging: logs and traces easier to understand
- ✅ Aesthetic: planner loop now shows planner-001 → planner-002 instead of worker-* with role=planner

## Effort
S (< 10 minutes) — 2-line change

Closes #111