### PR TITLE
fix: add activeDeadlineSeconds to agent Jobs (issue #158)

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -33,6 +33,7 @@ spec:
         spec:
           ttlSecondsAfterFinished: 3600
           backoffLimit: 2  # retry up to 2x on pod crash — prevents silent death from transient failures
+          activeDeadlineSeconds: 3600  # force termination after 1 hour — prevents stuck agents from consuming resources indefinitely
           template:
             metadata:
               labels:

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -69,6 +69,7 @@ spec:
         spec:
           ttlSecondsAfterFinished: 3600
           backoffLimit: 0
+          activeDeadlineSeconds: 3600  # force termination after 1 hour — prevents stuck swarm planners from consuming resources indefinitely
           template:
             metadata:
               labels:


### PR DESCRIPTION
## Summary

Prevents stuck agents from consuming cluster resources indefinitely by adding activeDeadlineSeconds to agent Job specs.

## Problem

Currently 61 incomplete agents and 52 running pods consuming resources:
- Old agents (planner-002 through 013) stuck since Message CR timestamp bug (before PR #131)
- Even after fix merged, stuck agents continue running
- API server experiencing timeouts due to resource overload
- kubectl commands taking >2 minutes

## Root Cause

agent-graph.yaml only had `ttlSecondsAfterFinished: 3600` which cleans up COMPLETED jobs. Jobs that fail or get stuck can retry (backoffLimit: 2) and run indefinitely.

## Solution

Added `activeDeadlineSeconds: 3600` (1 hour) to both:
- manifests/rgds/agent-graph.yaml
- manifests/rgds/swarm-graph.yaml

This ensures:
- Agents have max 1 hour to complete (generous for most tasks)
- Stuck agents are force-terminated after deadline
- Job status becomes Failed → triggers ttlSecondsAfterFinished cleanup
- Resources are freed for new agents

Most successful agents complete in < 10 minutes, so 1 hour is very generous.

## Impact

- ✅ Resource recovery from stuck agents
- ✅ API server load reduction
- ✅ Prevents cluster resource exhaustion
- ✅ New agents can be scheduled
- ✅ Cost reduction (no more zombie pods)

## Related

- Issue #158: Add activeDeadlineSeconds
- Issue #112: Consensus blocking (prevents NEW proliferation)
- PR #131: Message CR timestamp fix (root cause of current stuck agents)

## Verification

After deployment:
1. Existing stuck agents will hit deadline and terminate
2. Jobs transition to Failed state
3. ttlSecondsAfterFinished cleans them up
4. Cluster resource usage drops significantly

Fixes #158