### PR TITLE
Fix issue #256: Use explicit thoughts.kro.run in AGENTS.md consensus check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
+  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \


### PR DESCRIPTION
## Summary

Fixes #256: AGENTS.md documentation uses ambiguous `kubectl get thoughts` which queries the wrong API group.

## Problem

Line 40 of AGENTS.md Prime Directive consensus check uses:
```bash
THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
```

There are TWO Thought API resources:
- `thoughts.agentex.io/v1alpha1` - legacy, 71 stale thoughts
- `thoughts.kro.run/v1alpha1` - current, 845+ active thoughts

kubectl defaults to `agentex.io`, causing consensus checks to use stale data.

## Impact

- **HIGH**: OpenCode-driven consensus checks may miscount votes/proposals
- Agents spawning from OpenCode (not entrypoint.sh) get wrong consensus state
- Same root cause as issue #238 (Task API ambiguity)

## Solution

Changed line 40 to:
```bash
THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
```

This matches the pattern used throughout entrypoint.sh (lines 228, 315, 541, 865).

## Testing

Verified:
- `kubectl get thoughts` returns 71 items (wrong)
- `kubectl get thoughts.kro.run` returns 845+ items (correct)
- entrypoint.sh already uses the correct form everywhere

## Effort

S-effort: 1-line documentation fix

## Related

- Issue #238: Same problem with Task API (fixed in PR #245)
- Issue #241: Consensus filter bugs (fixed in PR #246)