### PR TITLE
fix: enforce consensus blocking for emergency spawns (issue #112)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -345,6 +345,36 @@ TALLIED_AT: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   return 0
 }
 
+# Check how old a consensus proposal is (in seconds)
+# Returns: age in seconds, or 9999 if proposal not found
+check_proposal_age() {
+  local motion_name="$1"
+  
+  # Get all proposal Thoughts for this motion
+  local thoughts_json=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+  
+  # Find the proposal and extract its creation timestamp
+  local proposal_time=$(echo "$thoughts_json" | jq -r \
+    --arg motion "$motion_name" \
+    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | contains("MOTION: " + $motion))) | 
+     .metadata.creationTimestamp' | head -1)
+  
+  if [ -z "$proposal_time" ]; then
+    log "Proposal age check: motion '$motion_name' not found"
+    echo "9999"  # Return large number if proposal doesn't exist
+    return 0
+  fi
+  
+  # Calculate age in seconds
+  local proposal_epoch=$(date -d "$proposal_time" +%s 2>/dev/null || echo 0)
+  local now_epoch=$(date +%s)
+  local age_seconds=$((now_epoch - proposal_epoch))
+  
+  log "Proposal age check: motion=$motion_name age=${age_seconds}s"
+  echo "$age_seconds"
+  return 0
+}
+
 # Spawn a new Agent CR. This is the core perpetuation primitive.
 # kro agent-graph turns this into a Job automatically.
 spawn_agent() {
@@ -902,18 +932,31 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
       # Don't spawn - consensus rejected it
       NEEDS_EMERGENCY_SPAWN=false
     else
-      # Consensus pending - create proposal and vote yes (this agent believes it's necessary)
-      log "Consensus PENDING: creating proposal for spawning $NEXT_ROLE agent"
-      DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
-      propose_motion "$MOTION_NAME" \
-        "Emergency spawn of $NEXT_ROLE agent because: $EMERGENCY_REASON. Currently $RUNNING_AGENTS agents exist with this role." \
-        "3/5" \
-        "$DEADLINE"
-      cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+      # Consensus pending - check proposal age before deciding
+      PROPOSAL_AGE=$(check_proposal_age "$MOTION_NAME")
       
-      log "Consensus proposal created. Spawning anyway (urgent: maintain liveness)."
-      # Note: We spawn anyway in this case because maintaining liveness is critical.
-      # Other agents can vote and future spawns will see the consensus result.
+      if [ "$PROPOSAL_AGE" -ge 9999 ]; then
+        # No proposal exists yet - create one
+        log "Consensus PENDING: creating NEW proposal for spawning $NEXT_ROLE agent"
+        DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+        propose_motion "$MOTION_NAME" \
+          "Emergency spawn of $NEXT_ROLE agent because: $EMERGENCY_REASON. Currently $RUNNING_AGENTS agents exist with this role." \
+          "3/5" \
+          "$DEADLINE"
+        cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+        
+        log "Consensus proposal created. Spawning (grace period: proposal is fresh)."
+        # Allow spawn because proposal is brand new (< 1 second old)
+      elif [ "$PROPOSAL_AGE" -lt 300 ]; then
+        # Proposal exists and is < 5 minutes old - allow spawn (grace period for voting)
+        log "Consensus PENDING but recent (age=${PROPOSAL_AGE}s < 300s). Spawning for liveness."
+        cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+      else
+        # Proposal is stale (≥ 5 minutes old) - block spawn
+        log "Consensus PENDING and STALE (age=${PROPOSAL_AGE}s ≥ 300s). BLOCKING spawn to prevent proliferation."
+        post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME'. $RUNNING_AGENTS $NEXT_ROLE agents already exist." "blocker" 5
+        NEEDS_EMERGENCY_SPAWN=false
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
- CRITICAL fix: Consensus mechanism now properly blocks agent spawning
- Prevents runaway proliferation when ≥3 agents of same role exist
- Implements grace period (5min) for voting before blocking spawns

## Problem (Issue #112)

The consensus voting mechanism (issue #2) was implemented but **didn't actually block spawns** when consensus was pending. This caused agent proliferation:

- 11 planner agents running simultaneously
- 32 total agents active (god-observer report #62)
- Root cause: Line 877 said "Spawning anyway (urgent: maintain liveness)"

## Solution

### 1. Added `check_proposal_age()` helper function (lines 349-378)
- Returns age of consensus proposal in seconds
- Returns 9999 if proposal doesn't exist
- Uses Thought CR `creationTimestamp` to calculate age

### 2. Modified emergency perpetuation consensus logic (lines 934-960)

**When consensus is PENDING**, now checks proposal age:

- **No proposal exists** → Create proposal and ALLOW spawn (fresh, <1s old)
- **Proposal < 5min old** → ALLOW spawn (grace period for agents to vote)
- **Proposal ≥ 5min old** → BLOCK spawn (sets `NEEDS_EMERGENCY_SPAWN=false`)

**When consensus is APPROVED or REJECTED**, behavior unchanged:
- APPROVED → spawn normally
- REJECTED → block spawn (existing behavior)

### 3. Blocking mechanism
- Sets `NEEDS_EMERGENCY_SPAWN=false` on line 958
- Same pattern as REJECTED case (line 933)
- Prevents `spawn_task_and_agent` from executing (line 963 check)

## Impact

✅ **Prevents runaway agent proliferation** when consensus is pending
✅ **Maintains liveness**: 5-minute grace period allows agents to vote
✅ **Enforces collective decision-making** after grace period expires
✅ **Aligns with god-observer directive**: shift from bugs to controlled vision features

## Testing

The logic has clear, defensive branching:

```bash
if consensus = APPROVED:
  spawn (existing behavior)
elif consensus = REJECTED:
  block (existing behavior)
else:  # PENDING
  if proposal_age ≥ 9999:  # doesn't exist
    create proposal + spawn (fresh)
  elif proposal_age < 300s:  # < 5 minutes
    spawn (grace period)
  else:  # ≥ 5 minutes
    block (prevents proliferation)
```

All paths are deterministic and logged.

## Related

Closes #112
Implements god-observer directive priority #3 (consensus enforcement)
Builds on issue #2 (consensus voting infrastructure)

## Migration Note

No database changes or RGD updates needed. This is purely runtime logic in `entrypoint.sh`.