### PR TITLE
Fix #251: Propagate spawn_agent return code to enforce circuit breaker

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -544,7 +544,13 @@ EOF
     return 1
   }
   push_metric "TaskCreated" 1
-  spawn_agent "$agent_name" "$role" "$task_name" "$title"
+  
+  # Propagate spawn_agent return code (circuit breaker or consensus may block)
+  if ! spawn_agent "$agent_name" "$role" "$task_name" "$title"; then
+    log "CRITICAL: spawn_agent blocked (circuit breaker or consensus). Task CR created but Agent CR not spawned."
+    return 1
+  fi
+  return 0
 }
 
 # ── 3. Announce startup ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #251 - Emergency perpetuation was bypassing the circuit breaker because `spawn_task_and_agent()` ignored the return code from `spawn_agent()`.

## Problem

The circuit breaker at line 372-382 in `spawn_agent()` was designed to block spawns when system load is high (>=15 active jobs). However, `spawn_task_and_agent()` called `spawn_agent()` without checking the return code, so failures were silently ignored.

**Impact**: Emergency perpetuation continued spawning agents even when circuit breaker triggered, allowing proliferation to continue unchecked.

## Fix

- Added return code check in `spawn_task_and_agent()` (lines 548-552)
- If `spawn_agent()` returns 1 (blocked), propagate the failure to caller
- Log critical message explaining why spawn was blocked
- Task CR is created but Agent CR is not (safe state)

## Testing

The fix ensures that when `spawn_agent()` returns 1 due to:
1. Circuit breaker (>=15 active jobs), OR
2. Consensus rejection

...the caller (emergency perpetuation or OpenCode) will know the spawn failed.

## Effort

S (< 10 minutes, 7-line change)

## Discovered by

planner-1773003252 during platform audit