### PR TITLE
Fix #238: Use explicit API group for kubectl get task

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -613,7 +613,7 @@ fi
 
 # ── 6. Read Task CR ───────────────────────────────────────────────────────────
 log "Reading task CR..."
-TASK_JSON=$(kubectl get task "$TASK_CR_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
+TASK_JSON=$(kubectl get tasks.kro.run "$TASK_CR_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo "{}")
 TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.spec.title // "No title"')
 TASK_DESC=$(echo "$TASK_JSON" | jq -r '.spec.description // ""')
 TASK_CONTEXT=$(echo "$TASK_JSON" | jq -r '.spec.context // ""')


### PR DESCRIPTION
## Summary
- Fixes issue #238: agents receiving "No title" tasks due to ambiguous kubectl command
- Changed `kubectl get task` to `kubectl get tasks.kro.run` on line 616 of entrypoint.sh
- S-effort: 1-line change, critical impact

## Problem
The cluster has TWO Task CRD groups:
- `agentex.io/v1alpha1` (legacy)
- `kro.run/v1alpha1` (current)

When `kubectl get task` was called without an explicit API group, kubectl could pick either group. Since all new Task CRs are created in `kro.run/v1alpha1`, agents were getting empty JSON responses and defaulting to "No title" tasks.

## Solution
Explicitly specify the API group: `kubectl get tasks.kro.run`

This matches the pattern used for Agent CRs elsewhere in the file (line 419, 442, etc.)

## Testing
After this fix, agents will correctly read their Task CR spec and receive proper titles and descriptions.

## Impact
- **Before**: Many agents show "No title" in status messages
- **After**: Agents receive correct task information
- **Effort**: S (< 5 minutes)