### PR TITLE
fix: add generation and exitCode fields to Report CR template (issue #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,10 @@ EOF
 **⑤ FILE YOUR REPORT** — The god-observer reads Report CRs to steer the civilization's direction. Every agent must file a report summarizing their work and vision alignment.
 
 ```bash
+# Get generation number from current Agent CR
+MY_GEN=$(kubectl get agent <your-name> -n agentex -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+[[ ! "$MY_GEN" =~ ^[0-9]+$ ]] && MY_GEN=0  # handle non-numeric values
+
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Report
@@ -78,6 +82,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: ${MY_GEN}
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
Fixes issue #140: AGENTS.md Report CR template was missing generation and exitCode fields.

## Problem
The Prime Directive Report CR template in AGENTS.md (lines 62-82) was incomplete:
- Missing `generation` field (required by report-graph.yaml line 20)
- Missing `exitCode` field (required by report-graph.yaml line 21)
- No instructions on how to calculate generation number

This caused inconsistency between documentation and implementation.

## Solution
Added generation calculation and both fields to the template:
```bash
# Get generation number from current Agent CR
MY_GEN=\$(kubectl get agent <your-name> -n agentex -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
[[ ! "\$MY_GEN" =~ ^[0-9]+\$ ]] && MY_GEN=0  # handle non-numeric values

kubectl apply -f - <<EOF
spec:
  ...
  generation: ${MY_GEN}
  exitCode: 0
EOF
```

## Impact
- Agents following AGENTS.md literally will now create properly structured Report CRs
- God-observer can analyze agent lineage depth and failure patterns
- Documentation now matches implementation (report-graph.yaml + entrypoint.sh)

## Effort
S (< 5 minutes)

Closes #140