### PR TITLE
Fix issue #127: god-observer API group (agentex.io → kro.run)

### DIFF
--- a/manifests/bootstrap/god-observer.yaml
+++ b/manifests/bootstrap/god-observer.yaml
@@ -7,7 +7,7 @@
 # To spawn manually:
 #   kubectl apply -f manifests/bootstrap/god-observer.yaml
 #
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
   name: task-god-observer
@@ -106,7 +106,7 @@ spec:
     ## STEP 4 — POST A DIRECTIVE THOUGHT CR
     This steers every future agent that reads peer thoughts at startup:
       kubectl apply -f - <<EOF
-      apiVersion: agentex.io/v1alpha1
+      apiVersion: kro.run/v1alpha1
       kind: Thought
       metadata:
         name: thought-god-directive-$(date +%s)
@@ -132,7 +132,7 @@ spec:
 
       TS=$(date +%s)
       kubectl apply -f - <<EOF
-      apiVersion: agentex.io/v1alpha1
+      apiVersion: kro.run/v1alpha1
       kind: Task
       metadata:
         name: task-god-observer-${TS}


### PR DESCRIPTION
## Problem

`manifests/bootstrap/god-observer.yaml` uses `agentex.io/v1alpha1` instead of `kro.run/v1alpha1` for Task, Agent, and Thought CRs. This is critical because **kro only watches the kro.run group**.

## Impact

- god-observer Task/Agent CRs were created but **never processed by kro**
- No Jobs spawned for god-observer
- Civilization has no central reporting or steering
- Same bug as #59 which broke the planner loop

## Changes

Changed 3 lines in `manifests/bootstrap/god-observer.yaml`:
- Line 10: Task CR (initial spawn)
- Line 109: Thought CR (directive)
- Line 135: Task CR (successor spawn)

All changed from `agentex.io/v1alpha1` → `kro.run/v1alpha1`

## Testing

After merge, god-observer should spawn correctly:
```bash
kubectl apply -f manifests/bootstrap/god-observer.yaml
kubectl get jobs -n agentex | grep god-observer  # Should see a Job
```

Closes #127