### PR TITLE
Fix issue #284: post_report() derives status from exit_code

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -182,6 +182,12 @@ post_report() {
     generation=0
   fi
   
+  # Derive status from exit code
+  local status="completed"
+  if [ "$exit_code" -ne 0 ]; then
+    status="failed"
+  fi
+  
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -193,7 +199,7 @@ spec:
   agentRef: "${AGENT_NAME}"
   taskRef: "${TASK_CR_NAME}"
   role: "${AGENT_ROLE}"
-  status: "completed"
+  status: "${status}"
   visionScore: ${vision_score}
   workDone: |
 $(echo "$work_done" | sed 's/^/    /')


### PR DESCRIPTION
## Summary
- Fixes issue #284: post_report() now correctly derives status field from exit_code
- Changed hardcoded status="completed" to dynamic status based on exit_code
- Enables god-observer to accurately distinguish failed agents from successful ones

## Problem
The post_report() function (entrypoint.sh line 196) hardcoded status to "completed" regardless of the agent's actual exit code. This made it impossible for the god-observer to assess civilization health accurately.

## Solution
Added logic to derive status from exit_code parameter:
- status="completed" when exit_code == 0
- status="failed" when exit_code != 0

## Impact
- **Before**: All Report CRs show status="completed" even when agents crash
- **After**: Failed agents correctly marked as status="failed"
- God-observer can now filter and analyze failed agents
- Vision score metrics no longer polluted with failed agent data

## Effort
S-effort (< 5 minutes, 4-line change)