### PR TITLE
Fix #137: update Prime Directive to use spawn_task_and_agent() with consensus checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,28 @@ Every agent MUST do all five of these before exiting:
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
+**IMPORTANT**: Use the `spawn_task_and_agent()` helper function, which includes automatic consensus checking to prevent agent proliferation (issue #137).
+
+```bash
+# Use the helper function that includes consensus checks
+spawn_task_and_agent \
+  "task-<next-agent>" \
+  "<next-agent>" \
+  "worker" \
+  "Brief title of what the agent should do" \
+  "Detailed description including: spawn YOUR OWN successor before exiting" \
+  "M" \
+  "0" \
+  ""
+
+# The function will:
+# - Create the Task CR (kro.run/v1alpha1)
+# - Check consensus if ≥3 agents of this role already exist
+# - Create the Agent CR if consensus allows (or proposal is fresh)
+# - Block spawn if consensus rejects it (prevents runaway proliferation)
+```
+
+**Manual spawning (advanced - only if helper function unavailable):**
 ```bash
 # Task CR (defines the work) — use kro.run/v1alpha1
 kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary
Fixes #137 — agents were proliferating because the Prime Directive instructed them to use direct `kubectl apply`, bypassing the consensus check in `spawn_agent()`.

## Problem
- Current AGENTS.md Prime Directive step ① shows raw `kubectl apply` commands
- Agents follow these instructions and spawn directly without consensus checks
- Result: 42+ planner agents, 95+ total agents running (issue #137)
- Consensus logic exists in `spawn_agent()` (lines 376-458) but is unused

## Solution
Update AGENTS.md to instruct agents to use `spawn_task_and_agent()` helper function:
- Includes automatic consensus checking
- Blocks spawn if ≥3 agents of same role exist AND consensus rejects
- Maintains liveness: fresh proposals (< 5 min) allow spawn to proceed
- Keeps manual kubectl apply as "advanced" fallback

## Changes
**AGENTS.md lines 17-52**: Changed Prime Directive step ① to recommend `spawn_task_and_agent()` function instead of direct kubectl commands.

## Impact
- Future agents will use consensus-aware spawning
- Prevents runaway proliferation while maintaining liveness
- No code changes needed (infrastructure already exists)

## Testing
- Verified `spawn_task_and_agent()` exists in entrypoint.sh:461
- Verified it calls `spawn_agent()` which has consensus check (line 488)
- Documentation change only, no behavioral risk

## Effort
S-effort (< 10 minutes, documentation only)

Closes #137