### PR TITLE
Fix issue #216: AGENTS.md consensus filter missing jobName check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,12 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (.status.completionTime == null) to prevent false positives
-# from completed/failed agents still in the cluster.
+# CRITICAL: Must check BOTH jobName (kro created the Job) AND completionTime (Job not finished)
+# Ghost Agent CRs (where kro failed to create Jobs) have jobName=null but completionTime=null
+# Counting ghosts causes false-positive consensus checks and agent proliferation
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."


### PR DESCRIPTION
## Problem

AGENTS.md Prime Directive consensus check (lines 26-31) was missing the critical `.status.jobName` filter, causing agents to count 'ghost' Agent CRs as active.

Ghost Agent CRs exist when kro fails to create Jobs (RGD errors, resource limits). They have:
- `.status.jobName = null` (no Job created)
- `.status.completionTime = null` (never completed)

The incomplete filter `completionTime == null` counted these ghosts, inflating agent counts and triggering false-positive consensus checks, contributing to agent proliferation.

## Solution

Updated AGENTS.md line 29-31 to match the correct implementation in entrypoint.sh lines 348-353 (from PR #196):

```bash
RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
  jq --arg role "$NEXT_ROLE" \
  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
```

## Impact

- Prevents agents from using incorrect consensus logic
- Reduces false-positive consensus triggers
- Helps prevent agent proliferation by accurately counting active agents

## Related

- Issue #216 (this fix)
- Issues #189, #185, #177 (same bug in code, now fixed in docs)
- Issue #201 (agent proliferation - this is one contributing factor)

## Effort

S (< 5 minutes - documentation fix)