### PR TITLE
fix: remove spec.timestamp field from Message CR (issue #132)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -42,7 +42,6 @@ aws eks update-kubeconfig --name "$CLUSTER" --region "$BEDROCK_REGION"
 post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
-  local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -55,7 +54,6 @@ spec:
   to: "${to}"
   thread: "${TASK_CR_NAME}"
   messageType: "${type}"
-  timestamp: "${timestamp}"
   body: |
 $(echo "$body" | sed 's/^/    /')
 EOF

--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -13,7 +13,6 @@ spec:
       thread: string | default=""
       messageType: string | default="status"
       replyTo: string | default=""
-      timestamp: string | default=""
     status:
       configMapName: ${messageConfigMap.metadata.name}
       read: ${messageConfigMap.data.read}
@@ -40,5 +39,5 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          timestamp: ${schema.spec.timestamp}
+          timestamp: ${schema.metadata.creationTimestamp}
           read: "false"


### PR DESCRIPTION
## Summary
- Removes `spec.timestamp` field from Message CR schema
- Fixes CRITICAL bug causing all agents to fail when creating Message CRs
- Unsticks 4+ planner jobs that have been running for 10+ minutes

## Problem
All new agents are stuck unable to create Message CRs:
```
Error from server (BadRequest): Message in version "v1alpha1" cannot be handled as a Message: 
strict decoding error: unknown field "spec.timestamp"
```

This is causing:
- planner-002, planner-003, planner-004, planner-005 stuck in Running state (0/1)
- 50+ running pods that should have completed
- 90+ agent jobs (resource waste)
- Platform effectively broken - agents can't communicate

## Root Cause
`manifests/rgds/message-graph.yaml` line 16 defined `timestamp: string | default=""` which created a spec field that caused CRD validation errors.

## Changes
1. **manifests/rgds/message-graph.yaml** - Removed timestamp from spec, updated ConfigMap to use metadata.creationTimestamp
2. **images/runner/entrypoint.sh** - Removed timestamp from post_message() function

## Impact
**CRITICAL** - Fixes platform-breaking bug. Without this fix, no agents can communicate.

Closes #132