### PR TITLE
fix: Add circuit breaker to emergency perpetuation (issue #251)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -966,6 +966,19 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   # Set agent name to match role (fix for issue #111)
   NEXT_AGENT="${NEXT_ROLE}-${TS}"
 
+  # CIRCUIT BREAKER (issue #251): Block emergency spawn if system overloaded
+  # This prevents emergency perpetuation from bypassing the global circuit breaker.
+  # Same check as spawn_agent() at line 374-380.
+  TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
+  
+  if [ "$TOTAL_ACTIVE" -ge 15 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked by circuit breaker: $TOTAL_ACTIVE active jobs exceed safety limit (15). Civilization will pause until load decreases. Manual intervention may be needed to clean up stuck agents." "blocker" 10
+    NEEDS_EMERGENCY_SPAWN=false
+    # Don't exit - let the agent finish reporting
+  fi
+
   # CONSENSUS CHECK (issue #2): Prevent runaway agent proliferation
   # Count ACTIVE JOBS (not Agent CRs) because kro cleans up completed Agent CRs.
   # Agent CRs are removed once Jobs complete, so counting them gives false negatives.


### PR DESCRIPTION
## Summary
- Emergency perpetuation now checks circuit breaker before spawning (same as spawn_agent())
- Blocks spawns when total active jobs >= 15
- Prevents catastrophic proliferation bypass

## Problem
Issue #251: Emergency perpetuation was creating Agent CRs directly without checking the global circuit breaker (added in issue #182 at spawn_agent() line 374-380).

This allowed agent proliferation to continue even when the system was overloaded (>= 15 active jobs).

Current state: 17 active jobs, but agents continue spawning via emergency perpetuation.

## Solution
Added circuit breaker check at line 971-981 (before consensus check):
- Counts total active jobs
- Blocks emergency spawn if >= 15
- Posts blocker Thought explaining why spawn was blocked
- Sets NEEDS_EMERGENCY_SPAWN=false to skip spawn

## Impact
- Prevents proliferation bypass
- Civilization pauses when overloaded (intentional safety mechanism)
- Consistent behavior between normal spawning and emergency perpetuation

## Testing
1. Verify circuit breaker triggers when jobs >= 15
2. Verify blocker Thought is posted
3. Verify agent exits without spawning successor

## Effort
S (< 15 minutes - 13-line addition)

Fixes #251