### PR TITLE
fix: swarm dissolution timestamp no longer resets on every task completion

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -933,15 +933,8 @@ if [ -n "$SWARM_REF" ]; then
   # Increment tasks completed
   NEW_TASKS=$(( CURRENT_TASKS + 1 ))
   
-  # Update last activity timestamp
-  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  
-  # Patch swarm state
-  kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
-    --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
-    2>/dev/null || true
-  
   # Check for dissolution condition (only if not already disbanded)
+  # IMPORTANT: Check this BEFORE updating timestamp to avoid resetting idle timer
   if [ "$CURRENT_PHASE" != "Disbanded" ]; then
     # Get all tasks associated with this swarm
     SWARM_TASKS=$(kubectl get tasks -n "$NAMESPACE" -l "agentex/swarm=${SWARM_REF}" -o json 2>/dev/null || echo '{"items":[]}')
@@ -951,6 +944,24 @@ if [ -n "$SWARM_REF" ]; then
     
     log "Swarm $SWARM_REF: $DONE_TASKS/$TOTAL_TASKS tasks done, $PENDING_TASKS pending"
     
+    # Update timestamp only if there are still pending tasks
+    # This prevents resetting the idle timer when all tasks are complete
+    if [ "$PENDING_TASKS" -gt 0 ]; then
+      TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    else
+      # All tasks done - preserve old timestamp to allow idle timer to accumulate
+      TIMESTAMP=$(echo "$SWARM_STATE" | jq -r '.data.lastActivityTimestamp // ""')
+      if [ -z "$TIMESTAMP" ]; then
+        # First time seeing all tasks done - set timestamp now
+        TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      fi
+    fi
+    
+    # Patch swarm state (moved here so we have correct timestamp)
+    kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+      --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
+      2>/dev/null || true
+    
     # Dissolution condition: all tasks done AND no activity for 5 minutes
     if [ "$PENDING_TASKS" -eq 0 ] && [ "$TOTAL_TASKS" -gt 0 ]; then
       LAST_ACTIVITY=$(echo "$SWARM_STATE" | jq -r '.data.lastActivityTimestamp // ""')
@@ -958,6 +969,8 @@ if [ -n "$SWARM_REF" ]; then
         LAST_EPOCH=$(date -d "$LAST_ACTIVITY" +%s 2>/dev/null || echo 0)
         NOW_EPOCH=$(date +%s)
         IDLE_SECONDS=$(( NOW_EPOCH - LAST_EPOCH ))
+        
+        log "Swarm $SWARM_REF idle check: ${IDLE_SECONDS}s since last activity (threshold: 300s)"
         
         # 300 seconds = 5 minutes idle threshold
         if [ "$IDLE_SECONDS" -gt 300 ]; then
@@ -975,6 +988,12 @@ if [ -n "$SWARM_REF" ]; then
         fi
       fi
     fi
+  else
+    # Swarm already disbanded - just update task count (no timestamp change needed)
+    TIMESTAMP=$(echo "$SWARM_STATE" | jq -r '.data.lastActivityTimestamp // ""')
+    kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+      --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\"}}" \
+      2>/dev/null || true
   fi
 fi
 


### PR DESCRIPTION
## Summary
Fixes #106 - Critical bug preventing swarm dissolution from ever triggering

## The Bug
Every agent that completed a task would reset `lastActivityTimestamp` to NOW, even when all tasks were already done. This prevented the idle timer from ever reaching the 5-minute threshold required for dissolution.

## The Fix
1. **Check task completion status BEFORE updating timestamp** (lines 936-943)
2. **Only update timestamp to NOW if there are pending tasks** (lines 949-950)
3. **When all tasks are done, preserve the old timestamp** so idle time accumulates (lines 952-958)
4. **Added logging** to show idle seconds vs threshold for debugging (line 973)

## Impact
- Swarms will now correctly disband 5 minutes after the last task completes
- Frees up cluster resources as designed
- Fixes resource leak (ConfigMaps accumulating indefinitely)

## Testing
The fix ensures:
- If tasks are still pending → timestamp updates to NOW (normal behavior)
- If all tasks done for first time → timestamp set to NOW (start idle timer)
- If all tasks done subsequently → timestamp preserved (idle timer accumulates)
- After 5 minutes idle → dissolution triggers (as designed)

## Effort
S (20 lines changed, logic reordering + conditional timestamp update)