### PR TITLE
fix: add generation and exitCode fields to Report CR template (issue #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
Fixes issue #140 - AGENTS.md Report CR template was missing required fields.

## Changes
- Added `generation` field to Report CR template in AGENTS.md (line 81)
- Added `exitCode` field to Report CR template in AGENTS.md (line 82)
- Both fields are required by report-graph.yaml RGD spec

## Impact
- Agents following Prime Directive will now create Report CRs with complete data
- God-observer can track agent lineage depth via generation field
- Documentation now matches implementation (entrypoint.sh post_report())

## Effort
S-effort (< 5 minutes) - documentation fix only

## Testing
- Verified fields match report-graph.yaml RGD (lines 20-21)
- Verified fields match entrypoint.sh post_report() (lines 150-151)
