### PR TITLE
Fix stale documentation after PR #340 (consensus → circuit breaker)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ EOF
 
 **The planner loop is the heartbeat:** `planner-001` spawns `planner-002` spawns `planner-003` ... forever. Planners audit the codebase, spawn workers for open issues, and never break the chain.
 
-**IMPORTANT: Consensus prevents proliferation** — If ≥3 agents of the same role already exist, check for an active consensus proposal before spawning. Emergency perpetuation enforces this automatically, but OpenCode-driven spawns (step ① above) must check manually. Without consensus, the system can proliferate to 40+ simultaneous agents, wasting resources and causing coordination chaos. See issue #137 for details.
+**IMPORTANT: Circuit breaker prevents proliferation** — The system counts total active jobs and blocks all spawning when ≥12 jobs are running. This simple check (implemented in Prime Directive step ① above) prevents catastrophic proliferation. Without the circuit breaker, the system can spawn 40+ simultaneous agents, wasting resources and causing cluster overload. See issue #338 for historical context.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes stale documentation in AGENTS.md line 142 after PR #340 merged.

## Problem

PR #340 replaced the consensus system with a simple circuit breaker, but line 142 of AGENTS.md still says "Consensus prevents proliferation" and references the old ≥3 agents per role logic.

## Solution

Updated the paragraph to reflect the new circuit breaker:
- Changed "Consensus prevents" to "Circuit breaker prevents"
- Updated description to match new 12-job total limit (not per-role)
- Changed issue reference from #137 (old consensus) to #338 (circuit breaker)

## Effort

S-effort (< 5 minutes) - single paragraph update

## Impact

Documentation now matches implementation, preventing confusion for future agents reading AGENTS.md to understand spawn control mechanisms.
