### PR TITLE
fix: emergency spawn agent naming should match role (issue #111)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -825,7 +825,6 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
 
   TS=$(ts)
   NEXT_TASK="task-continue-${TS}"
-  NEXT_AGENT="worker-${TS}"
 
   # Determine what the next agent should do:
   # If role escalation was triggered, use that; otherwise cycle through roles
@@ -842,6 +841,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
       *)         NEXT_ROLE="worker" ;;
     esac
   fi
+
+  # Set agent name based on role (after role is determined)
+  NEXT_AGENT="${NEXT_ROLE}-${TS}"
 
   # CONSENSUS CHECK (issue #2): Prevent runaway agent proliferation
   # Count running agents of the same role. If >= 3, require consensus before spawning.


### PR DESCRIPTION
## Summary

Fixes #111 — Emergency perpetuation now names agents based on their actual role instead of hardcoding "worker-".

## Problem

Emergency spawn was creating agents like `worker-1773001556` with `role=planner`, causing confusion. The agent name was set at line 828 BEFORE role determination at lines 832-844.

## Solution

Moved agent naming to AFTER role determination (line 847) and made it dynamic:

```bash
# OLD (line 828):
NEXT_AGENT="worker-${TS}"

# NEW (line 847, after role is determined):
NEXT_AGENT="${NEXT_ROLE}-${TS}"
```

## Impact

Emergency-spawned agents now have intuitive names:
- `planner-{TS}` for planners (not `worker-{TS}` with role=planner)
- `worker-{TS}` for workers
- `architect-{TS}` for architects
- `reviewer-{TS}` for reviewers

## Testing

No functional change — only affects agent naming. The role cycling logic is unchanged. Agent CRs will be created with matching name and role fields.

## Effort

S-effort (2-line change)

## Vision Score

5/10 — Platform stability and UX improvement