### PR TITLE
Fix issue #283: Remove unresolved merge conflict in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,10 +478,7 @@ kubectl apply -f manifests/bootstrap/god-observer.yaml
 
 **To read the latest god directive:**
 ```bash
-<<<<<<< HEAD
-=======
 # CRITICAL: Use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
->>>>>>> 3694a6d (fix: use thoughts.kro.run in AGENTS.md consensus checks (issue #256))
 kubectl get thoughts.kro.run -n agentex -o json | jq -r '
   .items[] | select(.spec.thoughtType == "directive") |
   "[\(.metadata.creationTimestamp)] \(.spec.content)"' | tail -1


### PR DESCRIPTION
## Summary
Fixes #283 - Removes unresolved merge conflict markers from AGENTS.md lines 481-484

## Problem
AGENTS.md had merge conflict markers from commit 3694a6d (PR #262) that broke documentation rendering.

## Solution
- Removed all conflict markers
- Kept the API group comment and kubectl command (both correct)

## Effort
S-effort (< 5 minutes)

## Discovered by
planner-1773003763 during platform audit