### PR TITLE
Fix #361: Align all circuit breaker limits to 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 10)"
 
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+if [ "$ACTIVE_JOBS" -ge 10 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 10"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -449,9 +449,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 15 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 15. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 10 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 10). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 10. Spawn blocked." "blocker" 10
     return 1
   fi
 
@@ -1081,9 +1081,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 15 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 15." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 10 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 10." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary

Aligns ALL three circuit breaker checks to **limit 10** for consistency and to prevent ongoing proliferation.

## Problem

Three circuit breaker locations with inconsistent limits:
- AGENTS.md Prime Directive: **12**
- entrypoint.sh spawn_agent(): **15** (line 452)
- entrypoint.sh emergency perpetuation: **15** (line 1084)

Current state: **39 active agents** still running despite these limits.

## Solution

Standardize to limit **10** across the platform:
1. Conservative enough to prevent proliferation (15 failed, 39 agents still running)
2. Consistent across all spawn paths (OpenCode + emergency perpetuation)
3. Provides safety margin before cluster overload

## Changes

```bash
# AGENTS.md line 30-33
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 10)"
+if [ "$ACTIVE_JOBS" -ge 10 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 10"

# entrypoint.sh line 452-454 (spawn_agent)
-if [ "$total_active" -ge 15 ]; then
-  log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
+if [ "$total_active" -ge 10 ]; then
+  log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 10). BLOCKING spawn."

# entrypoint.sh line 1084-1086 (emergency perpetuation)
-if [ "$TOTAL_ACTIVE" -ge 15 ]; then
-  log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
+if [ "$TOTAL_ACTIVE" -ge 10 ]; then
+  log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
```

## Impact

- **CRITICAL** fix for ongoing proliferation (39 active agents)
- All spawn paths (OpenCode, spawn_agent, emergency perpetuation) use same limit
- Earlier intervention prevents resource exhaustion
- Supersedes PR #349 (standardize to 15) and PR #351 (only one location)

## Effort

**S (< 15 minutes)** - 3 locations, 6 lines changed

## Related

- Fixes #361
- Related to #348, #343, #338, #325, #275

## Testing

After merge + CI rebuild:
1. Circuit breaker should trigger at 10 active agents
2. System should stabilize around 5-8 agents (healthy operation)
3. No more proliferation to 39+ agents

---
**Priority: CRITICAL** - Deploy immediately to stop proliferation