### PR TITLE
fix: remove unused file_report() function (issue #169)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -156,43 +156,6 @@ EOF
   log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
 }
 
-# file_report() - Simplified wrapper around post_report() for automatic reporting
-# Used by step 11 post-results logic (lines 727, 734)
-# Usage: file_report <status> <work_done> <blockers> <vision_score>
-file_report() {
-  local status="$1" work_done="$2" blockers="${3:-none}" vision_score="${4:-5}"
-  
-  # Automatically determine issues found and PR opened from git state
-  local issues_found=""
-  local pr_opened=""
-  
-  # Check if we're in a git repo and on a branch
-  if [ -d ".git" ]; then
-    # Extract issue numbers from branch name (e.g., issue-107-description -> #107)
-    local branch_name=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    if [[ "$branch_name" =~ issue-([0-9]+) ]]; then
-      issues_found="#${BASH_REMATCH[1]}"
-    fi
-    
-    # Check if a PR was opened (search recent git history for PR references)
-    local pr_number=$(git log --oneline -10 2>/dev/null | grep -oP 'PR #\K[0-9]+' | head -1 || echo "")
-    if [ -n "$pr_number" ]; then
-      pr_opened="PR #${pr_number}"
-    fi
-  fi
-  
-  # Determine next priority based on status
-  local next_priority=""
-  if [ "$status" = "completed" ]; then
-    next_priority="Continue platform improvement loop"
-  else
-    next_priority="Investigate failure and retry"
-  fi
-  
-  # Call the full post_report() function
-  post_report "$vision_score" "$work_done" "$issues_found" "$pr_opened" "$blockers" "$next_priority" "$OPENCODE_EXIT"
-}
-
 patch_task_status() {
   local phase="$1" outcome="${2:-}"
   local completed_at=""


### PR DESCRIPTION
## Summary

Removes dead code from entrypoint.sh - the `file_report()` function was never called.

## Changes

- Removed `file_report()` wrapper function (37 lines)
- All report filing already goes through `post_report()` directly (lines 846, 853)
- Reduces entrypoint.sh from 1139 → 1102 lines

## Testing

- Verified no calls to `file_report` exist in the codebase
- Only `post_report()` is used for filing Report CRs
- No behavioral change - pure dead code removal

Fixes #169