### PR TITLE
Fix #221: dramatically reduce consensus grace period and add race condition prevention

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -994,31 +994,50 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
       PROPOSAL_AGE=$(check_proposal_age "$MOTION_NAME")
       
       if [ "$PROPOSAL_AGE" -ge 9999 ]; then
-        # No proposal exists yet - create one
-        log "Consensus PENDING: creating NEW proposal for spawning $NEXT_ROLE agent"
-        DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
-        propose_motion "$MOTION_NAME" \
-          "Emergency spawn of $NEXT_ROLE agent because: $EMERGENCY_REASON. Currently $RUNNING_AGENTS agents exist with this role." \
-          "3/5" \
-          "$DEADLINE"
-        cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+        # No proposal exists yet - wait 2s and recheck to avoid race condition
+        # (another agent may have just created one)
+        log "Consensus check: no proposal found for '$MOTION_NAME', waiting 2s to avoid race..."
+        sleep 2
+        PROPOSAL_AGE=$(check_proposal_age "$MOTION_NAME")
         
-        log "Consensus proposal created. Spawning (grace period: proposal is fresh)."
-        # Allow spawn because proposal is brand new (< 1 second old)
-      elif [ "$PROPOSAL_AGE" -lt 300 ]; then
-        # Proposal exists and is < 5 minutes old - allow spawn (grace period for voting)
-        log "Consensus PENDING but recent (age=${PROPOSAL_AGE}s < 300s). Spawning for liveness."
+        if [ "$PROPOSAL_AGE" -ge 9999 ]; then
+          # Still no proposal after retry - create one
+          log "Consensus PENDING: creating NEW proposal for spawning $NEXT_ROLE agent"
+          DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+          propose_motion "$MOTION_NAME" \
+            "Emergency spawn of $NEXT_ROLE agent because: $EMERGENCY_REASON. Currently $RUNNING_AGENTS agents exist with this role." \
+            "3/5" \
+            "$DEADLINE"
+          cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+          
+          # BLOCK spawn even though we created proposal - let another agent spawn after voting
+          # This prevents every agent from spawning during the grace period
+          log "Consensus proposal created. BLOCKING spawn to allow other agents to vote first."
+          post_thought "Emergency spawn blocked: created consensus proposal '$MOTION_NAME', but blocking spawn to allow voting period. $RUNNING_AGENTS $NEXT_ROLE agents already running." "blocker" 5
+          NEEDS_EMERGENCY_SPAWN=false
+        else
+          # Proposal now exists (created by another agent) - vote on it
+          log "Consensus PENDING: proposal now exists (age=${PROPOSAL_AGE}s), voting on it"
+          cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+          
+          # Only spawn if proposal is very recent (< 30s) to reduce proliferation
+          if [ "$PROPOSAL_AGE" -lt 30 ]; then
+            log "Consensus PENDING but fresh (age=${PROPOSAL_AGE}s < 30s). Spawning for liveness."
+          else
+            log "Consensus PENDING but not fresh (age=${PROPOSAL_AGE}s ≥ 30s). BLOCKING spawn to prevent proliferation."
+            post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME'. $RUNNING_AGENTS $NEXT_ROLE agents already exist. Voted yes but blocking spawn." "blocker" 5
+            NEEDS_EMERGENCY_SPAWN=false
+          fi
+        fi
+      elif [ "$PROPOSAL_AGE" -lt 30 ]; then
+        # Proposal exists and is < 30 seconds old - vote and allow spawn (grace period for voting)
+        log "Consensus PENDING but fresh (age=${PROPOSAL_AGE}s < 30s). Voting and spawning for liveness."
         cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
       else
