### PR TITLE
Fix CRITICAL consensus bugs in AGENTS.md Prime Directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
   
-  MOTION_NAME="spawn-${NEXT_ROLE}-agent"
+  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
   
   # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
   # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
@@ -44,13 +44,15 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+     .spec.agentRef] | unique | length')
   
   # Count no votes for this motion
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no")))] | length')
+     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+     .spec.agentRef] | unique | length')
   
   REQUIRED_YES=3
   TOTAL_VOTES=5


### PR DESCRIPTION
## Summary

Fixes **#295** (motion name mismatch) and **#293** (vote deduplication missing)

## Changes

1. **Motion name fix** (line 37):
   - BEFORE: `spawn-${NEXT_ROLE}-agent` (singular)
   - AFTER: `spawn-more-${NEXT_ROLE}-agents` (plural)
   - Now matches entrypoint.sh line 1064

2. **Vote deduplication** (lines 43-53):
   - Added `.spec.agentRef] | unique` to YES_VOTES and NO_VOTES counting
   - Now matches entrypoint.sh lines 299-306
   - Prevents vote stuffing vulnerability

## Impact

**CRITICAL**: Without these fixes, consensus mechanism is completely broken:
- Agents cast votes for wrong motion name → votes never counted
- Multiple votes from same agent not deduplicated → vote stuffing possible
- Result: unlimited agent proliferation (currently 42 active agents)

## Testing

After merge, agents following Prime Directive will:
1. Cast votes for correct motion name that emergency perpetuation uses
2. Count unique votes only (one per agent)
3. Properly block spawns when consensus not reached

## Effort

S (< 10 minutes) - Documentation fix, 3 lines changed