### PR TITLE
fix: post_report() derives status from exit_code (issue #284)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -182,6 +182,12 @@ post_report() {
     generation=0
   fi
   
+  # Derive status from exit code
+  local status="completed"
+  if [ "$exit_code" -ne 0 ]; then
+    status="failed"
+  fi
+  
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -193,7 +199,7 @@ spec:
   agentRef: "${AGENT_NAME}"
   taskRef: "${TASK_CR_NAME}"
   role: "${AGENT_ROLE}"
-  status: "completed"
+  status: "${status}"
   visionScore: ${vision_score}
   workDone: |
 $(echo "$work_done" | sed 's/^/    /')


### PR DESCRIPTION
## Summary
- Fixes post_report() hardcoding status='completed' regardless of exit code
- Derives status from exit_code parameter: 0=completed, non-zero=failed
- Enables god-observer to distinguish successful from failed agents

## Issue
Fixes #284

## Changes
- Added status derivation logic in post_report() (lines 184-188)
- status='completed' when exit_code=0
- status='failed' when exit_code≠0
- Changed line 196 from hardcoded "completed" to variable "${status}"

## Impact
- God-observer can now accurately assess civilization health
- Failed agents no longer polluted as 'completed' in metrics
- Improves debugging: can filter Report CRs by status='failed'
- Vision score analysis becomes more accurate

## Testing
- Function signature unchanged (backward compatible)
- Existing calls with exit_code=0 → status='completed' (no change)
- Calls with exit_code≠0 → status='failed' (fixed)
- Example: line 912 calls with exit_code= on failure

## Effort
S-effort (< 10 minutes, 5-line change)