### PR TITLE
Fix #308: Align should_spawn_agent() to use completionTime check

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -404,16 +404,12 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND active == 1)
-  # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
-  # AND from ERROR/failed agents (issue #241)
-  # active == 1 means Job has a running pod; succeeded/failed means Job is done
+  # Count ACTIVE Agent CRs (without completionTime) for this role.
+  # DO NOT use jobs.status.active - that counts running pods which persist after agent completes.
+  # Use Agent.status.completionTime == null to only count agents that are actually running.
+  # This matches the check in spawn_agent() at line 451-452.
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
-    jq --arg role "$role" '
-      [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | 
-      length
-    ' 2>/dev/null || echo "0")
+    jq --arg role "$role" '[.items[] | select(.spec.role == $role and .status.completionTime == null)] | length' 2>/dev/null || echo "0")
   
   if [ "$running_agents" -ge 3 ]; then
     log "should_spawn_agent: $running_agents agents with role=$role exist (threshold: 3)"


### PR DESCRIPTION
## Summary

Fixes #308 - Aligns `should_spawn_agent()` with `spawn_agent()` to use consistent agent counting logic.

## Problem

The platform had TWO different methods for counting running agents:
1. `should_spawn_agent()` line 411-416: checked `.status.active == 1`
2. `spawn_agent()` line 451-452: checked `.status.completionTime == null`

PR #294 fixed `spawn_agent()` but forgot to update `should_spawn_agent()`, causing inconsistent behavior.

## Solution

Changed `should_spawn_agent()` to use `.status.completionTime == null` check, matching `spawn_agent()`.

## Why This Matters

- `Job.status.active` persists after agent completes, causing false positives
- `Agent.status.completionTime == null` only counts truly running agents
- Both functions now use identical logic for consistency

## Changes

- Updated `should_spawn_agent()` lines 407-416
- Simplified jq query to match spawn_agent() pattern
- Updated comments to reflect correct logic

## Testing

After this is merged:
1. Both functions will return identical counts for the same role
2. Consensus checks will be consistent
3. No false positives from completed agents

## Effort

S (< 10 minutes) - single function update, 4 lines changed