### PR TITLE
Add rolling restart mechanism for runner image updates (issue #266)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -564,6 +564,22 @@ EOF
 log "Agent starting. Role=$AGENT_ROLE Task=$TASK_CR_NAME Model=$BEDROCK_MODEL"
 push_metric "AgentRun" 1
 
+# ── 3.5. Rolling restart check (issue #266) ───────────────────────────────────
+# Check if a rolling restart has been triggered (new runner image deployed).
+# If forceRestart timestamp is newer than this agent's start time, exit gracefully
+# so emergency perpetuation spawns a replacement with the new image.
+AGENT_START_TIME=$(ts)
+RESTART_SIGNAL=$(kubectl get configmap agentex-runner-version -n "$NAMESPACE" \
+  -o jsonpath='{.data.forceRestart}' 2>/dev/null || echo "0")
+
+if [ -n "$RESTART_SIGNAL" ] && [ "$RESTART_SIGNAL" -gt "$AGENT_START_TIME" ]; then
+  log "Rolling restart triggered (signal=$RESTART_SIGNAL, start=$AGENT_START_TIME). Exiting for upgrade..."
+  post_thought "Rolling restart: exiting to upgrade to new runner version" "observation" 9
+  post_message "broadcast" "Rolling restart: $AGENT_NAME exiting for runner upgrade" "status"
+  patch_task_status "Done" "Rolling restart triggered"
+  exit 0  # Emergency perpetuation will spawn replacement with new image
+fi
+
 # ── 4. Process inbox ──────────────────────────────────────────────────────────
 log "Processing inbox..."
 INBOX_MESSAGES=""

--- a/manifests/system/runner-version.yaml
+++ b/manifests/system/runner-version.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-runner-version
+  namespace: agentex
+data:
+  # Current runner image version (commit SHA)
+  version: "main"
+  
+  # Unix timestamp (seconds since epoch) when rolling restart was triggered.
+  # When this is set to a future timestamp, all agents started BEFORE this time
+  # will exit gracefully on their next periodic check, allowing emergency
+  # perpetuation to spawn replacements with the new runner image.
+  # 
+  # To trigger a rolling restart:
+  #   kubectl patch configmap agentex-runner-version -n agentex \
+  #     --type=merge -p "{\"data\":{\"forceRestart\":\"$(date +%s)\"}}"
+  # 
+  # To check current value:
+  #   kubectl get configmap agentex-runner-version -n agentex \
+  #     -o jsonpath='{.data.forceRestart}'
+  forceRestart: "0"


### PR DESCRIPTION
## Summary

Implements S-effort solution for forcing agents to upgrade to new runner images.

## Problem

When critical fixes merge and new runner image builds:
- Old agents keep running buggy code for up to 1 hour (Job timeout)
- No mechanism to force agents to upgrade
- During that window, buggy agents can spawn more buggy agents
- System remains unstable even after fixes merge

## Solution

ConfigMap-based rolling restart signal:
- ConfigMap `agentex-runner-version` stores `forceRestart` timestamp
- Agents check on startup (new step 3.5 in entrypoint.sh)
- If `forceRestart > agent_start_time`, agent exits gracefully
- Emergency perpetuation spawns replacement with new image

## Usage

Trigger rolling restart after deploying new runner image:
```bash
kubectl patch configmap agentex-runner-version -n agentex \
  --type=merge -p "{\"data\":{\"forceRestart\":\"$(date +%s)\"}}"
```

Check when restart was triggered:
```bash
kubectl get configmap agentex-runner-version -n agentex \
  -o jsonpath='{.data.forceRestart}'
```

## Implementation

- **entrypoint.sh** (step 3.5): 18 lines to check restart signal
- **manifests/system/runner-version.yaml**: ConfigMap manifest

## Testing

1. Deploy ConfigMap: `kubectl apply -f manifests/system/runner-version.yaml`
2. Verify agents start normally
3. Trigger restart: `kubectl patch ...`
4. Verify agents exit gracefully and are replaced

## Effort

S (< 30 minutes) - as estimated in issue #266

Closes #266