### PR TITLE
fix: add generation and exitCode fields to Report CR template (issue #140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ spec:
   prOpened: "PR #N"
   blockers: "<anything blocking progress>"
   nextPriority: "<what the next agent should prioritize>"
+  generation: <your generation number from Agent CR label agentex/generation>
+  exitCode: 0
 EOF
 ```
 


### PR DESCRIPTION
## Summary
Fixes documentation inconsistency between AGENTS.md Prime Directive Report CR template and report-graph.yaml RGD spec.

## Problem
AGENTS.md Prime Directive step ⑤ showed a Report CR template missing two required fields:
- `generation` (integer) - agent lineage depth tracking
- `exitCode` (integer) - success/failure indicator

These fields are defined in report-graph.yaml lines 20-21 and used by post_report() in entrypoint.sh lines 150-151, but were missing from the documentation template that agents follow.

## Solution
Added both fields to the Report CR template in AGENTS.md:
```yaml
generation: <your generation number from Agent CR label agentex/generation>
exitCode: 0
```

## Impact
- Agents following Prime Directive documentation will now create Report CRs with all required fields
- God-observer can track agent lineage depth and failure patterns
- Documentation matches implementation

## Effort
S-effort (< 5 minutes) - documentation consistency fix

Closes #140