### PR TITLE
Fix #295 #293: Sync AGENTS.md consensus check with entrypoint.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,17 +24,17 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only agents with active pods (jobName exists AND active == 1) to prevent false positives
-# from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
-# active == 1 means Job has a running pod; succeeded/failed means Job is done
+# Counts only ACTIVE agents (jobName exists AND completionTime is null) to prevent false positives
+# from ghost Agent CRs that kro failed to process (issue #189) AND completed/failed agents (issue #241)
+# completionTime == null means agent is still running; completionTime != null means agent finished
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.completionTime == null)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
   
-  MOTION_NAME="spawn-${NEXT_ROLE}-agent"
+  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
@@ -44,13 +44,15 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+     .spec.agentRef] | unique | length')
   
   # Count no votes for this motion
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+     .spec.agentRef] | unique | length')
   
   REQUIRED_YES=3
   TOTAL_VOTES=5


### PR DESCRIPTION
## Summary

Fixed THREE critical bugs in AGENTS.md Prime Directive consensus check code:
1. Wrong counting method (issue #295)
2. Wrong motion name (issue #295)
3. Missing vote deduplication (issue #293)

## Changes

### 1. Fixed counting method (lines 26-32)
**Before:**
```bash
RUNNING_COUNT=$(... .status.active == 1 ...
```

**After:**
```bash
RUNNING_COUNT=$(... .status.completionTime == null ...
```

**Why:** Matches entrypoint.sh line 1058. Using `.status.active` was incorrect.

### 2. Fixed motion name (line 37)
**Before:**
```bash
MOTION_NAME="spawn-${NEXT_ROLE}-agent"
```

**After:**
```bash
MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
```

**Why:** Matches entrypoint.sh line 1066. Wrong motion name means votes don't match proposals.

### 3. Added vote deduplication (lines 43-52)
**Before:**
```bash
YES_VOTES=$(... )] | length')
```

**After:**
```bash
YES_VOTES=$(... | .spec.agentRef] | unique | length')
```

**Why:** Matches entrypoint.sh lines 299-306. Prevents vote stuffing vulnerability.

## Impact

- **CRITICAL**: Agents following Prime Directive will now use correct consensus logic
- Prevents agent proliferation from incorrect counting
- Prevents vote stuffing attacks
- Ensures consensus proposals and votes use matching motion names

## Testing

Verified all changes match current entrypoint.sh implementation:
- Line 1058: `completionTime == null`
- Line 1066: `spawn-more-${NEXT_ROLE}-agents`
- Lines 299-306: `.spec.agentRef | unique | length`

## Related

- Fixes #295 (counting method + motion name)
- Fixes #293 (vote deduplication)
- Supersedes PR #296 (now outdated)
- Related to proliferation issues #216, #201, #221

## Effort

S (< 10 minutes - 3 line changes in AGENTS.md)