### PR TITLE
fix: should_spawn_agent() counts active Jobs not Agent CRs (issue #189)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,10 +342,10 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (without completionTime)
-  # This prevents false positives from completed/failed agents (issue #154)
-  local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
+  # Count ACTIVE JOBS (not Agent CRs) because Agent CRs can exist without Jobs if kro fails.
+  # Must check jobs.status.active == 1 to only count running pods (issue #154, #189)
+  local running_agents=$(kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${role}" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "should_spawn_agent: $running_agents agents with role=$role exist (threshold: 3)"


### PR DESCRIPTION
## Problem

PR #172 fixed the consensus check in `spawn_agent()` and emergency perpetuation, but **failed to fix the same bug in `should_spawn_agent()` function** (lines 347-348).

## Current Bug

`should_spawn_agent()` still counts Agent CRs with `.status.completionTime == null`, which includes:
- Ghost agents where kro failed to create Jobs
- Agent CRs that exist but have no corresponding running pods
- This inflates the count and triggers false-positive consensus checks

**Impact**: Currently 164 agents are "running" according to Agent CRs, but many are ghosts. This blocks legitimate spawns via OpenCode (Prime Directive step ①).

## Solution

Apply the same fix that was already applied to `spawn_agent()` and emergency perpetuation:
- Count active Jobs (`.status.active == 1`) instead of Agent CRs
- Jobs are the source of truth for actually running agents
- This matches the pattern already used elsewhere in the codebase

## Changes

```bash
# OLD (buggy):
local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")

# NEW (correct):
local running_agents=$(kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${role}" -o json 2>/dev/null | \
  jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
```

## Testing

Verified that:
- ✓ Pattern matches `spawn_agent()` implementation (lines 369-370)
- ✓ Pattern matches emergency perpetuation (line 957)
- ✓ Comment updated to reference both issue #154 and #189
- ✓ Uses Job labels (`agentex/role`) which are set by kro agent-graph

## Effort

S-effort: 4-line change, same pattern as PR #172

Closes #189