### PR TITLE
CRITICAL: Implement emergency kill switch (issue #210)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,6 +536,46 @@ gh pr create --repo pnz1990/agentex ...
 
 ---
 
+## Emergency Procedures
+
+### Kill Switch — Instant Stop of All Agent Spawning
+
+If catastrophic agent proliferation occurs (e.g., > 40 active agents due to a bug in consensus or circuit breaker), activate the emergency kill switch to stop ALL spawning immediately without waiting for code fixes or CI rebuilds:
+
+**Activate kill switch:**
+```bash
+kubectl patch configmap agentex-killswitch -n agentex --type=merge \
+  -p '{"data":{"enabled":"true","reason":"Emergency stop: catastrophic proliferation detected"}}'
+```
+
+**Effect**: All agents check this ConfigMap before spawning. If `enabled=true`, spawn is hard-blocked. Agents will log the reason and exit without successors. The civilization pauses until the kill switch is deactivated.
+
+**Monitor that spawning stopped:**
+```bash
+# Watch agent count - should stop increasing immediately
+watch -n 5 'kubectl get agents.kro.run -n agentex -o json | jq "[.items[] | select(.status.completionTime == null)] | length"'
+```
+
+**After fix deployed (verify new image is running):**
+```bash
+# Check that new image is deployed
+kubectl get pods -n agentex -o jsonpath='{.items[0].spec.containers[0].image}'
+
+# Deactivate kill switch
+kubectl patch configmap agentex-killswitch -n agentex --type=merge \
+  -p '{"data":{"enabled":"false","reason":""}}'
+
+# Manually spawn one agent to restart the civilization
+kubectl apply -f manifests/bootstrap/seed-agent.yaml  # or spawn a specific role
+```
+
+**Bootstrap the ConfigMap** (done once during initial setup):
+```bash
+kubectl apply -f manifests/bootstrap/killswitch.yaml
+```
+
+---
+
 ## Key Invariants (Agents Must Not Violate)
 
 - **ALWAYS spawn a successor Agent CR before exiting** — this is the most important rule

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -431,6 +431,20 @@ should_spawn_agent() {
 spawn_agent() {
   local name="$1" role="$2" task_ref="$3" reason="$4"
   
+  # EMERGENCY KILL SWITCH (issue #210): Instant manual override to stop ALL spawning
+  # This provides a fast emergency brake when catastrophic proliferation occurs,
+  # without waiting 3-5 minutes for code fix + CI build + image deployment.
+  local killswitch_enabled=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" \
+    -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+  
+  if [ "$killswitch_enabled" = "true" ]; then
+    local killswitch_reason=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" \
+      -o jsonpath='{.data.reason}' 2>/dev/null || echo "Emergency stop activated")
+    log "EMERGENCY KILL SWITCH ACTIVE: $killswitch_reason. NOT spawning successor."
+    post_thought "Kill switch active: $killswitch_reason. Agent exiting without spawning successor. Manual intervention required to restart spawning." "blocker" 10
+    return 1  # Hard block - killswitch activated
+  fi
+  
   # GLOBAL CIRCUIT BREAKER (issue #182, #201): Hard limit to prevent catastrophic proliferation
   # Count TOTAL active Agent CRs (without completionTime). If >= 15, BLOCK all spawns.
   # This is a safety mechanism to prevent runaway proliferation that could crash the cluster.
@@ -1036,6 +1050,20 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
 
   # Set agent name to match role (fix for issue #111)
   NEXT_AGENT="${NEXT_ROLE}-${TS}"
+
+  # EMERGENCY KILL SWITCH (issue #210): Check before emergency spawn
+  # This provides instant manual override to stop ALL spawning during emergencies.
+  KILLSWITCH_ENABLED=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" \
+    -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+  
+  if [ "$KILLSWITCH_ENABLED" = "true" ]; then
+    KILLSWITCH_REASON=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" \
+      -o jsonpath='{.data.reason}' 2>/dev/null || echo "Emergency stop activated")
+    log "EMERGENCY KILL SWITCH ACTIVE: $KILLSWITCH_REASON. Blocking emergency spawn."
+    post_thought "Kill switch active: $KILLSWITCH_REASON. Emergency perpetuation blocked. Manual intervention required to restart spawning." "blocker" 10
+    NEEDS_EMERGENCY_SPAWN=false
+    # Continue to reporting - don't exit immediately
+  fi
 
   # CIRCUIT BREAKER (issue #251, #201): Block emergency spawn if system overloaded
   # This prevents emergency perpetuation from bypassing the global circuit breaker.

--- a/manifests/bootstrap/killswitch.yaml
+++ b/manifests/bootstrap/killswitch.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-killswitch
+  namespace: agentex
+  annotations:
+    description: "Emergency kill switch to instantly stop all agent spawning"
+data:
+  enabled: "false"
+  reason: ""
+  # To activate during emergency:
+  # kubectl patch configmap agentex-killswitch -n agentex \
+  #   --type=merge -p '{"data":{"enabled":"true","reason":"Reason for emergency stop"}}'
+  #
+  # To deactivate after fix:
+  # kubectl patch configmap agentex-killswitch -n agentex \
+  #   --type=merge -p '{"data":{"enabled":"false","reason":""}}'


### PR DESCRIPTION
Implements instant manual override to stop ALL agent spawning during emergencies. System has 46+ agents despite fixes. Killswitch provides <10s brake without CI rebuild. S-effort. Fixes #210.