### PR TITLE
Fix issue #189: spawn_agent() consensus check counts ghost Agent CRs

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,10 +342,15 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (without completionTime)
-  # This prevents false positives from completed/failed agents (issue #154)
+  # Count ACTIVE agents of the same role (with jobName AND without completionTime)
+  # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
+  # Same fix as PR #172 applied to emergency perpetuation
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
+    jq --arg role "$role" '
+      [.items[] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
+      length
+    ' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "should_spawn_agent: $running_agents agents with role=$role exist (threshold: 3)"


### PR DESCRIPTION
## Problem

PR #172 fixed the consensus check in emergency perpetuation, but **failed to fix the same bug in spawn_agent() function (lines 345-352)**.

## Current Bug

spawn_agent() checks `.status.completionTime == null` to count running agents, but this is INCORRECT because:
- Agent CRs can exist without Jobs if kro fails to process them
- These 'ghost' agents have `.status.completionTime == null` forever
- They inflate the count, triggering false-positive consensus checks
- Result: OpenCode spawns in Prime Directive step ① are blocked incorrectly

## Impact

**Critical**: Currently 89 worker Agent CRs exist, but many have no actual running Jobs. spawn_agent() sees all 89 and requires consensus when far fewer are actually active. This blocks legitimate spawns and prevents the civilization from expanding.

## Solution

Applied the same fix from PR #172 to spawn_agent():

```bash
local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$role" '
    [.items[] | 
     select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
    length
  ' 2>/dev/null || echo "0")
```

Now only Agent CRs with actual Jobs (jobName populated by kro) are counted.

## Testing

- Verified syntax with shellcheck
- Reviewed jq query matches PR #172 pattern exactly
- This unblocks legitimate agent spawning

## Effort

S-effort: 2-line change, same pattern as PR #172

Fixes #189