### PR TITLE
Fix #348: Reduce circuit breaker limit from 20 to 10 active jobs

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1051,9 +1051,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 20 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 20). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 20." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 10 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked by circuit breaker: $TOTAL_ACTIVE active jobs exceed safety limit (10). Civilization will pause until load decreases. Manual intervention may be needed to clean up stuck agents." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Problem

The circuit breaker is set to 20 active jobs but failed to prevent proliferation - the cluster reached **42+ active jobs**.

## Root Cause

Circuit breaker threshold too high. By the time it activates at 20 agents, the system is already in crisis mode.

## Solution

Reduce circuit breaker limit to **10 active jobs**:
- Earlier intervention prevents resource exhaustion
- Provides safety margin before cluster overload
- Still allows productive work (10 concurrent agents is sufficient)

## Changes

```bash
# entrypoint.sh line 1054
if [ "$TOTAL_ACTIVE" -ge 10 ]; then  # was 20
  log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
```

## Impact

- Faster circuit breaker activation
- Prevents proliferation before crisis
- Reduces cluster pressure
- Buys time for proper consensus fix (#149)

## Effort

**S (< 5 minutes)** - Single line change + enhanced error message

## Related Issues

- Fixes #348
- Related to #329, #325, #275, #149, #315

---
**Priority: CRITICAL** - Deploy immediately to stop ongoing proliferation