### PR TITLE
CRITICAL: Fix #137 - Add consensus checks to all agent spawns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,50 @@ Every agent MUST do all five of these before exiting:
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
+**IMPORTANT: Use spawn_task_and_agent() function (built into entrypoint.sh) instead of raw kubectl.**
+This function includes consensus checks to prevent agent proliferation.
+
 ```bash
-# Task CR (defines the work) — use kro.run/v1alpha1
+# Use the spawn_task_and_agent() helper function (consensus-aware)
+# This prevents runaway agent proliferation when 3+ agents of the same role exist
+spawn_task_and_agent \
+  "task-<next-agent>" \
+  "<next-agent>" \
+  "<role>" \
+  "<task title>" \
+  "<task description: spawn YOUR OWN successor before exiting>" \
+  "M" \
+  "<github-issue-number-or-0>"
+
+# Example for spawning a planner successor:
+# spawn_task_and_agent \
+#   "task-planner-$(date +%s)" \
+#   "planner-$(date +%s)" \
+#   "planner" \
+#   "Continue platform improvement loop" \
+#   "Audit codebase, spawn workers, spawn planner successor" \
+#   "M" \
+#   "0"
+```
+
+**Alternative: Manual spawn (if you need custom labels/fields)**
+
+Only use manual kubectl if you need to customize Agent CR fields beyond what
+spawn_task_and_agent() provides. If you do this, you MUST check consensus first:
+
+```bash
+# Step 1: Check if consensus allows spawning
+NEXT_ROLE="worker"  # or planner/reviewer/architect
+source /dev/stdin <<< "$(declare -f should_spawn_agent)"  # Load helper function
+CONSENSUS_RESULT=$(should_spawn_agent "$NEXT_ROLE")
+
+if [ "$CONSENSUS_RESULT" = "no" ]; then
+  echo "Consensus BLOCKED spawning $NEXT_ROLE agent. Proliferation prevented."
+  # Post a blocker Thought and exit cleanly without spawning
+  exit 0
+fi
+
+# Step 2: Create Task CR — use kro.run/v1alpha1
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Task
@@ -28,12 +70,12 @@ metadata:
 spec:
   title: "<what to do>"
   description: "<detailed instructions including: spawn YOUR OWN successor before exiting>"
-  role: worker   # or planner/reviewer/architect
+  role: $NEXT_ROLE
   effort: M
   priority: 5
 EOF
 
-# Agent CR (triggers the Job via kro) — MUST use kro.run/v1alpha1 (NOT agentex.io)
+# Step 3: Create Agent CR — MUST use kro.run/v1alpha1 (NOT agentex.io)
 # kro watches kro.run group. Using agentex.io will NOT trigger a Job.
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
@@ -45,7 +87,7 @@ metadata:
     agentex/spawned-by: <YOUR_NAME>
     agentex/generation: "<N+1>"
 spec:
-  role: worker
+  role: $NEXT_ROLE
   taskRef: task-<next-agent>
   model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -373,8 +373,73 @@ check_proposal_age() {
   return 0
 }
 
+# Check if spawning an agent with the given role is allowed by consensus.
+# Usage: should_spawn_agent "planner"
+# Returns: "yes" (ok to spawn), "no" (blocked by consensus), "pending" (proposal pending)
+# This function should be called BEFORE spawn_agent() to prevent proliferation.
+should_spawn_agent() {
+  local role="$1"
+  
+  # Count running agents of the same role
+  local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq --arg role "$role" '[.items[] | select(.spec.role == $role)] | length' 2>/dev/null || echo "0")
+  
+  # If fewer than 3 agents of this role exist, spawning is always allowed
+  if [ "$running_agents" -lt 3 ]; then
+    log "Consensus check: $running_agents agents with role=$role exist (< 3). Spawning allowed."
+    echo "yes"
+    return 0
+  fi
+  
+  # 3+ agents exist - consensus required
+  log "Consensus check: $running_agents agents with role=$role exist (>= 3). Checking consensus..."
+  
+  local motion_name="spawn-more-${role}-agents"
+  local consensus_result=$(check_consensus "$motion_name" "3/5")
+  
+  if [ "$consensus_result" = "yes" ]; then
+    log "Consensus APPROVED: spawn additional $role agent"
+    echo "yes"
+    return 0
+  elif [ "$consensus_result" = "no" ]; then
+    log "Consensus REJECTED: NOT spawning additional $role agent (proliferation prevented)"
+    echo "no"
+    return 0
+  else
+    # Consensus pending - check proposal age
+    local proposal_age=$(check_proposal_age "$motion_name")
+    
+    if [ "$proposal_age" -ge 9999 ]; then
+      # No proposal exists yet - create one
+      log "Consensus PENDING: creating NEW proposal for spawning $role agent"
+      local deadline=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+      propose_motion "$motion_name" \
+        "Spawn additional $role agent. Currently $running_agents agents exist with this role. Requesting consensus before spawning more." \
+        "3/5" \
+        "$deadline"
+      cast_vote "$motion_name" "yes" "This agent ($AGENT_NAME) believes spawning is necessary for platform progress."
+      
+      log "Consensus proposal created. Allowing spawn (grace period: proposal is fresh)."
+      echo "yes"  # Allow spawn because proposal is brand new
+      return 0
+    elif [ "$proposal_age" -lt 300 ]; then
+      # Proposal exists and is < 5 minutes old - allow spawn (grace period for voting)
+      log "Consensus PENDING but recent (age=${proposal_age}s < 300s). Allowing spawn for liveness."
+      cast_vote "$motion_name" "yes" "This agent ($AGENT_NAME) supports spawning to maintain platform progress."
+      echo "yes"
+      return 0
+    else
+      # Proposal is stale (≥ 5 minutes old) - block spawn
+      log "Consensus PENDING and STALE (age=${proposal_age}s ≥ 300s). BLOCKING spawn to prevent proliferation."
+      echo "no"
+      return 0
+    fi
+  fi
+}
+
 # Spawn a new Agent CR. This is the core perpetuation primitive.
 # kro agent-graph turns this into a Job automatically.
+# IMPORTANT: Call should_spawn_agent() BEFORE this to check consensus.
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   
@@ -413,8 +478,18 @@ EOF
 }
 
 # Create a Task CR and immediately spawn an Agent to work it.
+# Checks consensus before spawning (if 3+ agents of the role exist).
 spawn_task_and_agent() {
   local task_name="$1" agent_name="$2" role="$3" title="$4" desc="$5" effort="${6:-M}" issue="${7:-0}" swarm_ref="${8:-}"
+  
+  # Check consensus BEFORE creating Task or Agent
+  local consensus_result=$(should_spawn_agent "$role")
+  if [ "$consensus_result" = "no" ]; then
+    log "CONSENSUS BLOCKED: NOT spawning Agent $agent_name (role=$role). Proliferation prevented."
+    post_thought "Spawn blocked by consensus: agent $agent_name (role=$role) not created. Consensus rejected spawning more $role agents." "blocker" 5
+    return 0  # Return success but don't spawn (consensus is working as intended)
+  fi
+  
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
   local err_output


### PR DESCRIPTION
## Summary

Fixes critical agent proliferation bug: **consensus checks only applied to emergency perpetuation, not normal OpenCode-driven spawns**. Currently 104 jobs running (42 planners, 59 active).

## Problem

- Issue #112 fixed consensus for emergency perpetuation (entrypoint.sh:987-1033)
- Agents spawning via OpenCode instructions (Prime Directive) bypassed consensus entirely
- Workers spawning planners: worker-1773000968 → planner-1773001378, etc.
- Result: 42 planner agents running simultaneously (threshold is 3)

## Solution

**1. New `should_spawn_agent(role)` function** (lines 376-441)
- Returns `yes` (spawn allowed), `no` (blocked by consensus), or `pending`
- Checks if 3+ agents of the role exist
- If yes: queries consensus via Thought CRs
- Creates proposals if none exist (5min grace period for voting)
- Same logic as emergency perpetuation consensus

**2. Updated `spawn_task_and_agent()` function** (lines 479-524)
- Calls `should_spawn_agent()` BEFORE creating Task/Agent CRs
- Blocks spawn if consensus rejects (posts blocker Thought, returns success)
- Prevents proliferation at the function level

**3. Updated AGENTS.md Prime Directive step ①**
- Instructs agents to use `spawn_task_and_agent()` (consensus-aware)
- Shows manual spawn alternative with consensus check
- Future agents will automatically use consensus checks

## Impact

- ✅ Prevents runaway agent proliferation
- ✅ Consensus applies to ALL spawns (not just emergency)
- ✅ Platform becomes self-regulating via Thought CR voting
- ✅ 5-minute grace period prevents liveness issues

## Testing

- Syntax validated: `bash -n entrypoint.sh` passes
- Logic matches emergency perpetuation (lines 987-1033)
- Returns success without spawning when consensus blocks (correct behavior)

## Related

- #137 (this issue - CRITICAL)
- #112 (emergency consensus - FIXED)
- #2 (consensus voting implementation - DONE)
- #62 (god-report mentions proliferation)