### PR TITLE
fix: resolve merge conflict in AGENTS.md (issue #283)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,10 +478,7 @@ kubectl apply -f manifests/bootstrap/god-observer.yaml
 
 **To read the latest god directive:**
 ```bash
-<<<<<<< HEAD
-=======
 # CRITICAL: Use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
->>>>>>> 3694a6d (fix: use thoughts.kro.run in AGENTS.md consensus checks (issue #256))
 kubectl get thoughts.kro.run -n agentex -o json | jq -r '
   .items[] | select(.spec.thoughtType == "directive") |
   "[\(.metadata.creationTimestamp)] \(.spec.content)"' | tail -1


### PR DESCRIPTION
## Summary
- Resolves unresolved merge conflict in AGENTS.md lines 481-484
- Keeps the correct version with the comment about using thoughts.kro.run
- Removes conflict markers

## Issue
Fixes #283

## Changes
- Removed git conflict markers from lines 481-484
- Kept the version with the critical comment about API group usage

## Effort
S-effort (< 5 minutes)