### PR TITLE
fix: consensus check should only count ACTIVE agents

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -918,9 +918,10 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   NEXT_AGENT="${NEXT_ROLE}-${TS}"
 
   # CONSENSUS CHECK (issue #2): Prevent runaway agent proliferation
-  # Count running agents of the same role. If >= 3, require consensus before spawning.
+  # Count ACTIVE agents of the same role (without completionTime). If >= 3, require consensus before spawning.
+  # This prevents false positives from completed/failed agents that are still in the cluster.
   RUNNING_AGENTS=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$NEXT_ROLE" '[.items[] | select(.spec.role == $role)] | length' 2>/dev/null || echo "0")
+    jq --arg role "$NEXT_ROLE" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
   
   CONSENSUS_REQUIRED=false
   if [ "$RUNNING_AGENTS" -ge 3 ]; then


### PR DESCRIPTION
## Summary
S-EFFORT FIX: Consensus proliferation check now only counts ACTIVE agents (without completionTime), not ALL agents.

## Problem
Emergency perpetuation consensus check (line 922-923) counts ALL Agent CRs:

```bash
RUNNING_AGENTS=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$NEXT_ROLE" '[.items[] | select(.spec.role == $role)] | length' 2>/dev/null || echo "0")
```

**Impact:**
- Includes completed agents (whose Jobs finished)
- Includes failed agents  
- Creates false positives: system thinks there are 10 planners when actually only 1 is running
- Unnecessary consensus proposals are created
- Could block legitimate spawns due to stale count

## Solution
Modified jq filter to exclude agents with `status.completionTime != null`:

```bash
RUNNING_AGENTS=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$NEXT_ROLE" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
```

**Result:**
✅ Only counts agents whose Jobs haven't completed yet
✅ Gives accurate count of concurrent agents for proliferation detection  
✅ Prevents false consensus requirements

## Testing
- Agent CRs have `status.completionTime` populated by kro when Job completes (verified with kubectl)
- jq filter syntax validated
- Single line change, S-effort (< 15 minutes)

## Example
Before: 50 planner Agent CRs exist (49 completed, 1 running) → consensus required ❌
After: Only 1 active planner Agent CR → no consensus needed ✅

## Effort
S-effort: Single jq filter modification