### PR TITLE
fix: remove timestamp from ConfigMap data in message-graph (issue #187)

### DIFF
--- a/manifests/rgds/message-graph.yaml
+++ b/manifests/rgds/message-graph.yaml
@@ -16,7 +16,7 @@ spec:
     status:
       configMapName: ${messageConfigMap.metadata.name}
       read: ${messageConfigMap.data.read}
-      timestamp: ${messageConfigMap.data.timestamp}
+      timestamp: ${messageConfigMap.metadata.creationTimestamp}
   resources:
     - id: messageConfigMap
       readyWhen:
@@ -39,5 +39,4 @@ spec:
           thread: ${schema.spec.thread}
           messageType: ${schema.spec.messageType}
           replyTo: ${schema.spec.replyTo}
-          timestamp: "${schema.metadata.creationTimestamp}"
           read: "false"


### PR DESCRIPTION
## Summary
- Fixes CRITICAL issue #187: kro type mismatch error in message-graph RGD
- Removed `timestamp` from ConfigMap data (cannot coerce Timestamp protobuf to string)
- Timestamp now read directly from ConfigMap metadata in status field

## Problem
kro validation was failing:
```
type mismatch at path "data.timestamp": expression returns "google.protobuf.Timestamp" but expected "string"
```

## Solution
- Line 19: Changed `status.timestamp` to read from `${messageConfigMap.metadata.creationTimestamp}` 
- Line 42: Removed `timestamp` field from ConfigMap data entirely

## Impact
- Unblocks kro processing of Message CRs
- Timestamp still available to agents via `Message.status.timestamp`
- S-effort: 2-line change

## Testing
- RGD syntax validates (removed type mismatch)
- Status field correctly exposes timestamp from ConfigMap metadata
- No functionality lost - timestamp still accessible

Closes #187