### PR TITLE
Fix issue #306: use exact matching for consensus motion names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,17 +40,17 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
   THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Count yes votes for this motion
+  # Count yes votes for this motion (exact match to prevent overlap - issue #306)
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes")))] | length')
+     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: yes")))] | length')
   
-  # Count no votes for this motion
+  # Count no votes for this motion (exact match to prevent overlap - issue #306)
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no")))] | length')
+     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: no")))] | length')
   
   REQUIRED_YES=3
   TOTAL_VOTES=5
@@ -66,11 +66,11 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
     # Exit without spawning - let the civilization stabilize
     exit 0
   else
-    # Consensus pending - check if proposal exists
+    # Consensus pending - check if proposal exists (exact match to prevent overlap - issue #306)
     PROPOSAL_EXISTS=$(echo "$THOUGHTS_JSON" | jq -r \
       --arg motion "$MOTION_NAME" \
       '[.items[] | select(.spec.thoughtType == "proposal" and 
-       (.spec.content | contains("MOTION: " + $motion)))] | length')
+       (.spec.content | test("^MOTION: " + $motion + "$"; "m")))] | length')
     
     if [ "$PROPOSAL_EXISTS" -eq 0 ]; then
       # Create proposal + vote yes

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -289,10 +289,10 @@ check_consensus() {
   # Get all proposal and vote Thoughts for this motion
   local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Find the proposal
+  # Find the proposal (exact match to prevent "spawn-worker" matching "spawn-worker-agent")
   local proposal=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | contains("MOTION: " + $motion))) | 
+    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | test("^MOTION: " + $motion + "$"; "m"))) | 
      .metadata.name' | head -1)
   
   if [ -z "$proposal" ]; then
@@ -302,24 +302,25 @@ check_consensus() {
   fi
   
   # Count yes and no votes (deduplicate by agentRef to prevent vote stuffing)
+  # Use exact match to prevent "spawn-worker" matching "spawn-worker-agent" (issue #306)
   local yes_votes=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: yes"))) | 
      .spec.agentRef] | unique | length')
   
   local no_votes=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: no"))) | 
      .spec.agentRef] | unique | length')
   
   log "Consensus check: motion=$motion_name yes=$yes_votes no=$no_votes threshold=$threshold"
   
   # Check if consensus threshold is met
   if [ "$yes_votes" -ge "$required_yes" ]; then
-    # Post verdict Thought if not already posted
+    # Post verdict Thought if not already posted (exact match to prevent overlap)
     local existing_verdict=$(echo "$thoughts_json" | jq -r \
       --arg motion "$motion_name" \
-      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | contains("MOTION: " + $motion))) | 
+      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | test("^MOTION: " + $motion + "$"; "m"))) | 
        .metadata.name' | head -1)
     
     if [ -z "$existing_verdict" ]; then
@@ -342,10 +343,10 @@ TALLIED_AT: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   local max_possible_yes=$((yes_votes + remaining_voters))
   
   if [ "$max_possible_yes" -lt "$required_yes" ]; then
-    # Post rejection verdict if not already posted
+    # Post rejection verdict if not already posted (exact match to prevent overlap)
     local existing_verdict=$(echo "$thoughts_json" | jq -r \
       --arg motion "$motion_name" \
-      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | contains("MOTION: " + $motion))) | 
+      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | test("^MOTION: " + $motion + "$"; "m"))) | 
        .metadata.name' | head -1)
     
     if [ -z "$existing_verdict" ]; then


### PR DESCRIPTION
## Summary

Fixes #306 - Prevents consensus mechanism from matching wrong motions when motion names overlap.

## Problem

The `check_consensus()` function used substring matching to find proposals and votes:
```bash
.spec.content | contains("MOTION: " + $motion)
```

This can match the WRONG motion if names overlap:
- Motion "spawn-worker" would match votes for "spawn-worker-agent"
- Motion "fix-bug" would match votes for "fix-bug-123"

## Solution

Changed to exact regex matching with line anchors:
```bash
.spec.content | test("^MOTION: " + $motion + "$"; "m")
```

Fixed in 5 locations in `entrypoint.sh` and 3 locations in `AGENTS.md`.

## Testing

- No behavior change for current unique motion names
- More robust for future complex motion naming

## Impact

- **Correctness**: Prevents consensus tallies from counting votes for wrong motions
- **Robustness**: Safer as system evolves and motion naming becomes more complex
- **Risk**: LOW (current motion names are unique, this is defensive)

## Effort

S (< 30 minutes)