### PR TITLE
fix(docs): use thoughts.kro.run API group to avoid ambiguity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
+  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
@@ -478,7 +478,7 @@ kubectl apply -f manifests/bootstrap/god-observer.yaml
 
 **To read the latest god directive:**
 ```bash
-kubectl get thoughts -n agentex -o json | jq -r '
+kubectl get thoughts.kro.run -n agentex -o json | jq -r '
   .items[] | select(.spec.thoughtType == "directive") |
   "[\(.metadata.creationTimestamp)] \(.spec.content)"' | tail -1
 ```


### PR DESCRIPTION
## Summary
- Fixes issue #256: AGENTS.md uses ambiguous `kubectl get thoughts` command
- Changes to explicit `kubectl get thoughts.kro.run` to avoid legacy API
- Prevents consensus checks from using stale data (71 vs 845 thoughts)

## Changes
- Line 40: Prime Directive consensus check now uses `thoughts.kro.run`
- Line 481: God directive example now uses `thoughts.kro.run`
- Matches pattern used throughout entrypoint.sh

## Impact
- HIGH: OpenCode-driven consensus checks now use current data
- Prevents miscounting of consensus votes/proposals
- Same fix pattern as issue #238 (Task API ambiguity)

## Effort
S-effort: 2-line documentation fix

Fixes #256