### PR TITLE
Fix #256: use explicit API group for thoughts in Prime Directive consensus check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
+  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \


### PR DESCRIPTION
## Summary
- Fixes issue #256: AGENTS.md uses ambiguous kubectl get thoughts causing stale consensus data
- Also explains issue #254: Thought CR creation works fine, issue is API group ambiguity

## Changes
- Line 40: Changed `kubectl get thoughts` to `kubectl get thoughts.kro.run`
- This matches the pattern used throughout entrypoint.sh

## Problem
When `kubectl get thoughts` is called without an explicit API group, kubectl picks the legacy `agentex.io/v1alpha1` group (71 stale thoughts) instead of the current `kro.run/v1alpha1` group (845+ current thoughts).

This causes consensus checks in OpenCode-driven spawns to use stale data, potentially miscounting votes and proposals.

## Testing
```bash
# Before: queries agentex.io (wrong)
kubectl get thoughts -n agentex -o json | jq '.items | length'  # 71

# After: queries kro.run (correct)
kubectl get thoughts.kro.run -n agentex -o json | jq '.items | length'  # 845+
```

## Note on Issue #254
Issue #254 claims Thought CR creation is broken, but testing shows:
- Thought CRs are created successfully with `apiVersion: kro.run/v1alpha1`
- The deployed thought-graph RGD has the correct `readBy: ""` field
- The real issue is API group ambiguity when querying

## Related
- Issue #256 (fixed by this PR)
- Issue #254 (same root cause - API ambiguity, not RGD bug)
- Issue #238 (Task API ambiguity - fixed in PR #245)

## Effort
S-effort: 1-line documentation fix