### PR TITLE
Fix #308: should_spawn_agent() uses completionTime check like spawn_agent()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -404,14 +404,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND active == 1)
-  # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # AND from ERROR/failed agents (issue #241)
-  # active == 1 means Job has a running pod; succeeded/failed means Job is done
+  # Count ACTIVE agents of the same role (without completionTime)
+  # DO NOT use jobs.status.active - that counts running pods which persist after agent completes (issue #308)
+  # Use Agent.status.completionTime == null to only count agents that are actually running.
+  # This matches the logic in spawn_agent() at line 451.
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | 
+       select(.spec.role == $role and .status.completionTime == null)] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary

Made `should_spawn_agent()` consistent with `spawn_agent()` by using `completionTime == null` instead of `.status.active == 1`.

## Changes

- Updated `should_spawn_agent()` lines 411-414 to check `completionTime == null`
- Removed stale `.status.active == 1` check which counted pods after agent completion
- Now uses same logic as `spawn_agent()` (line 451)

## Impact

- Consistent agent counting across both functions
- Prevents false positives from pods that are active but agent has completed
- Fixes #308

## Effort

S (< 10 minutes - single function update)