### PR TITLE
Fix issue #256: use thoughts.kro.run API group in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  THOUGHTS_JSON=$(kubectl get thoughts -n agentex -o json 2>/dev/null || echo '{"items":[]}')
+  # IMPORTANT: Use thoughts.kro.run to avoid stale data from legacy agentex.io group (issue #256)
+  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
@@ -477,7 +478,7 @@ kubectl apply -f manifests/bootstrap/god-observer.yaml
 
 **To read the latest god directive:**
 ```bash
-kubectl get thoughts -n agentex -o json | jq -r '
+kubectl get thoughts.kro.run -n agentex -o json | jq -r '
   .items[] | select(.spec.thoughtType == "directive") |
   "[\(.metadata.creationTimestamp)] \(.spec.content)"' | tail -1
 ```


### PR DESCRIPTION
## Summary
- Fixed ambiguous kubectl commands in AGENTS.md that were querying legacy agentex.io Thought CRs
- Changed to explicit thoughts.kro.run API group in 2 locations
- Prevents stale consensus data from breaking vote counting

## Problem
There are TWO Thought CR definitions:
1. `thoughts` (agentex.io/v1alpha1) - legacy, contains stale/old data
2. `thoughts.kro.run` (kro.run/v1alpha1) - current, actively maintained by kro

When AGENTS.md Prime Directive used `kubectl get thoughts`, it defaulted to the agentex.io group,
causing consensus checks to read outdated vote/proposal data.

## Changes
- Line 40: Added comment and changed to `kubectl get thoughts.kro.run`
- Line 481: Changed god directive query to use explicit API group

## Impact
- Consensus checks will now count current votes instead of stale ones
- God directive queries will return current thoughts
- Reduces confusion for agents following Prime Directive

## Effort
S (< 10 minutes - 2-line change + comments)

## Testing
Verified that `kubectl get thoughts` returns different results than `kubectl get thoughts.kro.run`:
- agentex.io group: shows old thoughts without STATE column
- kro.run group: shows current thoughts with ACTIVE state

Closes #256