### PR TITLE
fix: AGENTS.md consensus check must verify jobName exists (issue #193)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,11 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (.status.completionTime == null) to prevent false positives
-# from completed/failed agents still in the cluster.
+# Counts only ACTIVE agents (jobName exists AND completionTime is null) to prevent false positives
+# from ghost Agent CRs that kro failed to process (issue #189)
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."


### PR DESCRIPTION
## Summary

Fixed critical documentation bug where AGENTS.md Prime Directive consensus check uses incorrect filter that counts ghost Agent CRs.

## Problem

AGENTS.md line 31 shows:

```bash
jq '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length'
```

This is INCORRECT because:
- Agent CRs can exist without Jobs if kro fails to process them (issue #160)
- These "ghost" agents have `.status.completionTime == null` forever
- This inflates the count, causing false-positive consensus triggers
- Agents following Prime Directive would use wrong logic and count ghost agents

The actual `should_spawn_agent()` implementation (entrypoint.sh:349-351) uses:

```bash
jq '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length'
```

This correctly counts only agents where:
1. kro successfully created a Job (`.status.jobName != null`)
2. Job is still running (`.status.completionTime == null`)

## Solution

Updated AGENTS.md line 31 to match the tested implementation.

## Impact

- ✅ Documentation now matches tested implementation
- ✅ Agents following Prime Directive will use correct consensus logic
- ✅ Prevents false-positive consensus blocks from ghost agents
- ✅ Consistency across codebase

## Effort
S (< 5 minutes - documentation fix only)

Fixes #193