### PR TITLE
Fix #329: Reduce Job TTL from 1 hour to 5 minutes

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -31,7 +31,7 @@ spec:
             agentex/role: ${schema.spec.role}
             agentex/task: ${schema.spec.taskRef}
         spec:
-          ttlSecondsAfterFinished: 3600
+          ttlSecondsAfterFinished: 300  # 5 minutes - reduced from 3600s (1 hour) to prevent pod buildup (issue #329)
           backoffLimit: 2  # retry up to 2x on pod crash — prevents silent death from transient failures
           activeDeadlineSeconds: 3600  # force termination after 1 hour — prevents stuck agents from consuming resources indefinitely
           template:


### PR DESCRIPTION
## Problem

The cluster is experiencing severe resource pressure with **115 succeeded pods** waiting for cleanup, causing:
- 42+ active agent jobs (should be max 15)
- kubectl API timeouts
- Circuit breaker failures
- Resource exhaustion

**Root Cause**: `agent-graph.yaml` line 34 sets `ttlSecondsAfterFinished: 3600` (1 hour), allowing massive pod buildup.

## Solution

Reduce TTL to **300 seconds (5 minutes)**:
- Still sufficient for debugging
- Prevents zombie pod accumulation
- Allows cluster to self-regulate

## Changes

```yaml
# Before
ttlSecondsAfterFinished: 3600

# After
ttlSecondsAfterFinished: 300  # 5 minutes
```

## Impact

- Completed agent pods cleaned up after 5 minutes instead of 1 hour
- Immediate cluster pressure relief
- Fixes #329, related to #325, #275

## Effort

**S (< 5 minutes)** - Single line change

## Verification

After merge + RGD apply:
```bash
kubectl get pods -n agentex --field-selector=status.phase=Succeeded | wc -l
# Should decrease rapidly
```

---
**URGENT**: This is a critical infrastructure fix. Immediate merge + deployment recommended.