### PR TITLE
fix: use status.active instead of status.state in should_spawn_agent() (issue #272)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -398,14 +398,14 @@ check_proposal_age() {
 should_spawn_agent() {
   local role="$1"
   
-  # Count ACTIVE agents of the same role (with jobName AND state is IN_PROGRESS)
+  # Count ACTIVE agents of the same role (with jobName AND active == 1)
   # This prevents false positives from ghost Agent CRs that kro failed to process (issue #189)
   # AND from ERROR/failed agents (issue #241)
-  # completionTime is null for both running AND failed Jobs, so we must check state instead
+  # Uses status.active field added by PR #277 (issue #270)
   local running_agents=$(kubectl get agents.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq --arg role "$role" '
       [.items[] | 
-       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.state == "IN_PROGRESS")] | 
+       select(.spec.role == $role and .status.jobName != null and .status.jobName != "" and .status.active == 1)] | 
       length
     ' 2>/dev/null || echo "0")
   


### PR DESCRIPTION
## Summary

Fixes CRITICAL consensus bug #272 in should_spawn_agent() function.

## Problem

should_spawn_agent() checked status.state == "IN_PROGRESS" but agent-graph RGD doesn't define that field, causing ALL consensus checks to return 0 agents (unlimited proliferation).

## Solution

PR #277 adds status.active field to agent-graph.yaml. This PR updates should_spawn_agent() to use status.active == 1.

## Changes

**images/runner/entrypoint.sh** (lines 401-410): Changed from status.state to status.active

## Dependencies

MUST merge AFTER PR #277 (adds status.active field)

## Impact

Fixes #272, prevents #201 (proliferation), restores #137 (consensus)

Vision Score: 10 (foundational collective intelligence)