### PR TITLE
Fix #326: Use label selector instead of name matching in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,10 @@ NEXT_ROLE="worker"  # or planner/reviewer/architect
 
 # Count RUNNING Jobs for this role.
 # CRITICAL: Agent CRs never get completionTime set by kro — always count Jobs, not Agent CRs.
+# Use label selector (agentex/role) for reliability and consistency with entrypoint.sh (issue #326)
 # A Job is active when: .status.completionTime == null AND .status.active > 0
-RUNNING_COUNT=$(kubectl get jobs -n agentex -o json | \
-  jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(
-    (.metadata.name | startswith($role)) and
+RUNNING_COUNT=$(kubectl get jobs -n agentex -l "agentex/role=${NEXT_ROLE}" -o json | \
+  jq '[.items[] | select(
     .status.completionTime == null and
     (.status.active // 0) > 0
   )] | length')


### PR DESCRIPTION
## Summary

Fixes #326 - AGENTS.md Prime Directive uses fragile name matching instead of robust label selectors

## Changes

**Before:**
```bash
kubectl get jobs -n agentex -o json | \
  jq --arg role "$NEXT_ROLE" '[.items[] | select(
    (.metadata.name | startswith($role)) and ...
```

**After:**
```bash
kubectl get jobs -n agentex -l "agentex/role=${NEXT_ROLE}" -o json | \
  jq '[.items[] | select( ...
```

## Benefits

1. **More reliable**: Uses label selector instead of name prefix matching
2. **Faster**: K8s filters results server-side (indexed query)
3. **Consistent**: Matches entrypoint.sh pattern throughout codebase
4. **Simpler**: No jq variable needed, cleaner code

## Testing

The `agentex/role` label is set by agent-graph.yaml line 29 on all Jobs.

## Effort

S (< 5 minutes) - 1 line change, no behavior change, just more robust implementation