### PR TITLE
CRITICAL: Fix consensus filter to use status.state (fixes #241)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,11 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (jobName exists AND completionTime is null) to prevent false positives
-# from ghost Agent CRs that kro failed to process (issue #189)
+# Fixed issue #241: completionTime == null matches failed agents too
+# Must filter by state == "IN_PROGRESS" to exclude ERROR state agents (failed Jobs)
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
+  '[.items[] | select(.spec.role == $role and .status.state == "IN_PROGRESS")] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -342,13 +342,13 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND without completionTime)
-  # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # Same fix as PR #172 applied to emergency perpetuation
+  # Count ACTIVE agents of the same role (IN_PROGRESS state only)
+  # Fixed issue #241: completionTime == null matches failed agents too
+  # Must filter by state to exclude ERROR state agents (failed Jobs)
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | 
+       select(.spec.role == $role and .status.state == "IN_PROGRESS")] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary
Fixes #241 - consensus check incorrectly counted failed agents as running

## Problem
The consensus check in `should_spawn_agent()` (entrypoint.sh line 351) and Prime Directive (AGENTS.md line 30) filtered agents by `completionTime == null`. However, kro only populates `completionTime` for successfully completed Jobs, so this filter matched:
- Agents with IN_PROGRESS Jobs (running) ✓ CORRECT
- Agents with ERROR state (failed) ✗ INCORRECT  
- Agents without Jobs yet (kro processing) ✗ INCORRECT

Result: Consensus saw 15+ agents when only 14 were actually running, causing constant false proliferation warnings.

## Solution
Filter by `.status.state == "IN_PROGRESS"` instead. This explicitly matches only running agents and excludes failed ones.

## Changes
- `images/runner/entrypoint.sh` line 351: Use state filter
- `AGENTS.md` line 30: Same fix in Prime Directive consensus check

## Impact
- **CRITICAL**: Fixes false positive proliferation warnings
- Related to #201, #164, #221 (mass proliferation)
- S-effort: 2-line change

## Testing
```bash
# Before: counts ERROR state agents too
kubectl get agents.kro.run -n agentex -o json | jq '[.items[] | select(.status.completionTime == null)] | length'

# After: only counts IN_PROGRESS agents
kubectl get agents.kro.run -n agentex -o json | jq '[.items[] | select(.status.state == "IN_PROGRESS")] | length'
```