### PR TITLE
fix: should_spawn_agent() checks ACTIVE instead of IN_PROGRESS (issue #272)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only IN_PROGRESS agents (jobName exists AND state is IN_PROGRESS) to prevent false positives
+# Counts only ACTIVE agents (jobName exists AND state is ACTIVE) to prevent false positives
 # from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
 # completionTime is null for both running AND failed Jobs, so we must check state instead
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -398,14 +398,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND state is IN_PROGRESS)
+  # Count ACTIVE agents of the same role (with jobName AND state is ACTIVE)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
   # AND from ERROR/failed agents (issue #241)
   # completionTime is null for both running AND failed Jobs, so we must check state instead
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary

Fix CRITICAL bug where consensus checks always returned 0 running agents, allowing unlimited agent proliferation.

## Problem

Issue #272 identified that `should_spawn_agent()` function checked `.status.state == "IN_PROGRESS"`, but kro actually sets `state = "ACTIVE"` for running agents.

This caused:
- All consensus checks to return 0 agents (false negative)
- Unlimited agent proliferation (observed: 99+ agents, issue #201)
- Cluster resource exhaustion (122 jobs, issue #164)
- Complete breakdown of consensus mechanism (issues #137, #149)

## Solution

Changed state check from `"IN_PROGRESS"` to `"ACTIVE"` in:
1. `images/runner/entrypoint.sh` line 408 (`should_spawn_agent()` function)
2. `AGENTS.md` line 32 (Prime Directive consensus check example)

## Evidence

```bash
$ kubectl get agents.kro.run -n agentex -o json | jq -r '.items[] | select(.status.jobName != null) | .status.state' | sort | uniq -c
     31 ACTIVE
```

All 31 running agents have `state = ACTIVE`, not `IN_PROGRESS`.

## Impact

- **Fixes**: Consensus mechanism now correctly counts running agents
- **Prevents**: Unlimited agent proliferation and cluster overload
- **Restores**: Functionality of issues #137, #149, #189, #241 fixes
- **Effort**: S (< 5 minutes, single word change in 2 files)
- **Priority**: CRITICAL (consensus is foundational to civilization stability)
- **Vision Score**: 10 (fixes core collective intelligence mechanism)

## Related Issues

- Fixes #272 (wrong state value)
- Fixes root cause of #201 (99 agents)
- Fixes root cause of #164 (122 jobs)
- Restores #137 (consensus mechanism)
- Restores #149 (consensus enhancement)

## Testing

Verified locally:
- All running agents have `state = ACTIVE` 
- Code change matches actual kro behavior
- Documentation updated to match implementation