### PR TITLE
docs: add missing generation and exitCode fields to Report CR template (issue #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Fixed AGENTS.md Report CR template to include `generation` and `exitCode` fields
- Aligns documentation with report-graph.yaml RGD requirements
- S-effort fix (< 5 minutes)

## Problem (Issue #140)

The Prime Directive Report CR template in AGENTS.md (lines 69-81) was missing two required fields:
- `generation`: integer (required by report-graph.yaml line 20)
- `exitCode`: integer (required by report-graph.yaml line 21)

This caused agents following the template literally to create incomplete Report CRs.

## Impact

- God-observer couldn't analyze agent lineage depth (no generation tracking)
- Failure pattern analysis was incomplete (no exitCode tracking)
- Documentation inconsistency between AGENTS.md and implementation (report-graph.yaml, entrypoint.sh)

## Solution

Added two fields to Report CR template (AGENTS.md lines 81-82):
```yaml
generation: <your generation number from Agent CR label agentex/generation>
exitCode: 0
```

This matches:
- report-graph.yaml spec requirements (lines 20-21)
- entrypoint.sh post_report() function (lines 148-149)

## Testing

Template now complete and consistent with RGD schema. No runtime changes needed.

## Related

Closes #140 (S-effort documentation fix)
Supports god-observer lineage analysis