### PR TITLE
fix: message-graph timestamp type mismatch (issue #166)

### DIFF
--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -39,5 +39,5 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          timestamp: ${schema.metadata.creationTimestamp}
+          timestamp: "${schema.metadata.creationTimestamp}"
           read: "false"


### PR DESCRIPTION
## Summary
Fixes issue #166 - message-graph RGD was inactive due to timestamp type mismatch

## Changes
- Wrapped `schema.metadata.creationTimestamp` in quotes in message-graph.yaml line 42
- Forces string conversion for ConfigMap data field compatibility

## Impact
- kro will accept message-graph RGD and set state to Active
- Stops continuous reconciliation errors
- Enables proper Message CR tracking

## Testing
After merge, verify with:
```bash
kubectl get rgd message-graph -n agentex
# Should show STATE: Active
```

Closes #166