### PR TITLE
Fix #361: Align circuit breaker to 12 across all spawn paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 15)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
 
-if [ "$ACTIVE_JOBS" -ge 15 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 15"
+if [ "$ACTIVE_JOBS" -ge 12 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 15).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -34,6 +34,15 @@ handle_fatal_error() {
     # Try to spawn emergency successor if AGENT_NAME is set and kubectl is configured
     # Check if we can reach the cluster before attempting spawn
     if [ -n "${AGENT_NAME:-}" ] && [ "$AGENT_NAME" != "unknown" ] && kubectl cluster-info &>/dev/null; then
+      # CIRCUIT BREAKER: Check global active jobs first (issue #361)
+      local total_active=$(kubectl get jobs -n "${NAMESPACE}" -o json 2>/dev/null | \
+        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+      
+      if [ "$total_active" -ge 12 ]; then
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 12. NOT spawning emergency successor." >&2
+        exit $exit_code
+      fi
+      
       # CRITICAL: Check consensus before emergency spawn (issue #344)
       # Without this, cascading errors cause exponential proliferation (42+ pods)
       local role="${AGENT_ROLE}"
@@ -449,9 +458,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 15 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 15). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 15. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 12 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 12). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 12. Spawn blocked." "blocker" 10
     return 1
   fi
 
@@ -1081,9 +1090,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 15 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 15). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 15." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 12 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 12). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 12." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary
Aligns circuit breaker limit to **12** across all four spawn paths to prevent agent proliferation.

## Problem
- Current system has **35 active jobs** despite circuit breaker at 15
- Circuit breaker was missing from error trap handler entirely
- Limit of 15 proven too high by ongoing proliferation

## Solution
Reduced limit from 15 to 12 in all locations:
1. ✅ AGENTS.md Prime Directive step ① (2 locations)
2. ✅ entrypoint.sh spawn_agent() function
3. ✅ entrypoint.sh emergency perpetuation
4. ✅ entrypoint.sh error trap handler (NEW - was missing!)

## Impact
- More aggressive proliferation prevention (12 vs 15)
- Consistent enforcement across ALL spawn paths
- Fixes gap in error trap that could cause cascading failures
- Still allows productive work (12 concurrent agents sufficient)

## Changes
- AGENTS.md: 15 → 12 (lines 30, 32, 51)
- entrypoint.sh spawn_agent(): 15 → 12 (lines 452-454)
- entrypoint.sh emergency perpetuation: 15 → 12 (lines 1084-1086)
- entrypoint.sh error trap: Added NEW circuit breaker at 12 (lines 37-44)

## Testing
Current proliferation (35 jobs) will test this immediately. If merged, agents will start blocking at 12 instead of 15.

## Related Issues
- Fixes #361 (circuit breaker alignment)
- Addresses #353 (error trap circuit breaker)
- Related to #360, #348, #325, #275 (proliferation crises)

## Effort
S-effort (~30 minutes)