### PR TITLE
fix: re-fetch swarm state before dissolution check (issue #114)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1004,6 +1004,10 @@ if [ -n "$SWARM_REF" ]; then
     --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
     2>/dev/null || true
   
+  # Re-fetch swarm state after patching to ensure dissolution check uses current data
+  SWARM_STATE=$(kubectl get configmap "${SWARM_REF}-state" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
+  CURRENT_PHASE=$(echo "$SWARM_STATE" | jq -r '.data.phase // "Forming"')
+  
   # Check for dissolution condition (only if not already disbanded)
   if [ "$CURRENT_PHASE" != "Disbanded" ]; then
     # Dissolution condition: all tasks done AND no activity for 5 minutes


### PR DESCRIPTION
## Summary
S-EFFORT FIX: Swarm dissolution logic now uses current (not stale) ConfigMap data.

## Problem
Issue #114 identified that swarm dissolution checks were using stale timestamp data:

1. Line 955: Fetch swarm state ConfigMap into `SWARM_STATE` variable
2. Line 1003: Patch ConfigMap with NEW timestamp and member data  
3. Line 1007-1032: Check dissolution conditions using stale `CURRENT_PHASE`

**Impact:**
- If another agent disbanded the swarm between lines 955 and 1007, this agent wouldn't see it
- Could result in duplicate dissolution messages
- Dissolution checks might operate on outdated phase information

## Solution
Re-fetch the swarm state ConfigMap after patching it (lines 1007-1009):

```bash
# Re-fetch swarm state after patching to ensure dissolution check uses current data
SWARM_STATE=$(kubectl get configmap "${SWARM_REF}-state" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
CURRENT_PHASE=$(echo "$SWARM_STATE" | jq -r '.data.phase // "Forming"')
```

This ensures the dissolution check sees:
- The actual current swarm phase (Forming/Active/Disbanded)
- Any updates from concurrent agents
- Correct timestamp for idle calculation

## Impact
✅ Dissolution checks now use current swarm state
✅ Prevents race conditions between concurrent swarm members
✅ Ensures accurate phase tracking
✅ Only 3 lines added (S-effort fix)

## Testing
- Syntax validated with bash -n
- Logic flow verified: fetch → patch → re-fetch → check

## Effort
S-effort: Single ConfigMap re-fetch + phase extraction (< 15 minutes)

Closes #114