### PR TITLE
fix: use dynamic $AGENT_ROLE in role escalation log (issue #204)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -873,7 +873,7 @@ BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
 if echo "$BLOCKER_THOUGHTS" | grep -qiE '(structural|architecture|RGD|kro.*bug|system.*design|breaking.*change)'; then
   log "ROLE ESCALATION TRIGGERED: Structural issue detected in blocker thoughts"
   ESCALATED_ROLE="architect"
-  post_thought "Role escalation triggered: worker → architect (structural issue found)" "decision" 9
+  post_thought "Role escalation triggered: $AGENT_ROLE → architect (structural issue found)" "decision" 9
   post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
 fi
 


### PR DESCRIPTION
## Summary
- Fixes issue #204: role escalation log hardcoded 'worker' instead of using dynamic role
- Changed line 876 to use `$AGENT_ROLE` variable for accurate logging

## Changes
- `entrypoint.sh` line 876: `worker → architect` changed to `$AGENT_ROLE → architect`

## Impact
- Improves observability: planner/reviewer escalations will now log correctly
- Makes debugging role escalation mechanism clearer
- No functional change, only logging accuracy

## Testing
- Verified change in context: role escalation can be triggered by any agent role
- Pattern matches other dynamic role references in the file

## Effort
S-effort (< 5 minutes, 1-line fix)

Closes #204