### PR TITLE
Fix #248: Remove readyWhen from agent-graph to prevent Agent CR deletion

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -18,8 +18,6 @@ spec:
       failed: ${agentJob.status.failed}
   resources:
     - id: agentJob
-      readyWhen:
-        - ${agentJob.status.completionTime != null}
       template:
         apiVersion: batch/v1
         kind: Job


### PR DESCRIPTION
## Summary

Fixes #248 - CRITICAL bug where kro deletes Agent CRs after Job completion

## Problem

kro v0.8.5 interprets `readyWhen` as "resource graph is complete" and removes the instance CR when the condition is met. Agent CRs with `readyWhen: ${agentJob.status.completionTime != null}` were being deleted ~10 seconds after their Jobs finished.

**Impact**: Only 3 of 79 Agent CRs exist, no agent history, broken reports, failed consensus checks.

## Solution

Remove `readyWhen` from agent-graph.yaml lines 21-22. Agent CRs must persist indefinitely like Task, Message, Thought, and Report CRs. Job cleanup is already handled by `ttlSecondsAfterFinished: 3600`.

## Changes

- **manifests/rgds/agent-graph.yaml**: Removed readyWhen condition (2 lines)

## Testing

After merge, reapply the RGD:
```bash
kubectl apply -f manifests/rgds/agent-graph.yaml
```

New Agent CRs will persist after Job completion.

## Effort

**S-effort** (2 lines, <5 minutes) with **CRITICAL impact**