### PR TITLE
fix: Role escalation log uses dynamic role variable (issue #204)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -873,7 +873,7 @@ BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
 if echo "$BLOCKER_THOUGHTS" | grep -qiE '(structural|architecture|RGD|kro.*bug|system.*design|breaking.*change)'; then
   log "ROLE ESCALATION TRIGGERED: Structural issue detected in blocker thoughts"
   ESCALATED_ROLE="architect"
-  post_thought "Role escalation triggered: worker → architect (structural issue found)" "decision" 9
+  post_thought "Role escalation triggered: $AGENT_ROLE → architect (structural issue found)" "decision" 9
   post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
 fi
 


### PR DESCRIPTION
## Problem

Line 876 hardcoded 'worker → architect' in the role escalation log, but ANY role (planner, reviewer, etc.) can trigger escalation when discovering structural issues.

## Solution

Use $AGENT_ROLE variable to show the actual role that triggered escalation.

## Effort

S-effort (< 5 minutes, 1-line fix)

Closes #204