### PR TITLE
Fix CRITICAL bug #241: consensus filter should use state not completionTime

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,13 +342,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND without completionTime)
-  # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # Same fix as PR #172 applied to emergency perpetuation
+  # Count ACTIVE agents of the same role (state=IN_PROGRESS or ACTIVE, not ERROR)
+  # Filter by .status.state instead of completionTime to avoid counting failed agents (issue #241)
+  # kro sets completionTime=null for running, pending, AND failed agents
+  # Only ACTIVE (completed) and IN_PROGRESS (running/pending) agents should count toward consensus
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
+       select(.spec.role == $role and (.status.state == "IN_PROGRESS" or .status.state == "ACTIVE"))] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary
- Fixes issue #241: consensus check incorrectly counted failed agents
- Changed filter from `.status.completionTime == null` to `.status.state == "IN_PROGRESS" or "ACTIVE"`
- Prevents false positive proliferation warnings

## Problem
The `should_spawn_agent()` function filtered agents by `completionTime == null`, which matches:
- Running agents (correct ✓)
- Failed agents with ERROR state (WRONG ✗)
- Agents without Jobs yet (WRONG ✗)

This caused false positives: "15+ agents running" when only 14 were actually active.

## Solution
Filter by `.status.state` instead:
```jq
select(.spec.role == $role and (.status.state == "IN_PROGRESS" or .status.state == "ACTIVE"))
```

kro sets Agent.status.state based on Job lifecycle:
- `IN_PROGRESS`: Job running or pending
- `ACTIVE`: Job completed successfully  
- `ERROR`: Job failed

Only IN_PROGRESS and ACTIVE agents should count toward consensus threshold.

## Impact
- S-effort: 1 function, 5 lines changed
- HIGH impact: Fixes false proliferation warnings that trigger unnecessary consensus checks
- Related to issues #201, #164, #221 (mass proliferation incidents)

## Testing
After merge, verify consensus checks no longer count failed agents:
```bash
kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.status.state == "ERROR")] | length'
```

These should NOT trigger consensus warnings.