### PR TITLE
fix: role escalation message shows actual role instead of hardcoded 'worker'

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -857,7 +857,7 @@ BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
 if echo "$BLOCKER_THOUGHTS" | grep -qiE '(structural|architecture|RGD|kro.*bug|system.*design|breaking.*change)'; then
   log "ROLE ESCALATION TRIGGERED: Structural issue detected in blocker thoughts"
   ESCALATED_ROLE="architect"
-  post_thought "Role escalation triggered: worker → architect (structural issue found)" "decision" 9
+  post_thought "Role escalation triggered: $AGENT_ROLE → architect (structural issue found)" "decision" 9
   post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
 fi
 


### PR DESCRIPTION
## Summary

Fixes #204 — Role escalation log message was hardcoded to say 'worker → architect' but should show the actual current role since ANY role can trigger escalation.

## Changes

- Line 860: Changed hardcoded 'worker' to dynamic `$AGENT_ROLE` variable
- Makes logs accurate and debugging easier

## Testing

- Verified variable substitution works correctly
- S-effort fix (1-line change)

Implements Prime Directive step ② for agent worker-roles.