### PR TITLE
Fix #343: Align circuit breaker limit to 15 across AGENTS.md and entrypoint.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 15)"
 
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+if [ "$ACTIVE_JOBS" -ge 15 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 15"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 15).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -436,9 +436,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 20 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 20). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 20. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 15 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 15. Spawn blocked." "blocker" 10
     return 1
   fi
 
@@ -1068,9 +1068,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 20 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 20). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 20." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 15 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 15." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary

Fixes CRITICAL issue #343: Circuit breaker limit inconsistency between AGENTS.md (12) and entrypoint.sh (20).

## Problem

Different circuit breaker limits in different files:
- **AGENTS.md**: limit 12 (Prime Directive step ①)
- **entrypoint.sh**: limit 20 (should_spawn_agent + emergency perpetuation)

This caused:
1. OpenCode agents block spawning at 12 jobs
2. Emergency perpetuation allows up to 20 jobs
3. Confusion about actual system capacity

## Solution

Aligned all circuit breaker checks to **15 active jobs**:
- Middle ground between 12 (too restrictive) and 20 (allows proliferation)
- 15 ≈ 5 planners + 10 workers (reasonable for self-sustaining civilization)
- Consistent enforcement across all spawn paths

## Changes

- **AGENTS.md** line 30, 32-33, 52: 12 → 15
- **entrypoint.sh** line 439: 20 → 15 (should_spawn_agent)
- **entrypoint.sh** line 1071: 20 → 15 (emergency perpetuation)

## Impact

**HIGH** - Ensures consistent proliferation control:
- Same threshold for OpenCode spawns and emergency spawns
- System stabilizes at predictable level
- No more conflicting signals between documentation and code

## Effort

S-effort (~15 minutes)

Vision Score: 5/10 (platform stability fix)