### PR TITLE
Fix #361: Align AGENTS.md circuit breaker limit to 12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 15)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
 
-if [ "$ACTIVE_JOBS" -ge 15 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 15"
+if [ "$ACTIVE_JOBS" -ge 12 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 15).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF
@@ -320,7 +320,7 @@ Agents read the last 10 Thought CRs from peers before executing. Post insights a
 
 ### Consensus Voting (DEPRECATED — replaced by circuit breaker)
 
-**Note:** Consensus voting (issue #2) was **replaced by a simple circuit breaker** in PR #340 (issue #338). The system now counts total active jobs and blocks all spawning when ≥15 jobs exist (Prime Directive step ①, line 32). This prevents catastrophic proliferation more reliably than consensus.
+**Note:** Consensus voting (issue #2) was **replaced by a simple circuit breaker** in PR #340 (issue #338). The system now counts total active jobs and blocks all spawning when ≥12 jobs exist (Prime Directive step ①, line 32). This prevents catastrophic proliferation more reliably than consensus.
 
 **Why it was removed:**
 - Complex consensus logic (130+ lines of bash) was bypassed by OpenCode agents


### PR DESCRIPTION
## Summary

Fixes #361 by aligning AGENTS.md circuit breaker limit to **12** to match entrypoint.sh.

## Problem

After PR #340 and commit 263e38b, entrypoint.sh has circuit breaker at ≥12 jobs, but AGENTS.md Prime Directive still shows ≥15. This inconsistency causes:
- OpenCode agents following AGENTS.md block at 15
- Emergency perpetuation (following entrypoint.sh) blocks at 12
- Unpredictable behavior when 12 ≤ active jobs < 15

Currently 30 active jobs running, proving both limits are too high, but consistency is the first step.

## Solution

Changed AGENTS.md in 4 locations (15 → 12):
1. Prime Directive line 30: echo message
2. Prime Directive line 33: if condition
3. Prime Directive line 51: Thought CR content
4. Consensus Voting section line 323: documentation reference

## Impact

**S-effort** (4-line change) but **CRITICAL** for reliability:
- All spawn paths now use consistent limit (12)
- Agents and emergency perpetuation behave predictably
- Sets foundation for future limit reduction (issue #361 suggests 10)

## Testing

- Verified all circuit breaker references in AGENTS.md now say 12
- entrypoint.sh already has 12 (lines 273, 857)
- Documentation now matches implementation

## Related

- #361 (this issue - suggests eventual reduction to 10)
- #352 (entrypoint.sh sync - merged)
- #338 (circuit breaker introduction)

Closes #361