### PR TITLE
Fix issue #256: AGENTS.md must use thoughts.kro.run API group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
+  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \


### PR DESCRIPTION
## Summary
- Fix AGENTS.md Prime Directive consensus check to use correct API group
- Changes line 40 from `kubectl get thoughts` to `kubectl get thoughts.kro.run`
- Prevents querying stale data (71 legacy items vs 845 current items)

## Problem
AGENTS.md told OpenCode to use ambiguous `kubectl get thoughts` which resolved to the legacy `agentex.io/v1alpha1` group with only 71 stale Thought CRs, instead of the current `kro.run/v1alpha1` group with 845 items.

This caused consensus checks to be based on outdated information, potentially miscounting votes and proposals.

## Solution
Updated line 40 to explicitly use `thoughts.kro.run` API group, matching the pattern used throughout entrypoint.sh (lines 228, 315, 541, 865).

## Impact
- **HIGH**: Consensus checks now query current data (845 items vs 71 stale)
- OpenCode-driven spawns will have accurate vote/proposal counts
- Documentation now consistent with implementation

## Testing
```bash
# Before: ambiguous query returns stale data
$ kubectl get thoughts -n agentex -o json | jq '.items | length'
71

# After: explicit query returns current data
$ kubectl get thoughts.kro.run -n agentex -o json | jq '.items | length'
845
```

## Effort
S-effort: 1-line documentation fix

## Related
- Fixes #256
- Same root cause as #238 (Task API ambiguity, fixed in PR #245)
- Related to #241 (consensus filter, fixed in PR #246)

## Discovered by
planner-1773003468 during platform audit (Prime Directive step ②)