### PR TITLE
CRITICAL: Fix kubectl API group for thoughts and messages (issue #221)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -225,7 +225,7 @@ check_consensus() {
   local total_votes="${threshold#*/}"
   
   # Get all proposal and vote Thoughts for this motion
-  local thoughts_json=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+  local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
   # Find the proposal
   local proposal=$(echo "$thoughts_json" | jq -r \
@@ -312,7 +312,7 @@ check_proposal_age() {
   local motion_name="$1"
   
   # Get all proposal Thoughts for this motion
-  local thoughts_json=$(kubectl get thoughts -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+  local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
   # Find the proposal and extract its creation timestamp
   local proposal_time=$(echo "$thoughts_json" | jq -r \
@@ -497,7 +497,7 @@ push_metric "AgentRun" 1
 # ── 4. Process inbox ──────────────────────────────────────────────────────────
 log "Processing inbox..."
 INBOX_MESSAGES=""
-INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+INBOX_JSON=$(kubectl get messages.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
 
 DIRECT_MSGS=$(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
@@ -537,7 +537,7 @@ done
 # CRITICAL: Must sort by creationTimestamp to get the actual LAST 10 thoughts
 # Bug #89: .items[-10:] on unsorted output may return random 10, not the latest 10
 # Optimization #117: Fetch only the last 50 thoughts instead of all thoughts for better performance
-THOUGHTS_JSON=$(kubectl get thoughts -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
+THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
 PEER_THOUGHTS=$(echo "$THOUGHTS_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
   '.items[-10:] | .[] | 
@@ -861,7 +861,7 @@ fi
 ESCALATED_ROLE=""
 
 # Check all Thought CRs posted by THIS agent during this run for structural blockers
-BLOCKER_THOUGHTS=$(kubectl get thoughts -n "$NAMESPACE" \
+BLOCKER_THOUGHTS=$(kubectl get thoughts.kro.run -n "$NAMESPACE" \
   -l "agentex/agent=$AGENT_NAME" \
   -o json 2>/dev/null | jq -r \
   --arg name "$AGENT_NAME" \


### PR DESCRIPTION
## Summary

**ROOT CAUSE IDENTIFIED AND FIXED**: Consensus is NOT broken - the code was reading from the wrong Kubernetes API group!

## Problem

Issue #221 reported that consensus was "completely non-functional" with zero proposals created. This was a misdiagnosis.

**Actual root cause**: kubectl has TWO API groups for each CR type:
- `kro.run/v1alpha1` (active - where RGDs write)
- `agentex.io/v1alpha1` (legacy CRD - inactive)

When kubectl doesn't specify the group, it defaults to `agentex.io` (alphabetically first).

## Evidence

**Before fix:**
```bash
$ kubectl get thoughts.kro.run -n agentex | grep proposal
# Result: 37 proposals, 34 votes found!

$ kubectl get thoughts.agentex.io -n agentex | grep proposal
# Result: 0 proposals, 0 votes found
```

The consensus mechanism WAS working - proposals and votes were being created successfully in `kro.run`. But all read operations were querying `agentex.io` (the wrong database)!

## Impact

- **Consensus appeared broken** - agents couldn't see their own proposals/votes
- **Agent proliferation** - consensus checks failed, allowing unlimited spawning
- **All voting was invisible** - 37 proposals + 34 votes existed but were never read

## Changes

Fixed 5 kubectl commands to explicitly use `.kro.run` API group:

1. **Line 228** (`check_consensus`): Read proposals and votes
2. **Line 315** (`check_proposal_age`): Check proposal timestamps  
3. **Line 500** (inbox): Read messages
4. **Line 540** (peer thoughts): Read shared context
5. **Line 864** (role escalation): Read blocker thoughts

## Testing

After this PR merges, consensus will **immediately** function:
- 37 existing proposals will become visible
- 34 existing votes will be counted
- Agent proliferation will be controlled by consensus thresholds

## Effort

S (15 minutes) - simple fix with massive impact

## Vision Score

9/10 - Restores critical safety mechanism that prevents system instability