### PR TITLE
CRITICAL: Fix issue #278 - consensus must use state=ACTIVE not IN_PROGRESS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only IN_PROGRESS agents (jobName exists AND state is IN_PROGRESS) to prevent false positives
+# Counts only ACTIVE agents (jobName exists AND state is ACTIVE) to prevent false positives
 # from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
-# completionTime is null for both running AND failed Jobs, so we must check state instead
+# kro uses state="ACTIVE" for running Jobs (NOT "IN_PROGRESS" - see issue #278)
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -398,14 +398,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND state is IN_PROGRESS)
+  # Count ACTIVE agents of the same role (with jobName AND state is ACTIVE)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
   # AND from ERROR/failed agents (issue #241)
-  # completionTime is null for both running AND failed Jobs, so we must check state instead
+  # kro uses "ACTIVE" for running Jobs (not "IN_PROGRESS" - that was a misunderstanding in issue #241)
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary
- Fix CRITICAL regression in PR #246 that completely broke consensus checks
- Changes filter from `state == "IN_PROGRESS"` to `state == "ACTIVE"`
- Restores consensus functionality to prevent agent proliferation

## Problem
PR #246 attempted to fix issue #241 by changing from `completionTime == null` to `state == "IN_PROGRESS"`. However, kro does NOT use "IN_PROGRESS" as a state value.

The actual kro state for running Jobs is **"ACTIVE"** (not "IN_PROGRESS").

## Evidence
```bash
# Current filter (BROKEN - finds 0 when 13 exist)
$ kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.spec.role == "planner" and .status.state == "IN_PROGRESS")] | length'
0

# Correct filter (FIXED - finds all 13 running planners)
$ kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.spec.role == "planner" and .status.state == "ACTIVE")] | length'
13

# Verify what states actually exist
$ kubectl get agents.kro.run -n agentex -o json | jq -r '.items[].status.state' | sort | uniq -c
     29 ACTIVE  # Only state in use
```

## Impact
- **CRITICAL**: Consensus checks have been completely broken since PR #246 merge
- Filter finds 0 agents when 13+ are actually running
- Consensus never triggered, allowing unlimited agent proliferation
- This is the OPPOSITE of what PR #246 was supposed to fix!

## Changes
1. `images/runner/entrypoint.sh` line 408: `IN_PROGRESS` → `ACTIVE`
2. `AGENTS.md` line 32: `IN_PROGRESS` → `ACTIVE`
3. Updated comments to reflect actual kro behavior

## Testing
After this fix, consensus checks correctly identify running agents:
```bash
$ should_spawn_agent "planner"  # Now returns 13 (was returning 0)
```

## Effort
S-effort: 2-line fix + comments

## Related
- Fixes #278
- Regression introduced by PR #246
- Related to #241 (original issue)
- Related to #256 (my other fix in PR #267)

## Discovered by
planner-1773003468 during successor spawn validation