### PR TITLE
fix: add global circuit breaker to prevent catastrophic agent proliferation (issue #182)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -378,6 +378,17 @@ check_proposal_age() {
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   
+  # GLOBAL CIRCUIT BREAKER (issue #149): Hard limit to prevent catastrophic proliferation
+  # Count TOTAL active agents (without completionTime). If >= 20, BLOCK all spawns.
+  local total_active=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.completionTime == null or .status.completionTime == "")] | length' 2>/dev/null || echo "0")
+  
+  if [ "$total_active" -ge 20 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active agents (limit: 20). BLOCKING spawn to prevent system overload."
+    post_thought "Circuit breaker activated: $total_active active agents exceed safety limit. Spawn blocked. System may need human intervention." "blocker" 10
+    return 1  # Hard block - too many agents
+  fi
+  
   # CONSENSUS CHECK (issue #137): Prevent runaway agent proliferation for ALL spawns
   # Count running agents of the same role. If >= 3, require consensus before spawning.
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \


### PR DESCRIPTION
## Summary

- Add hard limit of 20 active agents to prevent system overload
- Complements existing per-role consensus checks (issue #137, PR #151)
- Provides immediate protection against catastrophic proliferation

## Problem

Issue #149 and #137 noted that consensus checks were only applied to emergency spawns, not OpenCode-driven spawns. PR #151 fixed this by adding per-role consensus checks to `spawn_agent()`.

However, **per-role limits don't protect against TOTAL system overload**. If 5 different roles each spawn 3 agents simultaneously, we get 15+ agents, overwhelming the cluster. This was observed today: 92+ active agents caused severe resource pressure.

## Solution

Add a **global circuit breaker** at the top of `spawn_agent()`:

```bash
# Count TOTAL active agents (without completionTime)
total_active=$(kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.status.completionTime == null)] | length')

if [ "$total_active" -ge 20 ]; then
  # BLOCK all spawns, post blocker Thought CR
  return 1
fi
```

This runs **before** per-role consensus checks and provides a hard safety limit.

## Design Decisions

1. **Threshold: 20 active agents**
   - Allows reasonable parallelism (10-15 agents is normal)
   - Prevents resource exhaustion (observed issue at 92+ agents)
   - Conservative but not overly restrictive

2. **Counts active agents only** (without completionTime)
   - Completed agents don't consume resources
   - Accurate measure of current load

3. **Posts blocker Thought CR** when triggered
   - Alerts system that manual intervention may be needed
   - Visible to god-observer and human supervisor

4. **Hard block** (return 1, no spawn)
   - Unlike consensus (which can be overridden), this is absolute
   - System stability > liveness when at capacity

## Testing

Manual testing during proliferation event:
- Before: 92+ active agents, cluster overloaded
- After fix deployed: new spawns blocked when limit reached
- System stabilized as existing agents completed

## Related Issues

- Fixes #182 (circuit breaker)
- Complements #137 (per-role consensus)
- Related to #149 (consensus enhancement)

## Impact

- **Effort**: S (< 15 minutes, 11 lines added)
- **Priority**: HIGH (prevents catastrophic failure)
- **Vision Score**: 5 (platform stability)