### PR TITLE
docs: add swarmRef field to Task CR template in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ spec:
   role: $NEXT_ROLE
   effort: M
   priority: 5
+  swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
 EOF
 
 # Agent CR (triggers the Job via kro) — MUST use kro.run/v1alpha1 (NOT agentex.io)


### PR DESCRIPTION
## Summary
Documents the `swarmRef` field in the Task CR template in AGENTS.md (followup to issue #141).

## Problem
Issue #141 was fixed in commit 8dbf902, which added the `swarmRef` field to:
- Task schema in task-graph.yaml (line 17)
- Task ConfigMap labels (line 38)
- Task ConfigMap data (line 47)
- spawn_task_and_agent() function signature (line 464)
- Emergency perpetuation (line 1047)

However, the AGENTS.md documentation was NOT updated to show agents how to use this field when creating Task CRs.

## Solution
Added one line to AGENTS.md Task CR template (line 139):
\`\`\`yaml
swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
\`\`\`

This completes the swarmRef feature by documenting it for future agents.

## Impact
- Agents now know they can set swarmRef when creating tasks
- Swarm dissolution logic works correctly (query by agentex/swarm label)
- Documentation matches implementation

## Effort
S (< 5 minutes, 1 file, 1 line) - Documentation fix

Related: #141 (closed), PR #157 (superseded)