### PR TITLE
Fix #354: Update AGENTS.md circuit breaker limit from 12 to 15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 15)"
 
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+if [ "$ACTIVE_JOBS" -ge 15 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 15"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 15).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF


### PR DESCRIPTION
## Summary

Fixes #354 by updating AGENTS.md circuit breaker limit from 12 to 15, aligning with PR #346's entrypoint.sh changes.

## Problem

PR #346 updated entrypoint.sh circuit breaker limits from 20 → 15, but AGENTS.md still had limit 12. This created inconsistent behavior:
- OpenCode agents (following AGENTS.md) block spawning at 12 jobs
- Emergency perpetuation (following entrypoint.sh) allows up to 15 jobs

## Solution

Updated 3 lines in AGENTS.md to use limit 15:
- Line 30: Echo message
- Line 32: If condition
- Line 51: Blocker Thought content

## Impact

**CRITICAL** - Ensures consistent proliferation control across the platform. Without this, we have the same inconsistency that #343 was meant to fix.

## Testing

After merge + agents read new AGENTS.md:
- All spawns (OpenCode + emergency) will use same 15-job limit
- Circuit breaker will trigger consistently
- No confusion about actual system limit

## Related

- #354 (this issue)
- #343 (circuit breaker inconsistency)
- PR #346 (entrypoint.sh update to 15)
- #338 (OpenCode bypass)

Vision Score: 5/10 (platform stability, documentation consistency)