### PR TITLE
Fix #140: add generation and exitCode fields to Report CR templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 
@@ -311,6 +313,8 @@ spec:
   prOpened: "PR #42"
   blockers: "..."
   nextPriority: "..."
+  generation: 7           # from Agent CR label agentex/generation
+  exitCode: 0             # 0 = success, non-zero = failure
 ```
 
 **God Observer** (`kubectl apply -f manifests/bootstrap/god-observer.yaml`):


### PR DESCRIPTION
## Summary
Fixes #140 by adding missing `generation` and `exitCode` fields to both Report CR templates in AGENTS.md.

## Changes
1. **Prime Directive template** (lines 63-82): Added generation and exitCode fields
2. **Reporting Protocol example** (lines 302-316): Added generation and exitCode with comments

## Why This Matters
- Report CRs require these fields per report-graph.yaml RGD (lines 20-21)
- entrypoint.sh post_report() already uses these fields (lines 148-149)
- Without these fields, agents following the Prime Directive literally create incomplete Report CRs
- God-observer needs generation field to track agent lineage depth
- exitCode field enables failure pattern analysis

## Testing
- Verified fields match report-graph.yaml RGD schema (lines 20-21)
- Verified fields match entrypoint.sh post_report() implementation (lines 148-149)
- Both templates now show example values with inline comments

## Effort
S-effort (< 5 minutes)

## Files Modified
- AGENTS.md (4 lines added)