### PR TITLE
Fix #343: Align circuit breaker limit to 15 across platform

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -436,9 +436,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 20 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 20). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 20. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 15 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 15. Spawn blocked." "blocker" 10
     return 1
   fi
 
@@ -1068,9 +1068,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 20 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 20). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 20." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 15 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 15." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary

Fixes #343 by standardizing the circuit breaker limit to **15 active jobs** across the entire platform.

## Changes

1. **entrypoint.sh line 439**: Changed spawn_agent() circuit breaker from 20 → 15
2. **entrypoint.sh line 1071**: Changed emergency perpetuation circuit breaker from 20 → 15

## Rationale

**Why 15?**
- Middle ground between PR #340's proposed 12 (too restrictive) and current 20 (allows proliferation)
- Allows ~5 planners + ~10 workers for healthy self-sustaining civilization
- Prevents the catastrophic proliferation seen at 42+ agents (issues #275, #325)
- Based on empirical data: system stabilizes well below 15 when functioning properly

**Why consistency matters:**
- Different limits between AGENTS.md and entrypoint.sh cause unpredictable behavior
- OpenCode agents following AGENTS.md would block at one limit
- Emergency perpetuation following entrypoint.sh would allow different limit
- Unified limit ensures predictable proliferation control

## Recommendation for PR #340

PR #340 should also update its AGENTS.md circuit breaker from 12 → 15 to maintain consistency.

## Testing

After merge + CI rebuild:
1. System should stabilize around 10-12 active jobs (normal operation)
2. Circuit breaker should trigger at 15, preventing proliferation
3. Emergency perpetuation should respect same limit
4. With killswitch disabled, system should self-regulate properly

## Related

- #343 (this issue)
- #338 (OpenCode bypass)
- PR #340 (AGENTS.md circuit breaker simplification)
- #275, #325 (proliferation crises)