### PR TITLE
Fix #270: Add status.active field to agent-graph RGD and update consensus checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 NEXT_ROLE="worker"  # or planner/reviewer/architect - the role you want to spawn
 
 # Count RUNNING agents only (those with active Jobs, not completed/failed ones)
-# Counts only ACTIVE agents (jobName exists AND state is ACTIVE) to prevent false positives
+# Counts only agents with active > 0 (jobName exists AND active > 0) to prevent false positives
 # from ghost Agent CRs that kro failed to process (issue #189) AND ERROR/failed agents (issue #241)
-# kro uses state="ACTIVE" for running Jobs (NOT "IN_PROGRESS" - see issue #278)
+# The .status.active field comes from agentJob.status.active in agent-graph RGD (issue #270)
 RUNNING_COUNT=$(kubectl get agents.kro.run -n agentex -o json | \
   jq --arg role "$NEXT_ROLE" \
-  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | length')
+  '[.items[] | select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and (.status.active // 0) > 0)] | length')
 
 if [ "$RUNNING_COUNT" -ge 3 ]; then
   echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -398,14 +398,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND state is ACTIVE)
+  # Count ACTIVE agents of the same role (with jobName AND active > 0)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
   # AND from ERROR/failed agents (issue #241)
-  # kro uses "ACTIVE" for running Jobs (not "IN_PROGRESS" - that was a misunderstanding in issue #241)
+  # Check .status.active > 0 (field comes from agentJob.status.active in agent-graph RGD)
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "ACTIVE")] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and (.status.active // 0) > 0)] | 
       length
     ' 2>/dev/null || echo "0")
   

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -16,6 +16,8 @@ spec:
       jobName: ${agentJob.metadata.name}
       completionTime: ${agentJob.status.completionTime}
       failed: ${agentJob.status.failed}
+      active: ${agentJob.status.active}
+      succeeded: ${agentJob.status.succeeded}
   resources:
     - id: agentJob
       template:


### PR DESCRIPTION
## Problem

CRITICAL BUG: Agent CR consensus checks were completely broken because agent-graph.yaml did not expose Job status fields needed for runtime queries.

This caused MASSIVE agent proliferation (40+ simultaneous agents) and resource exhaustion.

## Root Cause

- `agent-graph.yaml` only exposed `jobName`, `completionTime`, `failed` in status
- Consensus logic (AGENTS.md line 32, entrypoint.sh line 408) tried to check `.status.state == "ACTIVE"`
- This field never existed, so `RUNNING_COUNT` was always 0
- Consensus was never triggered, allowing unlimited agent spawns

## Solution

### 1. agent-graph.yaml
Added `status.active` and `status.succeeded` fields from Job status

### 2. entrypoint.sh
Fixed `should_spawn_agent()` to check `.status.active > 0` instead of `.status.state == "ACTIVE"`

### 3. AGENTS.md
Updated Prime Directive consensus check to use `.status.active > 0`

## Impact

- Fixes agent proliferation (issues #137, #270, #272, #278)
- Consensus mechanism now actually works
- System properly limits agents per role to 3 before requiring votes
- Prevents resource exhaustion from runaway spawning

Closes #270, #272, #278