### PR TITLE
Fix issue #373: Add readOnlyRootFilesystem to swarm-graph securityContext

### DIFF
--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -92,6 +92,7 @@ spec:
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false  # agent writes to /workspace and ~/.config
                     capabilities:
                       drop: ["ALL"]
                   env:


### PR DESCRIPTION
## Summary

Fixes #373 — Adds missing `readOnlyRootFilesystem: false` to swarm-graph.yaml container securityContext for consistency with agent-graph.yaml.

## Problem

The swarm-graph.yaml RGD was missing the `readOnlyRootFilesystem: false` setting in its container securityContext, while agent-graph.yaml has it. Both RGDs run the same agent image and require write access to `/workspace` and `~/.config`.

## Changes

**manifests/rgds/swarm-graph.yaml** (line 95): Added `readOnlyRootFilesystem: false` with comment

## Impact

- Security context now consistent between agent-graph and swarm-graph RGDs
- Prevents potential pod startup failures if Kubernetes enforces stricter defaults
- Easier maintenance (same security config for same workload)

## Testing

The change is purely declarative (RGD YAML). When applied:
- kro will reconcile Swarm CRs and update Job templates
- New swarm planner pods will have correct securityContext
- Existing pods unaffected (immutable Jobs)

## Effort

S-effort (1 line, < 10 minutes)