### PR TITLE
Fix PR #51 critical bugs: API groups, RBAC, duplicate entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,6 @@ Six RGDs form the agent coordination layer:
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
 | `report-graph` | `Report` | ConfigMap (agent exit report for god-observer synthesis) |
 | `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
-| `report-graph` | `Report` | ConfigMap (structured exit report — feeds god-observer) |
 
 **kro DSL rules** (v0.8.5):
 - No `group:` field in schema — kro auto-assigns it

--- a/manifests/bootstrap/god-observer.yaml
+++ b/manifests/bootstrap/god-observer.yaml
@@ -7,7 +7,7 @@
 # To spawn manually:
 #   kubectl apply -f manifests/bootstrap/god-observer.yaml
 #
-apiVersion: agentex.io/v1alpha1
+apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
   name: task-god-observer
@@ -106,7 +106,7 @@ spec:
     ## STEP 4 — POST A DIRECTIVE THOUGHT CR
     This steers every future agent that reads peer thoughts at startup:
       kubectl apply -f - <<EOF
-      apiVersion: agentex.io/v1alpha1
+      apiVersion: kro.run/v1alpha1
       kind: Thought
       metadata:
         name: thought-god-directive-$(date +%s)
@@ -132,7 +132,7 @@ spec:
 
       TS=$(date +%s)
       kubectl apply -f - <<EOF
-      apiVersion: agentex.io/v1alpha1
+      apiVersion: kro.run/v1alpha1
       kind: Task
       metadata:
         name: task-god-observer-${TS}

--- a/manifests/system/kro-rbac.yaml
+++ b/manifests/system/kro-rbac.yaml
@@ -91,11 +91,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kro-agentex-access
+  name: kro-agentex-resources
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kro-agentex-access
+  name: kro-agentex-resources
 subjects:
 - kind: ServiceAccount
   name: kro


### PR DESCRIPTION
## What This Fixes

Found and fixed three critical bugs in PR #51 that would prevent the god-observer from working:

### 1. Wrong API Group (CRITICAL)
**Lines**: god-observer.yaml:10, 109, 136  
**Issue**: Used `agentex.io/v1alpha1` instead of `kro.run/v1alpha1`  
**Impact**: kro watches `kro.run` group to create Jobs. Using `agentex.io` means NO Job would be created, and god-observer would never run.  
**Fix**: Changed all three occurrences to `kro.run/v1alpha1` (same as PR #60)

### 2. Duplicate Table Entry
**Lines**: AGENTS.md:131  
**Issue**: `report-graph` listed twice in RGD table  
**Impact**: Documentation error, confusing for agents reading the file  
**Fix**: Removed duplicate line

### 3. RBAC Name Mismatch (CRITICAL)
**Lines**: kro-rbac.yaml:94, 98  
**Issue**: ClusterRoleBinding references `kro-agentex-access` but ClusterRole is named `kro-agentex-resources` (line 6)  
**Impact**: RBAC binding would FAIL, kro wouldn't have permissions to manage agent resources  
**Fix**: Changed binding name and roleRef to match ClusterRole name

## Testing
All three are straightforward fixes:
- API group change matches established pattern from PR #60
- Duplicate line removal is safe
- RBAC name alignment is required for binding to work

## Ready to Merge
These fixes make PR #51 ready to merge into main once this PR is merged into the feature branch.