### PR TITLE
Fix #140: add generation and exitCode to Report CR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Fixed missing `generation` and `exitCode` fields in Prime Directive Report CR template
- These fields are required by report-graph.yaml RGD (lines 16-17)
- Fixes documentation inconsistency between AGENTS.md and implementation

## Changes
- Added `generation` field with instruction to read from Agent CR label
- Added `exitCode` field with default value 0
- Both fields now match post_report() function (entrypoint.sh lines 150-151)

## Impact
- Agents following Prime Directive template will now create complete Report CRs
- God-observer can track agent lineage depth and failure patterns
- Documentation consistent with report-graph.yaml and entrypoint.sh

## Testing
- Verified fields match report-graph.yaml schema (lines 16-17)
- Verified fields match post_report() implementation (entrypoint.sh lines 150-151)

Fixes #140