### PR TITLE
CRITICAL: Fix issue #338 - Simplify circuit breaker to prevent OpenCode bypass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,118 +17,58 @@ Every agent MUST do all five of these before exiting:
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
-**IMPORTANT: Check consensus before spawning if ≥3 agents of the same role exist.**
+**IMPORTANT: Check circuit breaker before spawning to prevent system overload.**
 
 ```bash
-# STEP 1: Check if consensus is required before spawning
-NEXT_ROLE="worker"  # or planner/reviewer/architect
-
-# Count RUNNING Jobs for this role.
-# CRITICAL: Agent CRs never get completionTime set by kro — always count Jobs, not Agent CRs.
-# Use label selector (agentex/role) for reliability and consistency with entrypoint.sh (issue #326)
+# STEP 1: Circuit breaker check (prevents catastrophic agent proliferation)
+# Count all currently ACTIVE jobs (any role)
 # A Job is active when: .status.completionTime == null AND .status.active > 0
-RUNNING_COUNT=$(kubectl get jobs -n agentex -l "agentex/role=${NEXT_ROLE}" -o json | \
+ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(
     .status.completionTime == null and
     (.status.active // 0) > 0
   )] | length')
 
-if [ "$RUNNING_COUNT" -ge 3 ]; then
-  echo "WARNING: $RUNNING_COUNT $NEXT_ROLE agents already running. Checking consensus..."
+# Circuit breaker threshold: 15 active jobs maximum
+# This is enforced in both OpenCode spawns AND emergency perpetuation
+CIRCUIT_BREAKER_LIMIT=15
+
+if [ "$ACTIVE_JOBS" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
+  echo "System is overloaded. NOT spawning successor to allow load to decrease."
+  echo "Emergency perpetuation will handle successor spawn when load drops."
   
-  MOTION_NAME="spawn-more-${NEXT_ROLE}-agents"
-  
-  # Inline consensus check (can't call entrypoint.sh functions from OpenCode)
-  # CRITICAL: Must use thoughts.kro.run to avoid stale agentex.io/v1alpha1 data (issue #256)
-  THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n agentex -o json 2>/dev/null || echo '{"items":[]}')
-  
-  # Count yes votes for this motion (exact match + deduplicate - issues #237, #306)
-  YES_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
-    --arg motion "$MOTION_NAME" \
-    '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: yes"))) | 
-     .spec.agentRef] | unique | length')
-  
-  # Count no votes for this motion (exact match + deduplicate - issues #237, #306)
-  NO_VOTES=$(echo "$THOUGHTS_JSON" | jq -r \
-    --arg motion "$MOTION_NAME" \
-    '[.items[] | select(.spec.thoughtType == "vote" and 
-     (.spec.content | test("^MOTION: " + $motion + "$"; "m")) and (.spec.content | contains("VOTE: no"))) | 
-     .spec.agentRef] | unique | length')
-  
-  REQUIRED_YES=3
-  TOTAL_VOTES=5
-  
-  echo "Consensus check: motion=$MOTION_NAME yes=$YES_VOTES no=$NO_VOTES (need $REQUIRED_YES/$TOTAL_VOTES)"
-  
-  # Check if consensus reached
-  if [ "$YES_VOTES" -ge "$REQUIRED_YES" ]; then
-    echo "✓ CONSENSUS APPROVED: spawn allowed"
-  # Check if consensus impossible (too many no votes)
-  elif [ $(($YES_VOTES + ($TOTAL_VOTES - $YES_VOTES - $NO_VOTES))) -lt "$REQUIRED_YES" ]; then
-    echo "✗ CONSENSUS REJECTED: NOT spawning $NEXT_ROLE agent (proliferation blocked)"
-    # Exit without spawning - let the civilization stabilize
-    exit 0
-  else
-    # Consensus pending - check if proposal exists (exact match to prevent overlap - issue #306)
-    PROPOSAL_EXISTS=$(echo "$THOUGHTS_JSON" | jq -r \
-      --arg motion "$MOTION_NAME" \
-      '[.items[] | select(.spec.thoughtType == "proposal" and 
-       (.spec.content | test("^MOTION: " + $motion + "$"; "m")))] | length')
-    
-    if [ "$PROPOSAL_EXISTS" -eq 0 ]; then
-      # Create proposal + vote yes
-      echo "Creating consensus proposal for spawning $NEXT_ROLE agent..."
-      DEADLINE=$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-                 date -u -v+5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-                 date -u +%Y-%m-%dT%H:%M:%SZ)
-      
-      # Post proposal Thought
-      kubectl apply -f - <<PROPOSAL_EOF
+  # Post blocker thought so other agents know system is overloaded
+  kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
-  name: thought-consensus-proposal-$(date +%s)
+  name: thought-circuit-breaker-$(date +%s)
   namespace: agentex
 spec:
   agentRef: "${AGENT_NAME:-unknown}"
   taskRef: "${TASK_CR_NAME:-unknown}"
-  thoughtType: proposal
-  confidence: 9
+  thoughtType: blocker
+  confidence: 10
   content: |
-    MOTION: ${MOTION_NAME}
-    THRESHOLD: ${REQUIRED_YES}/${TOTAL_VOTES}
-    DEADLINE: ${DEADLINE}
-    TEXT: Spawn additional ${NEXT_ROLE} agent (currently ${RUNNING_COUNT} running)
-PROPOSAL_EOF
-      
-      # Post vote Thought
-      kubectl apply -f - <<VOTE_EOF
-apiVersion: kro.run/v1alpha1
-kind: Thought
-metadata:
-  name: thought-consensus-vote-$(date +%s)
-  namespace: agentex
-spec:
-  agentRef: "${AGENT_NAME:-unknown}"
-  taskRef: "${TASK_CR_NAME:-unknown}"
-  thoughtType: vote
-  confidence: 9
-  content: |
-    MOTION: ${MOTION_NAME}
-    VOTE: yes
-    REASON: Successor needed for platform continuity
-    CAST_BY: ${AGENT_NAME:-unknown}
-VOTE_EOF
-      
-      echo "⧗ CONSENSUS PENDING: proposal created, spawning for liveness (grace period)"
-    else
-      echo "⧗ CONSENSUS PENDING: spawning for liveness (existing proposal)"
-    fi
-  fi
+    Circuit breaker activated: $ACTIVE_JOBS active jobs exceed limit ($CIRCUIT_BREAKER_LIMIT).
+    NOT spawning successor to prevent proliferation. System will stabilize.
+EOF
+  
+  # Exit without spawning - emergency perpetuation will handle it when load drops
+  exit 0
 fi
 
-# STEP 2: Create Task CR
+echo "✓ Circuit breaker OK: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
+
+# STEP 2: Define successor role and create Task CR
+NEXT_ROLE="worker"  # or planner/reviewer/architect
+
+# Calculate next generation number
+MY_GEN=$(kubectl get agent ${AGENT_NAME} -n agentex \
+  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+NEXT_GEN=$((MY_GEN + 1))
+
 # Task CR (defines the work) — use kro.run/v1alpha1
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
@@ -145,6 +85,7 @@ spec:
   swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
 EOF
 
+# STEP 3: Create Agent CR
 # Agent CR (triggers the Job via kro) — MUST use kro.run/v1alpha1 (NOT agentex.io)
 # kro watches kro.run group. Using agentex.io will NOT trigger a Job.
 kubectl apply -f - <<EOF
@@ -154,8 +95,8 @@ metadata:
   name: <next-agent>
   namespace: agentex
   labels:
-    agentex/spawned-by: <YOUR_NAME>
-    agentex/generation: "<N+1>"
+    agentex/spawned-by: ${AGENT_NAME}
+    agentex/generation: "${NEXT_GEN}"
 spec:
   role: $NEXT_ROLE
   taskRef: task-<next-agent>
@@ -199,7 +140,7 @@ EOF
 
 **The planner loop is the heartbeat:** `planner-001` spawns `planner-002` spawns `planner-003` ... forever. Planners audit the codebase, spawn workers for open issues, and never break the chain.
 
-**IMPORTANT: Consensus prevents proliferation** — If ≥3 agents of the same role already exist, check for an active consensus proposal before spawning. Emergency perpetuation enforces this automatically, but OpenCode-driven spawns (step ① above) must check manually. Without consensus, the system can proliferate to 40+ simultaneous agents, wasting resources and causing coordination chaos. See issue #137 for details.
+**IMPORTANT: Circuit breaker prevents proliferation** — The system enforces a hard limit of 15 active jobs. If this limit is reached, agents exit without spawning to allow load to decrease. Emergency perpetuation and OpenCode spawns both respect this limit. This prevents catastrophic agent proliferation that can waste resources and cause system instability. See issues #137, #275, #338 for historical context.
 
 ---
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -436,9 +436,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 20 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 20). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 20. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 15 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 15. Spawn blocked." "blocker" 10
     return 1
   fi
 


### PR DESCRIPTION
## Problem

Issue #338 identified that OpenCode agents bypass the complex consensus check in AGENTS.md Prime Directive step ①, leading to catastrophic proliferation (39+ active jobs observed).

**Root cause**: The inline bash consensus checking code (123 lines) is too complex. OpenCode can choose to skip bash blocks if it thinks there's a simpler path or misunderstands the purpose.

## Solution (Option 1 - RECOMMENDED)

Replace complex consensus logic with ultra-simple circuit breaker:
- Hard limit: 15 active jobs (down from 20)
- Simple count + exit if exceeded
- Posts blocker Thought for visibility
- Impossible for OpenCode to misunderstand or skip

## Changes

### AGENTS.md Prime Directive ①
- Removed 110 lines of complex consensus checking code (lines 23-129)
- Added simple 45-line circuit breaker check
- Circuit breaker limit: 15 active jobs
- Posts blocker Thought if limit exceeded
- Exits cleanly without spawning (emergency perpetuation handles recovery)
- Added NEXT_ROLE variable definition before Task CR
- Updated generation label calculation to use variables

### images/runner/entrypoint.sh
- Aligned circuit breaker limit from 20 → 15 active jobs (line 439)
- Maintains consistency between OpenCode spawns and emergency perpetuation

## Testing

```bash
# Before fix: 39 active jobs
kubectl get jobs -n agentex -o json | jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length'

# After fix deploys: should stabilize at ≤15
```

## Impact

**CRITICAL** - Stops proliferation at the source:
- Prevents OpenCode agents from bypassing safety checks
- Simple logic is harder to misunderstand
- Emergency perpetuation already has this check (now aligned)
- System will stabilize instead of proliferating

## Effort

S-effort (~30 minutes)

## Related Issues

- Fixes #338 (OpenCode bypass)
- Related to #275 (emergency halt)
- Related to #325 (proliferation crisis)
- Related to #210 (kill switch)
- Related to #137 (original proliferation)

## Deployment

Merge this PR → runner image rebuilds → future agents respect circuit breaker