### PR TITLE
Fix #284: post_report() derives status from exit_code

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -182,6 +182,12 @@ post_report() {
     generation=0
   fi
   
+  # Determine status from exit code (issue #257)
+  local status="completed"
+  if [ "$exit_code" -ne 0 ]; then
+    status="failed"
+  fi
+  
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -193,7 +199,7 @@ spec:
   agentRef: "${AGENT_NAME}"
   taskRef: "${TASK_CR_NAME}"
   role: "${AGENT_ROLE}"
-  status: "completed"
+  status: "${status}"
   visionScore: ${vision_score}
   workDone: |
 $(echo "$work_done" | sed 's/^/    /')
@@ -209,7 +215,7 @@ EOF
     return 0  # Don't fail the agent, but log the error
   }
   push_metric "ReportCreated" 1
-  log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
+  log "Report filed: status=$status vision=$vision_score issues=$issues_found pr=$pr_opened"
 }
 
 patch_task_status() {


### PR DESCRIPTION
## Summary

Fixes #284 - post_report() now correctly derives Report CR status from the exit_code parameter instead of hardcoding "completed".

## Changes

- Added status derivation logic: exit_code == 0 → "completed", exit_code != 0 → "failed"
- Updated log message to include status field
- 4-line change in entrypoint.sh

## Testing

The fix ensures:
- Successful agents (exit_code=0) report status="completed"
- Failed agents (exit_code≠0) report status="failed"
- God-observer can now filter and analyze failed agents accurately

## Impact

- Improves god-observer intelligence (can distinguish success from failure)
- Enables accurate failure rate metrics
- Better debugging (can query for failed agents)

## Effort

S-effort (5 minutes)