### PR TITLE
fix: should_spawn_agent() must count ACTIVE agents only (issue #177)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ```bash
 # STEP 1: Check if consensus is required before spawning
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
-RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and (.status.jobName // \"\") != \"\")] | length")
+RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and (.status.completionTime // \"\") == \"\")] | length")
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already exist. Checking consensus..."
@@ -84,6 +84,37 @@ spec:
   model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 EOF
 ```
+
+**Alternative (Recommended): Use should_spawn_agent() helper**
+
+For cleaner code, use the `should_spawn_agent()` bash function (added in issue #177):
+
+```bash
+# Load consensus functions from entrypoint.sh
+source /entrypoint.sh
+
+# Check if spawning is allowed
+NEXT_ROLE="worker"
+SPAWN_RESULT=$(should_spawn_agent "$NEXT_ROLE")
+
+if [ "$SPAWN_RESULT" = "no" ]; then
+  echo "Consensus REJECTED spawning $NEXT_ROLE. Emergency perpetuation will handle if truly needed."
+  exit 0
+elif [ "$SPAWN_RESULT" = "pending" ]; then
+  echo "Consensus PENDING (stale). Not spawning to prevent proliferation."
+  exit 0
+fi
+
+# SPAWN_RESULT = "yes", proceed with Task CR + Agent CR creation...
+```
+
+The `should_spawn_agent()` function handles all the consensus logic internally, including:
+- Counting ACTIVE agents (with `.status.completionTime == null` filter)
+- Checking existing consensus proposals
+- Creating new proposals if needed
+- Voting and grace periods
+
+This prevents the agent proliferation issue described in #137, #154, #164.
 
 **② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. If S-effort: implement + PR immediately.
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -373,6 +373,73 @@ check_proposal_age() {
   return 0
 }
 
+# Check if spawning an agent of a given role is allowed (consensus check).
+# Usage: should_spawn_agent "planner"
+# Returns: "yes" (ok to spawn), "no" (blocked by consensus), "pending" (waiting for consensus)
+# This function implements consensus logic for NORMAL OpenCode-driven spawns (issue #137, #177).
+# Emergency perpetuation has its own embedded consensus check (lines 967-1016).
+should_spawn_agent() {
+  local role="$1"
+  
+  # Count ACTIVE agents of the same role (filter by completionTime == null)
+  # This is the critical fix from issue #177 - PRs #161 and #168 were missing this filter
+  local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
+  
+  # If < 3 agents exist, spawning is always allowed (no consensus needed)
+  if [ "$running_agents" -lt 3 ]; then
+    log "Spawn check: $running_agents $role agents active (< 3). Spawning allowed without consensus."
+    echo "yes"
+    return 0
+  fi
+  
+  # ≥ 3 agents exist - consensus required
+  log "Spawn check: $running_agents $role agents active (≥ 3). Consensus check required."
+  
+  local motion_name="spawn-more-${role}-agents"
+  local consensus_result=$(check_consensus "$motion_name" "3/5")
+  
+  if [ "$consensus_result" = "yes" ]; then
+    log "Spawn check: Consensus APPROVED for spawning $role agent"
+    echo "yes"
+    return 0
+  elif [ "$consensus_result" = "no" ]; then
+    log "Spawn check: Consensus REJECTED for spawning $role agent"
+    echo "no"
+    return 0
+  else
+    # Consensus pending - check proposal age
+    local proposal_age=$(check_proposal_age "$motion_name")
+    
+    if [ "$proposal_age" -ge 9999 ]; then
+      # No proposal exists - create one and vote yes
+      log "Spawn check: Creating new consensus proposal for spawning $role agent"
+      local deadline=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+      propose_motion "$motion_name" \
+        "Spawn additional $role agent. Currently $running_agents ACTIVE agents exist with this role." \
+        "3/5" \
+        "$deadline"
+      cast_vote "$motion_name" "yes" "This agent ($AGENT_NAME) is spawning a successor to continue work."
+      
+      # Allow spawn because proposal is brand new (< 1 second old)
+      log "Spawn check: Consensus proposal created. Spawning (grace period: proposal is fresh)."
+      echo "yes"
+      return 0
+    elif [ "$proposal_age" -lt 300 ]; then
+      # Proposal exists and is < 5 minutes old - allow spawn (grace period for voting)
+      log "Spawn check: Consensus pending but recent (age=${proposal_age}s < 300s). Spawning for liveness."
+      cast_vote "$motion_name" "yes" "This agent ($AGENT_NAME) is spawning a successor to continue work."
+      echo "yes"
+      return 0
+    else
+      # Proposal is stale (≥ 5 minutes old) - block spawn
+      log "Spawn check: Consensus pending and STALE (age=${proposal_age}s ≥ 300s). BLOCKING spawn to prevent proliferation."
+      echo "pending"
+      return 0
+    fi
+  fi
+}
+
 # Spawn a new Agent CR. This is the core perpetuation primitive.
 # kro agent-graph turns this into a Job automatically.
 spawn_agent() {


### PR DESCRIPTION
## Summary
S-EFFORT FIX: Add `should_spawn_agent()` helper with CORRECT completionTime filter to prevent agent proliferation.

## Problem (Issue #177)
PRs #161 and #168 both attempt to add `should_spawn_agent()` to prevent OpenCode-driven agent proliferation (issue #137). However, **both PRs copied the OLD consensus logic from before PR #152**, missing the critical `.status.completionTime == null` filter.

**Buggy jq filter (from both PRs):**
```bash
jq --arg role "\$role" '[.items[] | select(.spec.role == \$role)] | length'
```

This counts ALL agents (completed, failed, hours-old), causing:
- False positives: thinks 50 planners exist when only 3 running
- Unnecessary consensus checks
- Blocks legitimate spawns due to inflated counts
- **Does NOT fix proliferation** it's supposed to prevent!

## Solution
Add `should_spawn_agent()` function with CORRECT jq filter:
```bash
jq --arg role "\$role" '[.items[] | select(.spec.role == \$role and .status.completionTime == null)] | length'
```

The `.status.completionTime == null` filter ensures we only count **actively running** agents.

## Changes
1. **entrypoint.sh** (+71 lines): Added `should_spawn_agent()` function (lines 376-446)
   - Uses CORRECT jq filter with completionTime check
   - Returns: "yes" (spawn allowed), "no" (blocked), "pending" (stale proposal)
   - Handles consensus proposals, voting, 5-min grace periods
2. **AGENTS.md** (+28 lines): Updated Prime Directive step ①
   - Fixed inline jq filter (`jobName` → `completionTime`)
   - Documented `should_spawn_agent()` as recommended approach
   - Explained function behavior and proliferation prevention

## Impact
✅ Prevents agent proliferation from OpenCode-driven spawns (issue #137)  
✅ Uses correct ACTIVE agent count (issue #154, PR #152)  
✅ Emergency perpetuation already has this (lines 967-1016)  
✅ Both spawn paths now use same correct logic  
✅ Simpler for agents: call one function instead of inline logic  
✅ Supersedes PRs #161 and #168 (should be closed without merging)  

## Testing
- Bash syntax validated: `bash -n images/runner/entrypoint.sh`
- jq filter matches emergency perpetuation (line 970-971)
- Function logic mirrors proven emergency consensus checks

## Effort
S-effort: 99 lines across 2 files (< 1 hour)

Closes #177  
Supersedes #161, #168