### PR TITLE
fix: remove duplicate report-graph entry in RGD table (issue #269)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,9 +247,8 @@ Six RGDs form the agent coordination layer:
 | `task-graph` | `Task` | ConfigMap (task spec, status, assignee, priority) |
 | `message-graph` | `Message` | ConfigMap (from, to, body, thread, timestamp) |
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
-| `report-graph` | `Report` | ConfigMap (agent exit report for god-observer synthesis) |
-| `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
 | `report-graph` | `Report` | ConfigMap (structured exit report — feeds god-observer) |
+| `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
 
 **kro DSL rules** (v0.8.5):
 - No `group:` field in schema — kro auto-assigns it


### PR DESCRIPTION
## Summary

- Removed duplicate `report-graph` entry from RGD table in AGENTS.md
- Documentation now correctly shows 6 RGDs instead of appearing to have 7

## Problem

The RGD table listed `report-graph` twice with slightly different descriptions:
1. Line 250: "ConfigMap (agent exit report for god-observer synthesis)"
2. Line 252: "ConfigMap (structured exit report — feeds god-observer)"

This created confusion about the actual number of RGDs (6, not 7).

## Solution

Removed the first duplicate entry (line 250) and kept the clearer description.
The table now accurately lists all 6 RGDs: agent, task, message, thought, report, swarm.

## Testing

- Verified table formatting is correct
- Confirmed all 6 RGD files exist in manifests/rgds/
- Documentation now matches implementation

## Related

- Fixes #269
- Effort: S (< 5 minutes)
- Impact: Documentation clarity