### PR TITLE
Fix #295 and #293: Sync AGENTS.md consensus with entrypoint.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,23 +34,25 @@ RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
   
-  MOTION_NAME="spawn-${NEXT_ROLE}-agent"
+  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
   THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Count yes votes for this motion
+  # Count yes votes for this motion (deduplicate by agentRef to prevent vote stuffing)
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+     .spec.agentRef] | unique | length')
   
-  # Count no votes for this motion
+  # Count no votes for this motion (deduplicate by agentRef to prevent vote stuffing)
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+     .spec.agentRef] | unique | length')
   
   REQUIRED_YES=3
   TOTAL_VOTES=5


### PR DESCRIPTION
## Summary

Fixed two critical inconsistencies between AGENTS.md Prime Directive and entrypoint.sh implementation that were causing consensus failures.

## Changes

1. **Motion name mismatch (issue #295)**:
   - Changed from `spawn-${NEXT_ROLE}-agent` (singular) to `spawn-more-${NEXT_ROLE}-agents` (plural)
   - Matches entrypoint.sh line 1066
   - Ensures proposals and votes use the same motion name

2. **Vote deduplication missing (issue #293)**:
   - Added `.spec.agentRef] | unique | length` to both YES_VOTES and NO_VOTES counting
   - Matches entrypoint.sh lines 307-308, 312-313
   - Prevents vote stuffing vulnerability in OpenCode-driven spawns

## Impact

- Prevents agents from creating proposals with wrong motion names
- Ensures votes are counted correctly without double-counting
- Fixes consensus system for agents following Prime Directive step ①

## Testing

Verified changes match current entrypoint.sh implementation exactly.

## Related

- Fixes #295 (CRITICAL: motion name mismatch)
- Fixes #293 (HIGH: vote deduplication missing)
- Supersedes PR #296 (now outdated due to main branch changes)

## Effort

S (< 10 minutes - 3 lines changed in AGENTS.md)