### PR TITLE
fix: consensus check should count active JOBS not Agent CRs (issue #154)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,10 +342,10 @@ spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   
   # CONSENSUS CHECK (issue #137): Prevent runaway agent proliferation for ALL spawns
-  # Count ACTIVE agents of the same role (without completionTime). If >= 3, require consensus before spawning.
-  # This prevents false positives from completed/failed agents that are still in the cluster (issue #154).
-  local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
+  # Count ACTIVE JOBS (not Agent CRs) because kro cleans up completed Agent CRs.
+  # Must check jobs.status.active == 1 to only count running pods.
+  local running_agents=$(kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${role}" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "Consensus check: $running_agents agents with role=$role already exist (threshold: 3)"
@@ -928,35 +928,12 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   # Set agent name to match role (fix for issue #111)
   NEXT_AGENT="${NEXT_ROLE}-${TS}"
 
-  # CONSENSUS CHECK (issue #2, #154): Prevent runaway agent proliferation
-  # Count ACTIVE agents of the same role (agents with RUNNING Jobs only).
-  # Checking .status.completionTime == null is incorrect because:
-  # - Agent CRs can exist without Jobs (kro failures)
-  # - Those "ghost" agents have completionTime == null forever
-  # Instead, we check if the referenced Job exists AND is actively Running.
-  RUNNING_AGENTS=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$NEXT_ROLE" --arg ns "$NAMESPACE" '
-      [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "") |
-       .status.jobName] as $job_names |
-      if ($job_names | length) == 0 then 0
-      else
-        # For each job, check if it exists and is Running
-        [$job_names[] | select(. != null)] | length
-      end
-    ' 2>/dev/null || echo "0")
-  
-  # Additional check: verify Jobs are actually Running (not just existing)
-  # This requires a second kubectl call to get Job statuses
-  if [ "$RUNNING_AGENTS" -gt 0 ]; then
-    ACTUAL_RUNNING=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-      jq --arg role "$NEXT_ROLE" '
-        [.items[] | 
-         select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
-        length
-      ' 2>/dev/null || echo "0")
-    RUNNING_AGENTS="$ACTUAL_RUNNING"
-  fi
+  # CONSENSUS CHECK (issue #2): Prevent runaway agent proliferation
+  # Count ACTIVE JOBS (not Agent CRs) because kro cleans up completed Agent CRs.
+  # Agent CRs are removed once Jobs complete, so counting them gives false negatives.
+  # Must check jobs.status.active == 1 to only count running pods.
+  RUNNING_AGENTS=$(kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${NEXT_ROLE}" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
   
   CONSENSUS_REQUIRED=false
   if [ "$RUNNING_AGENTS" -ge 3 ]; then


### PR DESCRIPTION
## Problem

The consensus checks in `spawn_agent()` (line 383) and emergency perpetuation (line 970) count Agent CRs instead of active Jobs. This causes massive agent proliferation because:

1. kro cleans up Agent CRs after Jobs complete
2. Jobs with `status.active == 1` are still running  
3. Consensus check sees only 3 Agent CRs, thinks only 3 agents exist
4. Actually 87 jobs running: 48 workers + 39 planners
5. Keeps spawning more agents because count is always below threshold

## Current State (CRITICAL)
```bash
$ kubectl get agents -n agentex --no-headers | wc -l
3

$ kubectl get jobs -n agentex -o json | jq '[.items[] | select(.status.active == 1)] | length'
87
```

The consensus mechanism is completely broken and the system is spiraling out of control.

## Solution

Count active **Jobs** instead of Agent CRs:

```bash
kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${role}" -o json | \
  jq '[.items[] | select(.status.active == 1)] | length'
```

This gives the accurate count of actually running agents.

## Changes

- **Line 383**: `spawn_agent()` consensus check now counts active Jobs
- **Line 970**: Emergency perpetuation consensus check now counts active Jobs
- Both use job label selector `agentex/role=${role}` and filter by `.status.active == 1`

## Impact

- Fixes runaway agent proliferation (issue #154)
- Consensus mechanism will actually work
- System will respect the 3-agent threshold
- Massive cost savings (87 pods → controlled spawning)

## Testing

After this PR merges and runner image rebuilds:
1. Running job count should stabilize around 3-5 per role
2. Consensus proposals should trigger when actually needed
3. No more exponential proliferation

Fixes #154