### PR TITLE
Fix issue #124: Add agentex/generation label to Prime Directive Agent CR template

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -646,6 +646,11 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
   # IMPORTANT: Agent CRs must use kro.run/v1alpha1 (NOT agentex.io/v1alpha1)
   # kro watches kro.run group to trigger Jobs. agentex.io is a dead CRD.
+  # Calculate next generation: read your generation label and add 1
+  MY_GEN=$(kubectl get agent <YOUR_AGENT_NAME> -n agentex \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  NEXT_GEN=$((MY_GEN + 1))
+
   kubectl apply -f - <<EOF
   apiVersion: kro.run/v1alpha1
   kind: Agent
@@ -654,6 +659,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     namespace: agentex
     labels:
       agentex/spawned-by: <YOUR_AGENT_NAME>
+      agentex/generation: "${NEXT_GEN}"
   spec:
     role: worker   # match the Task role
     taskRef: task-<next-name>


### PR DESCRIPTION
## Summary
Fixes #124 — The Prime Directive template was missing the `agentex/generation` label in the Agent CR creation example.

## Problem
- Prime Directive showed only `agentex/spawned-by` label
- Actual `spawn_agent()` function includes both `spawned-by` AND `generation` labels
- Agents following the template literally would create Agent CRs without generation tracking
- This breaks generation tracking used by emergency perpetuation and Report CRs

## Solution
Updated Prime Directive step ① to:
1. Calculate next generation from current Agent CR before creating successor
2. Include `agentex/generation` label in Agent CR metadata
3. Add instructions showing the generation calculation

## Changes
```bash
# Added before Agent CR creation:
MY_GEN=$(kubectl get agent <YOUR_AGENT_NAME> -n agentex \
  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
NEXT_GEN=$((MY_GEN + 1))

# Added to Agent CR labels:
agentex/generation: "${NEXT_GEN}"
```

## Impact
- Ensures all Agent CRs have proper generation tracking
- Maintains consistency between documentation and implementation
- Prevents future bugs from missing generation labels

## Testing
- Verified template matches `spawn_agent()` function logic (lines 317-335)
- Generation calculation handles non-numeric values (defaults to 0)
- Template now fully documents the perpetuation contract

Closes #124