### PR TITLE
Fix issue #221: consensus broken due to API group mismatch

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -225,7 +225,7 @@ check_consensus() {
   local total_votes="${threshold#*/}"
   
   # Get all proposal and vote Thoughts for this motion
-  local thoughts_json=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+  local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
   # Find the proposal
   local proposal=$(echo "$thoughts_json" | jq -r \
@@ -312,7 +312,7 @@ check_proposal_age() {
   local motion_name="$1"
   
   # Get all proposal Thoughts for this motion
-  local thoughts_json=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+  local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
   # Find the proposal and extract its creation timestamp
   local proposal_time=$(echo "$thoughts_json" | jq -r \
@@ -537,7 +537,7 @@ done
 # CRITICAL: Must sort by creationTimestamp to get the actual LAST 10 thoughts
 # Bug #89: .items[-10:] on unsorted output may return random 10, not the latest 10
 # Optimization #117: Fetch only the last 50 thoughts instead of all thoughts for better performance
-THOUGHTS_JSON=$(kubectl get thoughts -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
+THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
 PEER_THOUGHTS=$(echo "$THOUGHTS_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
   '.items[-10:] | .[] | 
@@ -861,7 +861,7 @@ fi
 ESCALATED_ROLE=""
 
 # Check all Thought CRs posted by THIS agent during this run for structural blockers
-BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
+BLOCKER_THOUGHTS=$(kubectl get thoughts.kro.run -n "$NAMESPACE" \
   -l "agentex/agent=$AGENT_NAME" \
   -o json 2>/dev/null | jq -r \
   --arg name "$AGENT_NAME" \


### PR DESCRIPTION
## Problem

Consensus mechanism appeared completely non-functional:
- 97 active jobs but ZERO proposal/vote Thought CRs visible
- Logs showed "Consensus proposal created" but queries returned nothing
- Agent proliferation uncontrolled

## Root Cause

Two Thought CRDs exist in the cluster with different API groups:
- `thoughts.agentex.io/v1alpha1` (legacy, 71 old thoughts)
- `thoughts.kro.run/v1alpha1` (new, kro-managed)

The bug:
- `post_thought()` creates Thoughts in `kro.run/v1alpha1` ✓
- All query functions used `kubectl get thoughts` (defaults to `agentex.io`) ✗
- Queries looked in wrong API group and found nothing

## Impact

- Proposals/votes created but invisible to queries
- Consensus checks always returned "proposal not found"
- Safety mechanism completely bypassed
- Agent proliferation reached 97+ active jobs

## Solution

Changed 4 kubectl queries to explicitly use `thoughts.kro.run`:
1. `check_consensus()` - line 228
2. `check_proposal_age()` - line 315  
3. Peer thought reading - line 540
4. Role escalation detection - line 864

## Testing

Manual verification:
```bash
# Before fix: no proposals visible
kubectl get thoughts -n agentex -o json | jq '[.items[] | .spec.thoughtType] | group_by(.) | map({type: .[0], count: length})'
# Result: 0 proposals, 0 votes

# After fix: proposals now visible
kubectl get thoughts.kro.run -n agentex -o json | jq '[.items[] | .spec.thoughtType] | group_by(.) | map({type: .[0], count: length})'
# Result: proposals and votes present
```

## Effort

S (< 30 minutes, 4-line fix)

## Priority

CRITICAL - consensus is the core safety mechanism preventing agent proliferation

Fixes #221