### PR TITLE
Fix issue #306: use exact line matching in consensus functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,17 +43,21 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
   THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
   
   # Count yes votes for this motion (deduplicate by agentRef to prevent vote stuffing)
+  # Use exact line matching to prevent "spawn-worker" matching "spawn-worker-agents" (issue #306)
   YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+     (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0) and 
+     (.spec.content | contains("VOTE: yes"))) | 
      .spec.agentRef] | unique | length')
   
   # Count no votes for this motion (deduplicate by agentRef to prevent vote stuffing)
+  # Use exact line matching to prevent "spawn-worker" matching "spawn-worker-agents" (issue #306)
   NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
     --arg motion "$MOTION_NAME" \
     '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+     (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0) and 
+     (.spec.content | contains("VOTE: no"))) | 
      .spec.agentRef] | unique | length')
   
   REQUIRED_YES=3
@@ -70,11 +74,11 @@ if [ "$RUNNING_COUNT" -ge 3 ]; then
     # Exit without spawning - let the civilization stabilize
     exit 0
   else
-    # Consensus pending - check if proposal exists
+    # Consensus pending - check if proposal exists (exact match)
     PROPOSAL_EXISTS=$(echo "$THOUGHTS_JSON" | jq -r \
       --arg motion "$MOTION_NAME" \
       '[.items[] | select(.spec.thoughtType == "proposal" and 
-       (.spec.content | contains("MOTION: " + $motion)))] | length')
+       (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0))] | length')
     
     if [ "$PROPOSAL_EXISTS" -eq 0 ]; then
       # Create proposal + vote yes

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -289,10 +289,10 @@ check_consensus() {
   # Get all proposal and vote Thoughts for this motion
   local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Find the proposal
+  # Find the proposal (exact match to prevent "spawn-worker" matching "spawn-worker-agents")
   local proposal=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | contains("MOTION: " + $motion))) | 
+    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0)) | 
      .metadata.name' | head -1)
   
   if [ -z "$proposal" ]; then
@@ -302,24 +302,29 @@ check_consensus() {
   fi
   
   # Count yes and no votes (deduplicate by agentRef to prevent vote stuffing)
+  # Use exact line matching to prevent "spawn-worker" matching "spawn-worker-agents" (issue #306)
   local yes_votes=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: yes"))) | 
+    '[.items[] | select(.spec.thoughtType == "vote" and 
+     (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0) and 
+     (.spec.content | contains("VOTE: yes"))) | 
      .spec.agentRef] | unique | length')
   
   local no_votes=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '[.items[] | select(.spec.thoughtType == "vote" and (.spec.content | contains("MOTION: " + $motion) and contains("VOTE: no"))) | 
+    '[.items[] | select(.spec.thoughtType == "vote" and 
+     (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0) and 
+     (.spec.content | contains("VOTE: no"))) | 
      .spec.agentRef] | unique | length')
   
   log "Consensus check: motion=$motion_name yes=$yes_votes no=$no_votes threshold=$threshold"
   
   # Check if consensus threshold is met
   if [ "$yes_votes" -ge "$required_yes" ]; then
-    # Post verdict Thought if not already posted
+    # Post verdict Thought if not already posted (exact match)
     local existing_verdict=$(echo "$thoughts_json" | jq -r \
       --arg motion "$motion_name" \
-      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | contains("MOTION: " + $motion))) | 
+      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0)) | 
        .metadata.name' | head -1)
     
     if [ -z "$existing_verdict" ]; then
@@ -342,10 +347,10 @@ TALLIED_AT: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   local max_possible_yes=$((yes_votes + remaining_voters))
   
   if [ "$max_possible_yes" -lt "$required_yes" ]; then
-    # Post rejection verdict if not already posted
+    # Post rejection verdict if not already posted (exact match)
     local existing_verdict=$(echo "$thoughts_json" | jq -r \
       --arg motion "$motion_name" \
-      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | contains("MOTION: " + $motion))) | 
+      '.items[] | select(.spec.thoughtType == "verdict" and (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0)) | 
        .metadata.name' | head -1)
     
     if [ -z "$existing_verdict" ]; then
@@ -376,10 +381,10 @@ check_proposal_age() {
   # Get all proposal Thoughts for this motion
   local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Find the proposal and extract its creation timestamp
+  # Find the proposal and extract its creation timestamp (exact match)
   local proposal_time=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | contains("MOTION: " + $motion))) | 
+    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0)) | 
      .metadata.creationTimestamp' | head -1)
   
   if [ -z "$proposal_time" ]; then


### PR DESCRIPTION
## Summary

Implements correct fix for issue #306 with exact line matching to prevent motion name collisions.

## Problem

PRs #313 and #314 both attempted to fix the substring matching bug but both had flaws:
- PR #313: regex with `test("^MOTION: " + $motion + "$"; "m")` doesn't work as expected (multiline mode doesn't anchor properly)
- PR #314: `startswith("MOTION: " + $motion)` still allows substring matches (e.g., "spawn-worker" matches "spawn-worker-agents-extra")

The current code uses `contains()` which causes the original bug:
```bash
(.spec.content | contains("MOTION: " + $motion))
```

This can match wrong motions if names overlap (e.g., "spawn-worker" matches votes for "spawn-worker-agents").

## Solution

Use split/map/select with exact equality:
```bash
(.spec.content | split("\n") | map(select(. == ("MOTION: " + $motion))) | length > 0)
```

This ensures:
1. Content is split by newlines
2. Each line is checked for exact equality with "MOTION: <name>"
3. Returns true only if at least one line matches exactly

## Changes

- `check_consensus()`: Updated all 5 jq queries to use exact matching
- `check_proposal_age()`: Updated to use exact matching
- `AGENTS.md`: Updated inline consensus check to match entrypoint.sh pattern

## Testing

Verified the logic works correctly:
- Exact match: "spawn-worker-agents" matches "MOTION: spawn-worker-agents" ✓
- Substring: "spawn-worker-agents" does NOT match "MOTION: spawn-more-worker-agents" ✓

## Related

- Closes #306
- Closes #313 (duplicate with flawed regex)
- Closes #314 (duplicate with flawed startswith)