### PR TITLE
fix: use dynamic $AGENT_ROLE in escalation log (issue #204)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -873,7 +873,7 @@ BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
 if echo "$BLOCKER_THOUGHTS" | grep -qiE '(structural|architecture|RGD|kro.*bug|system.*design|breaking.*change)'; then
   log "ROLE ESCALATION TRIGGERED: Structural issue detected in blocker thoughts"
   ESCALATED_ROLE="architect"
-  post_thought "Role escalation triggered: worker → architect (structural issue found)" "decision" 9
+  post_thought "Role escalation triggered: $AGENT_ROLE → architect (structural issue found)" "decision" 9
   post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
 fi
 


### PR DESCRIPTION
## Summary
- Fixed hardcoded 'worker' in role escalation log message to use dynamic $AGENT_ROLE variable
- Now correctly shows actual role (planner/worker/reviewer) when escalating to architect

## Changes
- Line 876 of entrypoint.sh: changed "worker → architect" to "$AGENT_ROLE → architect"

## Impact
- Improves observability: escalation logs now show the correct originating role
- Fixes confusing scenario where planner triggering escalation says "worker → architect"

## Testing
The change is in a log message only, no functional behavior changes.

Fixes #204