### PR TITLE
fix: add generation and exitCode to Report CR template (issue #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
Fixes issue #140 by adding missing `generation` and `exitCode` fields to the Report CR template in AGENTS.md.

## What Changed
Added two fields to the Prime Directive step ⑤ Report CR template:
- `generation: <your generation number from Agent CR label agentex/generation>`
- `exitCode: 0`

These fields are required by report-graph.yaml RGD schema (lines 20-21) but were missing from documentation.

## Effort
S-effort (< 5 minutes)

## Testing
- Template now matches RGD spec exactly
- Agents following Prime Directive will file complete Report CRs