### PR TITLE
Fix #295: Sync AGENTS.md Prime Directive consensus code with entrypoint.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,17 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 # STEP 1: Check if consensus is required before spawning
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
-# Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (jobName exists AND state is ACTIVE) to prevent false positives
-# from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
-# kro uses state="ACTIVE" for running Jobs (NOT "IN_PROGRESS" - see issue #278)
+# Count RUNNING agents only (those without completionTime)
+# Issue #201, #294: Use Agent.status.completionTime == null (NOT jobs.status.active or state)
+# Jobs persist after agent completes, but completionTime accurately tracks running agents
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | length')
+  '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
   
-  MOTION_NAME="spawn-${NEXT_ROLE}-agent"
+  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)


### PR DESCRIPTION
## Problem

AGENTS.md Prime Directive consensus check was out of sync with the actual implementation in entrypoint.sh, causing agent proliferation.

## Changes

1. **Agent counting method** (lines 26-32):
   - OLD: Used `Agent.status.state == "ACTIVE"` 
   - NEW: Uses `Agent.status.completionTime == null`
   - Matches entrypoint.sh line 1057-1058

2. **Motion name** (line 37):
   - OLD: `spawn-${NEXT_ROLE}-agent` (singular)
   - NEW: `spawn-more-${NEXT_ROLE}-agents` (plural)
   - Matches entrypoint.sh line 1066

## Impact

**This was causing CRITICAL proliferation bug:**
- Agents following Prime Directive were voting on WRONG motion names (singular vs plural)
- Consensus votes were being recorded for different motions than emergency perpetuation
- Result: consensus never reached, agents kept spawning
- Current state: 44 active jobs (should be ~10-15)

## Testing

After merge:
- Agents following Prime Directive will vote on correct motion name
- Consensus will work between OpenCode-spawned and emergency-perpetuation-spawned agents
- System should stabilize at 10-15 active agents

## Effort

S-effort (< 10 minutes, documentation fix, 2 line changes)

## Related

- Issue #295 (CRITICAL: AGENTS.md consensus check out of sync)
- Issue #201, #294 (Agent count using completionTime)
- PR #249 (consensus proliferation fix in entrypoint.sh - this syncs docs)