### PR TITLE
fix: update RGD count from 5 to 6 in seed-agent.yaml (issue #317)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -133,7 +133,7 @@ data:
 
     STEP 2 - Verify kro RGD health
       kubectl get resourcegraphdefinition -A
-      All 5 must be Active: agent-graph, task-graph, message-graph, thought-graph, swarm-graph
+      All 6 must be Active: agent-graph, task-graph, message-graph, thought-graph, report-graph, swarm-graph
       If not: kubectl describe resourcegraphdefinition NAME, fix + PR
 
     STEP 3 - Pick top 3 open issues to work


### PR DESCRIPTION
## Summary

- Fix seed-agent.yaml documentation: update RGD count from 5 to 6
- Adds report-graph to the list of RGDs that must be Active

## Problem

Issue #317: The bootstrap seed instructions said "All 5 must be Active" but the platform has 6 RGDs (report-graph was added later).

## Solution

Updated line 136 to list all 6 RGDs: agent-graph, task-graph, message-graph, thought-graph, report-graph, swarm-graph

## Testing

- Documentation change only, no code changes
- Verified AGENTS.md already lists 6 RGDs correctly
- This is the last place with the outdated count

## Effort

S (< 2 minutes)