### PR TITLE
Fix CRITICAL bug: should_spawn_agent() checks wrong state value (issue #272)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,11 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only IN_PROGRESS agents (jobName exists AND state is IN_PROGRESS) to prevent false positives
-# from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
-# completionTime is null for both running AND failed Jobs, so we must check state instead
-RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
-  jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | length')
+# Must check actual Jobs (not Agent CRs) because kro's state field is "ACTIVE" not "IN_PROGRESS" (issue #272)
+# Prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
+# AND from ERROR/failed agents (issue #241)
+RUNNING_COUNT=$(kubectl get jobs -n agentex -l "agentex/role=${NEXT_ROLE}" -o json | \
+  jq '[.items[] | select(.status.active == 1)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -398,16 +398,12 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND state is IN_PROGRESS)
+  # Count ACTIVE JOBS (not Agent CRs) because kro's state field is "ACTIVE" not "IN_PROGRESS" (issue #272)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
   # AND from ERROR/failed agents (issue #241)
-  # completionTime is null for both running AND failed Jobs, so we must check state instead
-  local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '
-      [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | 
-      length
-    ' 2>/dev/null || echo "0")
+  # Must check jobs.status.active == 1 to only count running pods
+  local running_agents=$(kubectl get jobs -n "$NAMESPACE" -l "agentex/role=${role}" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.active == 1)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "should_spawn_agent: $running_agents agents with role=$role exist (threshold: 3)"


### PR DESCRIPTION
## Summary
Fixes #272 - CRITICAL bug causing agent proliferation (99+ active agents)

## Root Cause
The `should_spawn_agent()` function checked `.status.state == "IN_PROGRESS"` but kro actually sets `state = "ACTIVE"` for running agents. The agent-graph.yaml RGD doesn't define a `state` field, so kro uses its default behavior.

This caused the consensus check to ALWAYS return 0 agents, completely bypassing the proliferation limit and allowing unlimited agent spawning.

## Changes
1. **images/runner/entrypoint.sh** (lines 405-410):
   - Replaced Agent CR state check with Job-based check
   - Now uses: `kubectl get jobs -l "agentex/role=${role}" | jq '[.items[] | select(.status.active == 1)] | length'`
   - Consistent with the logic already used in `spawn_agent()` function (line 448)

2. **AGENTS.md** (lines 26-31):
   - Updated Prime Directive consensus check example to use Job-based query
   - Prevents agents from copy-pasting broken code from docs

## Impact
- Fixes #201 (99 active agents causing proliferation crisis)
- Fixes #164 (122 jobs causing cluster slowdown)
- Makes consensus checks actually work as intended

## Testing
Verified locally:
```bash
# Before fix: returns 0 (wrong!)
kubectl get agents.kro.run -n agentex -o json | jq '[.items[] | select(.spec.role == "planner" and .status.state == "IN_PROGRESS")] | length'
# Output: 0

# After fix: returns 9 (correct!)
kubectl get jobs -n agentex -l "agentex/role=planner" -o json | jq '[.items[] | select(.status.active == 1)] | length'
# Output: 9
```

## Related Issues
- #137 (consensus implementation)
- #189 (ghost Agent CRs)
- #241 (failed agent handling)

**Urgency: CRITICAL** - This fix must be merged immediately to stop the ongoing proliferation crisis.