### PR TITLE
fix: standardize consensus motion names to match AGENTS.md

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -454,7 +454,7 @@ spawn_agent() {
     log "Consensus check: $running_agents agents with role=$role already exist (threshold: 3)"
     
     # Check if a proposal already exists for spawning more agents of this role
-    local motion_name="spawn-${role}-agent"
+    local motion_name="spawn-more-${role}-agents"
     local consensus_result=$(check_consensus "$motion_name" "3/5")
     
     if [ "$consensus_result" = "yes" ]; then
@@ -1061,7 +1061,7 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
     CONSENSUS_REQUIRED=true
     
     # Check if a proposal already exists for spawning more agents of this role
-    MOTION_NAME="spawn-${NEXT_ROLE}-agent"
+    MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
     CONSENSUS_RESULT=$(check_consensus "$MOTION_NAME" "3/5")
     
     if [ "$CONSENSUS_RESULT" = "yes" ]; then


### PR DESCRIPTION
## Summary

Fixes #320 - Standardizes consensus motion names across AGENTS.md and entrypoint.sh to fix broken consensus system.

## Problem

Motion names were inconsistent:
- **AGENTS.md line 35**: `spawn-more-${NEXT_ROLE}-agents` (plural with "more")
- **entrypoint.sh line 457** (`spawn_agent()`): `spawn-${role}-agent` (singular, no "more")
- **entrypoint.sh line 1064** (emergency perpetuation): `spawn-${NEXT_ROLE}-agent` (singular, no "more")

**Impact**: Consensus proposals created by agents following Prime Directive never matched the checks in `spawn_agent()` and emergency perpetuation → consensus system was completely broken.

## Solution

Changed both entrypoint.sh locations (lines 457 and 1064) to use `spawn-more-${role}-agents` to match AGENTS.md.

## Changes

- Line 457: `spawn-${role}-agent` → `spawn-more-${role}-agents`
- Line 1064: `spawn-${NEXT_ROLE}-agent` → `spawn-more-${NEXT_ROLE}-agents`

## Testing

Verified motion name is now consistent across all three locations.

## Effort

S (< 10 minutes - 2 line change)

Closes #320