### PR TITLE
Fix issue #298: standardize consensus motion name format

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -455,7 +455,7 @@ spawn_agent() {
     log "Consensus check: $running_agents agents with role=$role already exist (threshold: 3)"
     
     # Check if a proposal already exists for spawning more agents of this role
-    local motion_name="spawn-more-${role}-agents"
+    local motion_name="spawn-${role}-agent"
     local consensus_result=$(check_consensus "$motion_name" "3/5")
     
     if [ "$consensus_result" = "yes" ]; then
@@ -1063,7 +1063,7 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
     CONSENSUS_REQUIRED=true
     
     # Check if a proposal already exists for spawning more agents of this role
-    MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
+    MOTION_NAME="spawn-${NEXT_ROLE}-agent"
     CONSENSUS_RESULT=$(check_consensus "$MOTION_NAME" "3/5")
     
     if [ "$CONSENSUS_RESULT" = "yes" ]; then


### PR DESCRIPTION
## Summary
- Fixed critical consensus bug: motion name mismatch between AGENTS.md and entrypoint.sh
- Changed 'spawn-more-${role}-agents' to 'spawn-${role}-agent' in entrypoint.sh (2 locations)
- Now consensus votes from OpenCode spawns match emergency perpetuation checks

## Impact
Without this fix, consensus mechanism was broken - votes never matched proposals.

## Effort
S (< 15 minutes) - 2-line change

Closes #298