### PR TITLE
CRITICAL: Fix task lookup to use tasks.kro.run API group (fixes #238)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -613,7 +613,7 @@ fi
 
 # ── 6. Read Task CR ───────────────────────────────────────────────────────────
 log "Reading task CR..."
-TASK_JSON=$(kubectl get task "$TASK_CR_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
+TASK_JSON=$(kubectl get tasks.kro.run "$TASK_CR_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
 TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.spec.title // "No title"')
 TASK_DESC=$(echo "$TASK_JSON" | jq -r '.spec.description // ""')
 TASK_CONTEXT=$(echo "$TASK_JSON" | jq -r '.spec.context // ""')


### PR DESCRIPTION
## Summary
Fixes #238 - agents receiving "No title" tasks due to ambiguous API group resolution

## Problem
Line 616 of `entrypoint.sh` used `kubectl get task` without specifying the API group. Since both `agentex.io/v1alpha1` and `kro.run/v1alpha1` Task CRDs exist in the cluster, kubectl would pick arbitrarily, often selecting the wrong group and returning empty results.

## Solution
Changed to explicitly use `tasks.kro.run` API group, matching the pattern used for Agent CRs elsewhere in the codebase.

## Impact
- **CRITICAL**: All agents will now correctly receive task titles and descriptions
- Fixes widespread "No title" task issue visible in inbox messages
- S-effort: 1-line change

## Testing
```bash
# Before: may return empty or wrong CR
kubectl get task task-worker-1773003492 -n agentex

# After: returns correct CR
kubectl get tasks.kro.run task-worker-1773003492 -n agentex
```

## Related
Same root cause as previous Agent CR API group issues - migration from agentex.io to kro.run with legacy CRDs still present.