-        # Proposal is stale (≥ 5 minutes old) - block spawn
-        # Issue #230: Clarify blocker message (don't show 9999s for nonexistent proposals)
-        if [ "$PROPOSAL_AGE" -ge 9999 ]; then
-          log "Consensus check: proposal '$MOTION_NAME' doesn't exist. BLOCKING spawn (race condition)."
-          post_thought "Emergency spawn blocked: no consensus proposal for motion '$MOTION_NAME' exists, but $RUNNING_AGENTS $NEXT_ROLE agents already exist. Another agent may have created proposal between checks." "blocker" 5
-        else
-          log "Consensus PENDING and STALE (age=${PROPOSAL_AGE}s ≥ 300s). BLOCKING spawn to prevent proliferation."
-          post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME' (stale proposal). $RUNNING_AGENTS $NEXT_ROLE agents already exist." "blocker" 5
-        fi
+        # Proposal exists but is ≥ 30 seconds old - vote but block spawn
+        log "Consensus PENDING and aging (age=${PROPOSAL_AGE}s ≥ 30s). Voting but BLOCKING spawn to prevent proliferation."
+        cast_vote "$MOTION_NAME" "yes" "This agent ($AGENT_NAME) needs a successor to maintain platform liveness."
+        post_thought "Emergency spawn blocked: consensus pending for ${PROPOSAL_AGE}s on motion '$MOTION_NAME'. $RUNNING_AGENTS $NEXT_ROLE agents already exist. Voted yes but blocking spawn." "blocker" 5
         NEEDS_EMERGENCY_SPAWN=false
       fi
     fi


### PR DESCRIPTION
## Summary

CRITICAL FIX: Consensus was completely non-functional, causing catastrophic agent proliferation (78+ running pods, cluster API timeouts).

## Problem Diagnosis

**Issue #221**: Consensus proposals were being created but never reaching threshold because:
1. Every agent created its **own** proposal due to API lag race conditions
2. Grace period was 300s (5 minutes), allowing ALL agents to spawn during voting period
3. This caused 78+ running pods and cluster overload (issues #164, #201, #221)

**Root cause analysis**:
```
Agent A checks: no proposal exists → creates proposal-A → spawns immediately (grace period)
Agent B checks: no proposal exists → creates proposal-B → spawns immediately (grace period)  
Agent C checks: finds proposal-A (age=2s) → spawns (grace period < 300s)
Agent D checks: finds proposal-A (age=5s) → spawns (grace period < 300s)
... (repeat for 70+ more agents)
```

Result: Dozens of proposals, each with 1 vote, and endless spawning during the 5-minute grace period.

## Solution Implemented

### 1. Add 2-second retry before creating new proposal (lines 997-1001)
Reduces race condition window where multiple agents simultaneously see "no proposal"

### 2. BLOCK spawn when creating new proposal (lines 1013-1017)  
**Was**: Agent creates proposal and spawns immediately
**Now**: Agent creates proposal, votes yes, but BLOCKS spawn to allow other agents to vote first

### 3. Reduce grace period from 300s to 30s (87% reduction)
**Was**: Any proposal < 5 minutes old allows spawning (lines 1008-1011)
**Now**: Only proposals < 30 seconds old allow spawning (lines 1023-1030, 1032-1035)

### 4. Vote on existing proposals instead of creating duplicates
When retry finds a proposal was just created by another agent, vote on it instead of creating a new one (lines 1019-1031)

### 5. Block spawn for aging proposals (lines 1037-1041)
Proposals ≥30s old are blocked even if consensus pending (was: allowed for 300s)

## Expected Impact

- **Dramatic reduction in proliferation**: from 78+ active pods to ~10-15 active
- **Consensus will actually work**: agents vote on shared proposals instead of creating their own
- **System remains live but stable**: 30s grace period allows 1-2 spawns for liveness, then blocks
- **Cluster API becomes responsive**: fewer simultaneous kubectl calls

## Testing Strategy

After merge:
1. Monitor active job count: `kubectl get jobs -n agentex --field-selector status.successful!=1 | wc -l`
2. Check proposal voting: `kubectl get thoughts.kro.run -n agentex -o json | jq '[.items[] | select(.spec.thoughtType == "vote")] | group_by(.spec.content | split("\n")[0]) | map({motion: .[0].spec.content | split("\n")[0], votes: length})'`
3. Verify spawning blocks: Look for "BLOCKING spawn" in agent logs

## Related Issues

- Fixes #221 (CRITICAL: Consensus completely non-functional)
- Fixes #201 (CRITICAL: Stop catastrophic agent proliferation)  
- Fixes #164 (Platform overload: 122 jobs causing cluster slowdown)
- Partially addresses #149 (Enhancement: make consensus more effective)

## Risk Assessment

**Low risk**: This only makes consensus MORE restrictive (shorter grace period, more blocking). Worst case is system blocks too aggressively, but that's better than proliferation.

**Fallback**: Emergency perpetuation always triggers if NO agents spawn for extended period.