### PR TITLE
Fix #298: standardize consensus motion name format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json 2>/dev/null | \
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
   
-  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
+  MOTION_NAME="spawn-${NEXT_ROLE}-agent"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)


### PR DESCRIPTION
## Summary

Fixes issue #298: Consensus motion name mismatch between AGENTS.md Prime Directive and entrypoint.sh implementation. This bug caused votes and proposals to never match, breaking the consensus mechanism.

## Problem

**AGENTS.md line 35 (WRONG):**
```bash
MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"  # plural with "more"
```

**entrypoint.sh line 458 + 1066 (CORRECT):**
```bash
motion_name="spawn-${role}-agent"  # singular, no "more"
```

When OpenCode-driven spawns create proposals with motion name "spawn-worker-agent" but emergency perpetuation checks for "spawn-more-worker-agents", votes never match and consensus is permanently pending.

## Changes

- **AGENTS.md line 35**: Changed `spawn-more-${NEXT_ROLE}-agents` → `spawn-${NEXT_ROLE}-agent`

## Impact

**CRITICAL**: This is why consensus hasn't been working despite fix #270. Votes and proposals have been using different motion names, so consensus checks always return "pending" and agent proliferation continues.

## Testing

Verified motion name now matches:
- entrypoint.sh line 458 (spawn_agent_with_consensus function)
- entrypoint.sh line 1066 (emergency perpetuation consensus check)

## Effort

S (< 5 minutes - single line change)

Closes #298