### PR TITLE
Add emergency kill switch for instant spawn blocking (issue #210)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1014,6 +1014,16 @@ fi
 if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   log "EMERGENCY PERPETUATION ACTIVATED: $EMERGENCY_REASON"
 
+  # EMERGENCY KILL SWITCH (issue #210): Check if all spawning is disabled
+  KILLSWITCH=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+  if [ "$KILLSWITCH" = "true" ]; then
+    KILLSWITCH_REASON=$(kubectl get configmap agentex-killswitch -n "$NAMESPACE" -o jsonpath='{.data.reason}' 2>/dev/null || echo "unknown")
+    log "EMERGENCY KILL SWITCH ACTIVE: $KILLSWITCH_REASON. NOT spawning successor."
+    post_thought "Kill switch active: $KILLSWITCH_REASON. Agent exiting without spawning successor to stop proliferation." "blocker" 10
+    NEEDS_EMERGENCY_SPAWN=false
+    # Don't exit - let the agent finish reporting
+  fi
+
   TS=$(ts)
   NEXT_TASK="task-continue-${TS}"
 

--- a/manifests/bootstrap/killswitch.yaml
+++ b/manifests/bootstrap/killswitch.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-killswitch
+  namespace: agentex
+data:
+  enabled: "false"
+  reason: ""
+  # To activate emergency kill switch during proliferation:
+  # kubectl patch configmap agentex-killswitch -n agentex \
+  #   --type=merge -p '{"data":{"enabled":"true","reason":"Emergency stop due to agent proliferation"}}'
+  #
+  # To deactivate after fix deployed:
+  # kubectl patch configmap agentex-killswitch -n agentex \
+  #   --type=merge -p '{"data":{"enabled":"false","reason":""}}'


### PR DESCRIPTION
## Summary

Implements instant emergency stop mechanism to halt all agent spawning via ConfigMap (no image rebuild needed during emergencies).

## Changes

1. **entrypoint.sh (lines 1017-1026)**: Added kill switch check at start of emergency perpetuation
2. **manifests/bootstrap/killswitch.yaml**: Bootstrap ConfigMap (disabled by default)

## How It Works

```bash
# To activate during emergency (instant - no image rebuild needed)
kubectl patch configmap agentex-killswitch -n agentex \
  --type=merge -p '{"data":{"enabled":"true","reason":"Emergency stop due to proliferation"}}'

# To deactivate after fix deployed
kubectl patch configmap agentex-killswitch -n agentex \
  --type=merge -p '{"data":{"enabled":"false","reason":""}}'
```

When enabled:
- Agent checks ConfigMap before spawning successor
- Logs reason and posts blocker Thought CR
- Exits without spawning (breaks the chain intentionally)
- Takes effect on next spawn attempt (~10 seconds)

## Why This Is Critical

**Problem:** During proliferation emergencies, we must wait 3-5 minutes for:
1. Code fix merged to main
2. GitHub Actions builds new runner image  
3. New image pushed to ECR
4. New agents pick up fixed image

**Cost:** Issue #201 burned money with 99 agents while waiting for pipeline.

**Solution:** ConfigMap-based kill switch takes effect in ~10 seconds (no CI/CD delay).

## Emergency Scenarios

### Issue #275 (43 pods)
- worker-1773003679 manually broke successor chain to stop proliferation
- With kill switch: human patches ConfigMap, all agents stop spawning

### Issue #201 (99 agents)  
- Waited 3-5 minutes for circuit breaker image to deploy
- With kill switch: instant halt while circuit breaker image builds

## Testing

Tested logic:
- ConfigMap not found → returns "false" (safe default)
- ConfigMap enabled=true → blocks spawn, logs reason, posts Thought
- ConfigMap enabled=false → normal spawning continues

## Related

- Fixes #210 (emergency kill switch)
- Related to #275 (system halt), #201 (99 agents), #164 (122 jobs)
- Complements circuit breaker from #182 (permanent limit vs instant override)

## Effort

S (< 30 minutes)