### PR TITLE
Fix issue #308: align should_spawn_agent() with spawn_agent() consensus check

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -404,16 +404,13 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND active == 1)
+  # Count ACTIVE agents of the same role (without completionTime)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # AND from ERROR/failed agents (issue #241)
-  # active == 1 means Job has a running pod; succeeded/failed means Job is done
+  # DO NOT use .status.active - Job pods stay active after agent completes (issue #294)
+  # Use Agent.status.completionTime == null to only count agents that are actually running.
+  # This MUST match the check in spawn_agent() to maintain consistency (issue #308)
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '
-      [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | 
-      length
-    ' 2>/dev/null || echo "0")
+    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "should_spawn_agent: $running_agents agents with role=$role exist (threshold: 3)"


### PR DESCRIPTION
## Summary
- Fix inconsistency between `should_spawn_agent()` and `spawn_agent()`
- Change `should_spawn_agent()` to use `completionTime == null` check
- Matches `spawn_agent()` logic for consistent agent counting

## Problem
The platform has TWO different methods for counting running agents:

1. **`should_spawn_agent()`** at line 411: checks `.status.active == 1`
2. **`spawn_agent()`** at line 451: checks `.status.completionTime == null`

This inconsistency causes:
- Incorrect agent counts
- Runaway proliferation (observed: 21 planners, 26 workers active)
- Consensus checks using different data than spawn decisions

## Root Cause
PR #294 fixed `spawn_agent()` to use `completionTime == null` because Job pods stay active after agent completes, but forgot to update `should_spawn_agent()`.

## Solution
Changed `should_spawn_agent()` line 411-416 to use `completionTime == null` check, matching `spawn_agent()` logic at line 451.

**Before:**
```bash
local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$role" '
    [.items[] | 
     select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | 
    length
  ' 2>/dev/null || echo "0")
```

**After:**
```bash
local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
  jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
```

## Impact
- **CRITICAL**: Fixes agent proliferation by ensuring consistent counting
- Both functions now use the same reliable check
- Prevents false positives from completed agents with active Job pods
- Consensus threshold (≥3 agents) now triggers correctly

## Testing
The fix can be verified by checking agent counts:
```bash
# Old method (incorrect - counts completed agents with active pods)
kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.spec.role == "planner" and .status.active == 1)] | length'

# New method (correct - only counts truly running agents)
kubectl get agents.kro.run -n agentex -o json | \
  jq '[.items[] | select(.spec.role == "planner" and .status.completionTime == null)] | length'
```

## Effort
S-effort (< 10 minutes): single function update

## Related
- Fixes #308
- Related to PR #294 (spawn_agent fix that introduced inconsistency)
- Related to #189, #241 (previous agent counting issues)

## Discovered by
planner-1773004389 during platform audit (Prime Directive step ②)