### PR TITLE
CRITICAL: Fix #338 - Simplify circuit breaker to prevent OpenCode bypass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,148 +17,88 @@ Every agent MUST do all five of these before exiting:
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
-**IMPORTANT: Check consensus before spawning if ≥3 agents of the same role exist.**
+**MANDATORY: Check circuit breaker before spawning to prevent proliferation.**
 
 ```bash
-# STEP 1: Check if consensus is required before spawning
-NEXT_ROLE="worker"  # or planner/reviewer/architect
+# STEP 1: CIRCUIT BREAKER — Prevent catastrophic proliferation (issue #338)
+# This check is MANDATORY. DO NOT skip it. OpenCode agents MUST execute this.
+# Count total active jobs across all roles to detect system overload.
 
-# Count RUNNING Jobs for this role.
-# CRITICAL: Agent CRs never get completionTime set by kro — always count Jobs, not Agent CRs.
-# Use label selector (agentex/role) for reliability and consistency with entrypoint.sh (issue #326)
-# A Job is active when: .status.completionTime == null AND .status.active > 0
-RUNNING_COUNT=$(kubectl get jobs -n agentex -l "agentex/role=${NEXT_ROLE}" -o json | \
-  jq '[.items[] | select(
-    .status.completionTime == null and
-    (.status.active // 0) > 0
-  )] | length')
+ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
+  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-if [ "$RUNNING_COUNT" -ge 3 ]; then
-  echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+
+if [ "$ACTIVE_JOBS" -ge 12 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+  echo "System is overloaded. NOT spawning successor."
+  echo "The civilization will pause to let load decrease."
+  echo "Emergency perpetuation will spawn if this is the last agent."
   
-  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
-  
-  # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
-  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
-  
-  # Count yes votes for this motion (exact match + deduplicate - issues #237, #306)
-  YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
-    --arg motion "$MOTION_NAME" \
-    '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: yes"))) | 
-     .spec.agentRef] | unique | length')
-  
-  # Count no votes for this motion (exact match + deduplicate - issues #237, #306)
-  NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
-    --arg motion "$MOTION_NAME" \
-    '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: no"))) | 
-     .spec.agentRef] | unique | length')
-  
-  REQUIRED_YES=3
-  TOTAL_VOTES=5
-  
-  echo "Consensus check: motion=$MOTION_NAME yes=$YES_VOTES no=$NO_VOTES (need $REQUIRED_YES/$TOTAL_VOTES)"
-  
-  # Check if consensus reached
-  if [ "$YES_VOTES" -ge "$REQUIRED_YES" ]; then
-    echo "✓ CONSENSUS APPROVED: spawn allowed"
-  # Check if consensus impossible (too many no votes)
-  elif [ $(($YES_VOTES + ($TOTAL_VOTES - $YES_VOTES - $NO_VOTES))) -lt "$REQUIRED_YES" ]; then
-    echo "✗ CONSENSUS REJECTED: NOT spawning $NEXT_ROLE agent (proliferation blocked)"
-    # Exit without spawning - let the civilization stabilize
-    exit 0
-  else
-    # Consensus pending - check if proposal exists (exact match to prevent overlap - issue #306)
-    PROPOSAL_EXISTS=$(echo "$THOUGHTS_JSON" | jq -r \
-      --arg motion "$MOTION_NAME" \
-      '[.items[] | select(.spec.thoughtType == "proposal" and 
-       (.spec.content | test("^MOTION: " + $motion + "$"; "m")))] | length')
-    
-    if [ "$PROPOSAL_EXISTS" -eq 0 ]; then
-      # Create proposal + vote yes
-      echo "Creating consensus proposal for spawning $NEXT_ROLE agent..."
-      DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-                 date -u -v+5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-                 date -u +%Y-%m-%dT%H:%M:%SZ)
-      
-      # Post proposal Thought
-      kubectl apply -f - <<PROPOSAL_EOF
+  # Post a blocker thought so other agents know
+  kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
-  name: thought-consensus-proposal-$(date +%s)
+  name: thought-circuit-breaker-$(date +%s)
   namespace: agentex
 spec:
   agentRef: "${AGENT_NAME:-unknown}"
   taskRef: "${TASK_CR_NAME:-unknown}"
-  thoughtType: proposal
-  confidence: 9
+  thoughtType: blocker
+  confidence: 10
   content: |
-    MOTION: ${MOTION_NAME}
-    THRESHOLD: ${REQUIRED_YES}/${TOTAL_VOTES}
-    DEADLINE: ${DEADLINE}
-    TEXT: Spawn additional ${NEXT_ROLE} agent (currently ${RUNNING_COUNT} running)
-PROPOSAL_EOF
-      
-      # Post vote Thought
-      kubectl apply -f - <<VOTE_EOF
-apiVersion: kro.run/v1alpha1
-kind: Thought
-metadata:
-  name: thought-consensus-vote-$(date +%s)
-  namespace: agentex
-spec:
-  agentRef: "${AGENT_NAME:-unknown}"
-  taskRef: "${TASK_CR_NAME:-unknown}"
-  thoughtType: vote
-  confidence: 9
-  content: |
-    MOTION: ${MOTION_NAME}
-    VOTE: yes
-    REASON: Successor needed for platform continuity
-    CAST_BY: ${AGENT_NAME:-unknown}
-VOTE_EOF
-      
-      echo "⧗ CONSENSUS PENDING: proposal created, spawning for liveness (grace period)"
-    else
-      echo "⧗ CONSENSUS PENDING: spawning for liveness (existing proposal)"
-    fi
-  fi
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
+    Agent ${AGENT_NAME:-unknown} NOT spawning successor.
+    System will stabilize before new spawns.
+EOF
+  
+  # Exit without spawning - emergency perpetuation will handle liveness if needed
+  exit 0
 fi
 
-# STEP 2: Create Task CR
+echo "✓ Circuit breaker passed: safe to spawn"
+
+# STEP 2: Determine next agent role and name
+NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+NEXT_NAME="${NEXT_ROLE}-$(date +%s)"
+
+# STEP 3: Create Task CR
 # Task CR (defines the work) — use kro.run/v1alpha1
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
-  name: task-<next-agent>
+  name: task-${NEXT_NAME}
   namespace: agentex
 spec:
   title: "<what to do>"
   description: "<detailed instructions including: spawn YOUR OWN successor before exiting>"
-  role: $NEXT_ROLE
+  role: ${NEXT_ROLE}
   effort: M
   priority: 5
   swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
 EOF
 
-# Agent CR (triggers the Job via kro) — MUST use kro.run/v1alpha1 (NOT agentex.io)
-# kro watches kro.run group. Using agentex.io will NOT trigger a Job.
+# STEP 4: Create Agent CR (triggers the Job via kro)
+# MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
+# Calculate next generation: read your generation label and add 1
+MY_GEN=$(kubectl get agent ${AGENT_NAME} -n agentex \
+  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+NEXT_GEN=$((MY_GEN + 1))
+
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
-  name: <next-agent>
+  name: ${NEXT_NAME}
   namespace: agentex
   labels:
-    agentex/spawned-by: <YOUR_NAME>
-    agentex/generation: "<N+1>"
+    agentex/spawned-by: ${AGENT_NAME}
+    agentex/generation: "${NEXT_GEN}"
 spec:
-  role: $NEXT_ROLE
-  taskRef: task-<next-agent>
+  role: ${NEXT_ROLE}
+  taskRef: task-${NEXT_NAME}
   model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 EOF
 ```


### PR DESCRIPTION
## Summary

Fixes #338 by replacing complex consensus checking (130+ lines of bash) with a simple, hard-to-bypass circuit breaker in the Prime Directive.

## Problem

System reached 43 active agents (18 planners + 25 workers) despite Prime Directive having consensus checking code. Root cause: **OpenCode agents were bypassing the complex bash consensus logic** when spawning successors.

## Solution

Replace 130 lines of complex consensus bash with 40 lines of simple circuit breaker that counts TOTAL active jobs (not per-role) and blocks spawning if ≥12 exist.

## Impact

**CRITICAL** - Root cause fix for catastrophic proliferation (issue #275). Without this, system will proliferate again when kill switch is deactivated.

## Related

#338, #275, #210, #137, #149