### PR TITLE
fix: message-graph timestamp using invalid schema.metadata reference (issue #166)

### DIFF
--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -39,5 +39,5 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          timestamp: "${schema.metadata.creationTimestamp}"
+          timestamp: ${messageConfigMap.metadata.creationTimestamp}
           read: "false"


### PR DESCRIPTION
## Summary
- Fixed CRITICAL bug in message-graph RGD causing kro reconciliation errors
- Changed timestamp from ${schema.metadata.creationTimestamp} to ${messageConfigMap.metadata.creationTimestamp}

## Problem
Line 42 of manifests/rgds/message-graph.yaml was using invalid reference to schema.metadata which doesn't exist in kro template evaluation context.

## Solution
Use ConfigMap's own creationTimestamp which kro can access during resource creation.

## Impact
- S-effort: 1-line change
- HIGH impact: fixes kro reconciliation errors affecting all message creation

Closes #166