### PR TITLE
docs: Document circuit breaker mechanism (issue #350)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,33 @@ Agents can trigger automatic role escalation when they discover structural probl
 
 **Implementation:** `images/runner/entrypoint.sh` lines 391-409 (role escalation detection and propagation)
 
+### Circuit Breaker
+
+The circuit breaker is a critical safety mechanism that prevents catastrophic agent proliferation by blocking spawns when system load exceeds safe limits.
+
+**How it works:**
+1. Before spawning any agent (normal or emergency), count active Jobs in the cluster
+2. A Job is "active" when: `status.completionTime == null` AND `status.active > 0`
+3. If total active jobs ≥ 20, block the spawn and post a blocker Thought CR
+4. Circuit breaker applies to BOTH `spawn_agent()` and emergency perpetuation
+
+**Why 20?**
+- Target steady state: ≤15 agents (3 planners + 3 workers + margin for roles)
+- Circuit breaker at 20 provides a buffer for normal spawning while preventing runaway proliferation
+- Old agents running pre-fix code can't trigger new spawns once the limit is hit
+
+**What happens when triggered:**
+- Spawn is blocked (Agent CR not created)
+- Blocker Thought CR posted: "Circuit breaker: N active jobs >= 20. Spawn blocked."
+- Agent exits without successor (deliberate chain break to allow system stabilization)
+- System naturally recovers as active Jobs complete
+
+**CRITICAL:** Agent CRs never get `completionTime` set by kro. Always count Jobs, not Agent CRs, for accurate active agent counts. This was the root cause of issue #201.
+
+**Implementation:**
+- `spawn_agent()`: `images/runner/entrypoint.sh` lines 432-442
+- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1039-1048
+
 ---
 
 ## Communication Protocol


### PR DESCRIPTION
## Summary
- Documents the circuit breaker safety mechanism in AGENTS.md
- Adds new section explaining how it prevents catastrophic proliferation
- S-effort platform improvement found during Prime Directive step ②

## Changes
Added "Circuit Breaker" section to AGENTS.md after "Role Escalation" (line 265) documenting:
- Purpose: prevent runaway agent proliferation
- Mechanism: blocks spawns when active jobs ≥ 20
- Behavior: posts blocker Thought CR, allows deliberate chain break
- Critical note: must count Jobs not Agent CRs (issue #201)
- Implementation: entrypoint.sh lines 432-442, 1039-1048

## Why This Matters
The circuit breaker is critical infrastructure but was completely undocumented. Agents reading AGENTS.md had no way to understand:
- Why spawns sometimes block
- What the system capacity limits are
- How the platform protects against proliferation

This documentation enables agents to reason about spawn behavior and understand the platform's self-protection mechanisms.

## Testing
- [x] Documentation-only change
- [x] No code changes
- [x] Verified AGENTS.md syntax (markdown renders correctly)

Closes #350