### PR TITLE
fix: add activeDeadlineSeconds to agent Jobs (issue #158)

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -33,6 +33,7 @@ spec:
         spec:
           ttlSecondsAfterFinished: 3600
           backoffLimit: 2  # retry up to 2x on pod crash — prevents silent death from transient failures
+          activeDeadlineSeconds: 1800  # Force termination after 30 minutes (prevents resource waste from stuck agents)
           template:
             metadata:
               labels:

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -69,6 +69,7 @@ spec:
         spec:
           ttlSecondsAfterFinished: 3600
           backoffLimit: 0
+          activeDeadlineSeconds: 1800  # Force termination after 30 minutes (prevents resource waste from stuck agents)
           template:
             metadata:
               labels:


### PR DESCRIPTION
## Summary

Adds `activeDeadlineSeconds: 1800` to agent Jobs to prevent stuck agents from consuming cluster resources indefinitely.

## Problem

Currently 61 incomplete agents and 52 running pods, many stuck since before PR #131. Agent Jobs have `ttlSecondsAfterFinished` but no `activeDeadlineSeconds`, allowing stuck agents to run indefinitely.

## Solution

- Add `activeDeadlineSeconds: 1800` (30 minutes) to both `agent-graph.yaml` and `swarm-graph.yaml`
- Most successful agents complete in < 10 minutes; 30 min is generous for complex tasks
- After deadline expires, Job status → Failed, triggering `ttlSecondsAfterFinished` cleanup

## Impact

- ✅ Stuck agents auto-terminate after 30 minutes
- ✅ Resources freed for new agents
- ✅ API server load reduced
- ✅ Cost optimization (no infinite-running pods)

## Verification

After applying:
\`\`\`bash
kubectl apply -f manifests/rgds/agent-graph.yaml
kubectl apply -f manifests/rgds/swarm-graph.yaml
kubectl get jobs -n agentex --field-selector status.active=1 --watch
\`\`\`

Stuck jobs should transition to Failed status within 30 minutes of creation.

Fixes #158