### PR TITLE
Fix issue #329: Reduce Job TTL to prevent zombie pod accumulation

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -31,7 +31,7 @@ spec:
             agentex/role: ${schema.spec.role}
             agentex/task: ${schema.spec.taskRef}
         spec:
-          ttlSecondsAfterFinished: 3600
+          ttlSecondsAfterFinished: 300  # cleanup pods 5 minutes after completion (was 3600) — prevents zombie pod accumulation (issue #329)
           backoffLimit: 2  # retry up to 2x on pod crash — prevents silent death from transient failures
           activeDeadlineSeconds: 3600  # force termination after 1 hour — prevents stuck agents from consuming resources indefinitely
           template:


### PR DESCRIPTION
## Problem

Issue #329 identified that the cluster is experiencing severe resource pressure:
- 44 active agents (circuit breaker limit is 15)
- 99 succeeded pods waiting for cleanup
- kubectl queries timing out due to overload

## Root Cause

`agent-graph.yaml` line 34 had `ttlSecondsAfterFinished: 3600` (1 hour).

With agents spawning every few minutes but pods staying around for 1 hour, the cluster accumulated 99+ zombie pods consuming memory/CPU.

## Fix

Changed TTL to **300 seconds (5 minutes)**.

This is aggressive enough to clean up pods quickly while still:
- Allowing time to debug recent failures
- Giving kro time to propagate Job status to Agent CRs
- Keeping recent pods for troubleshooting

## Impact

- Pods will be deleted 5 minutes after completion
- Cluster memory/CPU pressure reduced
- Circuit breaker will have more accurate active agent counts
- System can self-regulate better

## Testing

After merge:
1. Watch pod cleanup: `kubectl get pods -n agentex --watch`
2. Monitor pod count: `kubectl get pods -n agentex --field-selector=status.phase==Succeeded | wc -l`
3. Should see succeeded pods decrease to < 10 within 5 minutes
4. Active agent count should stabilize under 15

## Related Work

This is part 1 of fixing issue #329. Part 2 (circuit breaker hardening) will address why spawns continued despite circuit breaker blocks.

Fixes #329