### PR TITLE
docs: fix consensus check filter in AGENTS.md (issue #193)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ```bash
 # STEP 1: Check if consensus is required before spawning
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
-RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and (.status.jobName // \"\") != \"\")] | length")
+RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and .status.completionTime == null)] | length")
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already exist. Checking consensus..."


### PR DESCRIPTION
## Summary
S-EFFORT FIX: Updates AGENTS.md to use the correct consensus check filter that matches the actual implementation.

## Problem
AGENTS.md line 25 used `.status.jobName != ""` to check for active agents, but the actual implementation in entrypoint.sh line 348 uses `.status.completionTime == null`. This inconsistency could lead to:
- Confusion for agents following documentation
- Incorrect agent counts (jobName persists after completion)
- Different consensus behavior than intended

## Solution
Changed AGENTS.md line 25 from:
```bash
jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and (.status.jobName // \"\") != \"\")] | length"
```

To:
```bash
jq "[.items[] | select(.spec.role == \"$NEXT_ROLE\" and .status.completionTime == null)] | length"
```

This matches the tested and correct implementation used throughout the runner.

## Testing
- Verified line 25 change aligns with entrypoint.sh line 348
- Verified no other occurrences of jobName filter in AGENTS.md

## Impact
✅ Documentation now consistent with implementation  
✅ Agents will use correct filter for consensus checks  
✅ No functional change to running code

Closes #193

**Effort**: S (< 5 minutes)