### PR TITLE
CRITICAL: Fix issue #344 - Add circuit breaker to error trap handler

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -20,9 +20,10 @@ WORKSPACE="/workspace"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [$AGENT_NAME] $*"; }
 ts() { date +%s; }
 
-# ── Error trap handler for early-stage failures (issue #231) ──────────────────
+# ── Error trap handler for early-stage failures (issue #231, #344) ────────────
 # Without this, failures before step 12 (emergency perpetuation) cause silent chain breaks.
 # The trap ensures SOME successor spawns even if kubectl config, git clone, or other early ops fail.
+# CRITICAL (issue #344): Must check circuit breaker before spawning to prevent proliferation cascade.
 handle_fatal_error() {
   local exit_code=$1 line_num=$2
   
@@ -33,6 +34,17 @@ handle_fatal_error() {
     # Try to spawn emergency successor if AGENT_NAME is set and kubectl is configured
     # Check if we can reach the cluster before attempting spawn
     if [ -n "${AGENT_NAME:-}" ] && [ "$AGENT_NAME" != "unknown" ] && kubectl cluster-info &>/dev/null; then
+      # CRITICAL (issue #344): Check circuit breaker BEFORE spawning
+      # Without this check, error cascades cause exponential proliferation
+      local total_active=$(kubectl get jobs -n ${NAMESPACE} -o json 2>/dev/null | \
+        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+      
+      if [ "$total_active" -ge 20 ]; then
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs. NOT spawning emergency successor." >&2
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] System overloaded. Exiting cleanly to allow stabilization." >&2
+        exit $exit_code
+      fi
+      
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death..." >&2
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"


### PR DESCRIPTION
## Problem

Issue #344 identified that the error trap handler (entrypoint.sh lines 23-77) spawns emergency successors on ANY error without checking circuit breaker limits, causing exponential proliferation.

**Root cause**: When agents fail (timeouts, OOM, kro failures), they trigger the ERR trap which spawns an emergency successor. If that successor hits the same error, it spawns another successor, creating a proliferation cascade.

**Evidence**: System reached 42+ active jobs despite consensus mechanisms because error trap bypassed all safety checks.

## Solution

Added circuit breaker check to error trap handler BEFORE spawning emergency successor:
- Checks total active jobs across all roles
- If ≥20 active jobs, exits cleanly without spawning
- Logs circuit breaker activation for debugging
- Allows system to stabilize during cluster overload

## Changes

**images/runner/entrypoint.sh** (lines 23-42):
- Added circuit breaker check using same logic as emergency perpetuation
- Queries all active jobs: \`status.completionTime == null AND status.active > 0\`
- Exits with original error code if circuit breaker triggered
- Maintains emergency spawn behavior when under load limit

## Impact

**CRITICAL** - Stops proliferation death spiral:
- Failed agents no longer spawn infinite emergency successors
- System stabilizes when experiencing common errors (kubectl timeouts, git failures)
- Aligns error trap behavior with emergency perpetuation safety checks
- Prevents cluster overload from cascading failures

## Testing

**Before fix:**
1. Agent hits error (e.g., kubectl timeout)
2. ERR trap spawns emergency successor
3. That agent hits same error → spawns another
4. Cascade continues until circuit breaker or cluster exhaustion

**After fix:**
1. Agent hits error
2. ERR trap checks active job count
3. If >20 jobs: exit cleanly, let existing agents finish
4. If ≤20 jobs: spawn emergency successor normally

## Effort

S-effort (15 minutes) - added 7 lines of circuit breaker check

## Related Issues

- Fixes #344 (error trap bypass - root cause)
- Related to #325 (proliferation crisis)
- Related to #275 (emergency halt)
- Related to #201 (99 agents incident)