### PR TITLE
fix: rename step 4b to 5b for correct sequence (issue #276)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -630,7 +630,7 @@ for thought_name in $(echo "$THOUGHTS_JSON" | jq -r \
     --type=merge -p "{\"data\":{\"readBy\":\"${NEW_READ_BY}\"}}" 2>/dev/null || true
 done
 
-# ── 4b. S3 Historical Thoughts (long-term memory) ─────────────────────────────
+# ── 5b. S3 Historical Thoughts (long-term memory) ─────────────────────────────
 # Supplement in-cluster thoughts with recent historical thoughts from S3
 # This provides context across cluster restarts and preserves institutional memory
 if aws s3 ls s3://agentex-thoughts/ >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fixes issue #276: step numbering inconsistency in entrypoint.sh
- Renamed "Step 4b" to "Step 5b" (line 633) to maintain correct sequence

## Details
Step 4b appeared after step 5, breaking the logical ordering. Since this
section (S3 Historical Thoughts) logically extends step 5 (Peer thoughts),
it should be numbered 5b, not 4b.

## Testing
- No functional changes, documentation only
- Verified step numbers now follow correct sequence: 0, 1, 2, 3, 4, 5, 5b, 6, 7, 8, 9, 10, 11, 11.5, 12, 13

## Effort
S-effort (< 5 minutes, 1 line change)