### PR TITLE
Fix issue #230: clarify consensus blocker messages

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1011,8 +1011,14 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
         cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
       else
         # Proposal is stale (≥ 5 minutes old) - block spawn
-        log "Consensus PENDING and STALE (age=${PROPOSAL_AGE}s ≥ 300s). BLOCKING spawn to prevent proliferation."
-        post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME'. $RUNNING_AGENTS $NEXT_ROLE agents already exist." "blocker" 5
+        # Issue #230: Clarify blocker message (don't show 9999s for nonexistent proposals)
+        if [ "$PROPOSAL_AGE" -ge 9999 ]; then
+          log "Consensus check: proposal '$MOTION_NAME' doesn't exist. BLOCKING spawn (race condition)."
+          post_thought "Emergency spawn blocked: no consensus proposal for motion '$MOTION_NAME' exists, but $RUNNING_AGENTS $NEXT_ROLE agents already exist. Another agent may have created proposal between checks." "blocker" 5
+        else
+          log "Consensus PENDING and STALE (age=${PROPOSAL_AGE}s ≥ 300s). BLOCKING spawn to prevent proliferation."
+          post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME' (stale proposal). $RUNNING_AGENTS $NEXT_ROLE agents already exist." "blocker" 5
+        fi
         NEEDS_EMERGENCY_SPAWN=false
       fi
     fi


### PR DESCRIPTION
## Summary

Fixes confusing blocker messages in emergency perpetuation consensus checks. When proposals don't exist, agents were showing "consensus pending for 9999s" (9999 is a sentinel value, not a real age).

## Changes

`images/runner/entrypoint.sh` lines 1012-1017:
- Added check in else block to distinguish nonexistent vs stale proposals
- Nonexistent proposal: "no consensus proposal exists" (clearer)
- Stale proposal: "consensus pending for Ns (stale proposal)" (real age shown)

## Testing

Before:
```
Emergency spawn blocked: consensus pending for 9999s on motion 'spawn-more-worker-agents'
```

After:
```
Emergency spawn blocked: no consensus proposal for motion 'spawn-more-worker-agents' exists, but 34 worker agents already exist
```

## Impact

- Makes debugging consensus issues easier
- Prevents confusion about proposal state
- No functional change (same blocking logic)

## Effort

S (< 15 minutes)

Closes #230