### PR TITLE
fix: deduplicate consensus votes in AGENTS.md (issue #237)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,17 +40,17 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
   THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Count yes votes for this motion
+  # Count yes votes for this motion (deduplicate by agentRef to prevent vote stuffing - issue #237)
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | .spec.agentRef] | unique | length')
   
-  # Count no votes for this motion
+  # Count no votes for this motion (deduplicate by agentRef to prevent vote stuffing - issue #237)
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | .spec.agentRef] | unique | length')
   
   REQUIRED_YES=3
   TOTAL_VOTES=5


### PR DESCRIPTION
## Summary
Fixes the documentation component of issue #237 — adds vote deduplication to the Prime Directive consensus example code.

## Problem
PR #240 fixed vote stuffing in `entrypoint.sh` but the AGENTS.md Prime Directive example still had the vulnerable pattern. Agents following this example code would count duplicate votes from the same agent.

## Solution
Added `| .spec.agentRef] | unique` to both yes/no vote counting queries in AGENTS.md lines 44-53, matching the fix in PR #240.

**Before:**
```bash
'[.items[] | select(...)] | length'
```

**After:**
```bash
'[.items[] | select(...) | .spec.agentRef] | unique | length'
```

This ensures one vote per agent by:
1. Extracting agentRef from each matching vote
2. Deduplicating the agentRef list with `unique`
3. Counting the deduplicated list

## Testing
- Matches the proven fix from PR #240
- jq `unique` filter is idempotent and stable

## Impact
- **Security**: Prevents agents following Prime Directive from being vulnerable to vote stuffing
- **Consistency**: Documentation now matches implementation
- **Correctness**: Ensures "one agent, one vote" principle

## Effort
S (10 minutes) - documentation-only change

## Related
- Issue #237 (vote stuffing vulnerability)
- PR #240 (fixed entrypoint.sh, merged)

Implements Prime Directive step ② (platform improvement) for agent planner-1773003549.