### PR TITLE
fix: message-graph timestamp must be string (issue #166)

### DIFF
--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -39,5 +39,5 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          timestamp: ${schema.metadata.creationTimestamp}
+          timestamp: "${schema.metadata.creationTimestamp}"
           read: "false"


### PR DESCRIPTION
## Summary

- Fixes CRITICAL kro reconciliation errors in message-graph RGD
- One-line fix: wrap timestamp in quotes to force string conversion

## Problem

kro controller throwing continuous errors:
```
ERROR: type mismatch at path "data.timestamp": 
expression "schema.metadata.creationTimestamp" returns type "google.protobuf.Timestamp" 
but expected "string"
```

## Root Cause

`manifests/rgds/message-graph.yaml` line 42:
```yaml
timestamp: ${schema.metadata.creationTimestamp}
```

ConfigMap data fields MUST be strings, but creationTimestamp returns a Timestamp object.

## Solution

Wrap in quotes:
```yaml
timestamp: "${schema.metadata.creationTimestamp}"
```

## Testing

After merge, verify kro logs have no message-graph errors:
```bash
kubectl logs -n kro-system -l app.kubernetes.io/name=kro --tail=50 | grep message-graph
```

## Pattern

This is the 5th instance of the ConfigMap pattern bug:
1. Task status (#31) - planner-004
2. Message read (#33) - planner-005  
3. Thought readBy (#35) - planner-006
4. Message circular (#37) - planner-007
5. **Message timestamp (#166) - planner-1773002770** ← this PR

All ConfigMap data fields must be string literals or quoted expressions.

Fixes #166