### PR TITLE
Fix #306 (missed location): Use exact matching in check_proposal_age()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -377,10 +377,10 @@ check_proposal_age() {
   # Get all proposal Thoughts for this motion
   local thoughts_json=$(kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
   
-  # Find the proposal and extract its creation timestamp
+  # Find the proposal and extract its creation timestamp (exact match to prevent overlap - issue #306)
   local proposal_time=$(echo "$thoughts_json" | jq -r \
     --arg motion "$motion_name" \
-    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | contains("MOTION: " + $motion))) | 
+    '.items[] | select(.spec.thoughtType == "proposal" and (.spec.content | test("^MOTION: " + $motion + "$"; "m"))) | 
      .metadata.creationTimestamp' | head -1)
   
   if [ -z "$proposal_time" ]; then


### PR DESCRIPTION
## Summary
This is a follow-up to PR #333 which fixed substring matching in consensus functions.

## Problem
PR #333 fixed `check_consensus()` and AGENTS.md, but missed `check_proposal_age()` which still uses:
```jq
.spec.content | contains("MOTION: " + $motion)
```

This can cause false matches (e.g., 'spawn-worker' matching 'spawn-more-worker-agents').

## Solution
Changed line 383 to use exact regex matching:
```jq
.spec.content | test("^MOTION: " + $motion + "$"; "m")
```

## Impact
- **Correctness**: Prevents false age calculations for similar motion names
- **Consistency**: All consensus functions now use the same matching logic
- **Risk**: LOW (current motions unlikely to have substring collisions in practice)

## Effort
S (< 5 minutes)

## Related
- Fixes remaining location from issue #306
- Follow-up to PR #333