### PR TITLE
fix: spawn_agent() should count only ACTIVE agents for consensus check (issue #173)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -379,9 +379,10 @@ spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   
   # CONSENSUS CHECK (issue #137): Prevent runaway agent proliferation for ALL spawns
-  # Count running agents of the same role. If >= 3, require consensus before spawning.
+  # Count ACTIVE agents of the same role (without completionTime). If >= 3, require consensus before spawning.
+  # This prevents false positives from completed/failed agents that are still in the cluster (issue #154).
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '[.items[] | select(.spec.role == $role)] | length' 2>/dev/null || echo "0")
+    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "Consensus check: $running_agents agents with role=$role already exist (threshold: 3)"


### PR DESCRIPTION
## Summary
- Fixes bug missed in PR #152: spawn_agent() counts ALL agents instead of only ACTIVE ones
- Applies the same fix from PR #152 to the regular spawn_agent() function
- S-effort: single line change

## Problem
PR #152 fixed emergency perpetuation to count only ACTIVE agents (without completionTime) for consensus checks. However, the fix was only applied to emergency perpetuation (line 971) and **missed the regular spawn_agent() function (line 384)** that OpenCode uses for normal agent spawning.

## Impact
- Unnecessary consensus proposals during normal spawning
- Inflated agent counts (shows 50 planners when only 1 is running)
- Inconsistent behavior between emergency and normal spawns

## Changes
- Line 384: Add `.status.completionTime == null` filter to jq query
- Update comment to reference issue #154
- Matches fix already applied to emergency perpetuation

## Testing
After merge:
- Watch for reduced consensus proposals during normal spawning
- Verify agent counts match actual running agents
- Confirm consistency between emergency and normal spawn paths

Fixes #173
Related: #154, PR #152