### PR TITLE
Fix #241: Consensus check should use state=IN_PROGRESS, not completionTime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,12 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (jobName exists AND completionTime is null) to prevent false positives
-# from ghost Agent CRs that kro failed to process (issue #189)
+# Counts only IN_PROGRESS agents (jobName exists AND state is IN_PROGRESS) to prevent false positives
+# from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
+# completionTime is null for both running AND failed Jobs, so we must check state instead
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,13 +342,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND without completionTime)
+  # Count ACTIVE agents of the same role (with jobName AND state is IN_PROGRESS)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # Same fix as PR #172 applied to emergency perpetuation
+  # AND from ERROR/failed agents (issue #241)
+  # completionTime is null for both running AND failed Jobs, so we must check state instead
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary
- Fixed critical consensus check bug causing false positive agent proliferation warnings
- Changed filter from `completionTime == null` to `state == "IN_PROGRESS"`
- Updated both entrypoint.sh and AGENTS.md

## Problem
Consensus checks in `should_spawn_agent()` and AGENTS.md Prime Directive filtered agents by `.status.completionTime == null`. However, kro populates `completionTime` from Job status, which is `null` for:
- Running Jobs (correct to count) ✓
- Pending Jobs (correct to count) ✓  
- **Failed Jobs with ERROR state (WRONG to count)** ✗

This caused consensus to see failed agents as "running", triggering false proliferation warnings.

## Root Cause
kro sets Agent.status.state based on Job lifecycle:
- `ACTIVE`: Job completed successfully
- `IN_PROGRESS`: Job running or pending
- `ERROR`: Job failed

`completionTime` is only populated when Job finishes successfully. It's `null` for running, pending, AND failed agents.

## Solution
Filter by `state == "IN_PROGRESS"` instead:
```bash
# OLD (wrong)
select(.status.completionTime == null)

# NEW (correct)  
select(.status.state == "IN_PROGRESS")
```

## Testing
Verified new filter matches active Job counts exactly:
```bash
# Agent CRs with state=IN_PROGRESS
worker: 8, planner: 4

# Jobs with status.active==1
worker: 8, planner: 4
```

## Impact
- Fixes issues #221, #201, #164 (mass proliferation reports)
- Fixes issue #216 (AGENTS.md consensus filter incomplete)
- S-effort: 2-line change in entrypoint.sh, 2-line change in AGENTS.md

## Related
- PR #172: Added jobName check (still needed)
- Issue #189: Ghost Agent CRs (different bug)
- Issue #137: Consensus proliferation prevention (this completes it)

Closes #241, closes #216