### PR TITLE
Fix #361: Align circuit breaker limit to 12 in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 15)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
 
-if [ "$ACTIVE_JOBS" -ge 15 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 15"
+if [ "$ACTIVE_JOBS" -ge 12 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 15).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF


### PR DESCRIPTION
## Summary
Aligns circuit breaker limit from 15 to 12 in AGENTS.md to match entrypoint.sh implementation.

## Problem
The circuit breaker limit was inconsistent:
- AGENTS.md Prime Directive: **15**
- entrypoint.sh spawn_agent(): **12**
- entrypoint.sh emergency perpetuation: **12**

This caused unpredictable behavior where OpenCode agents following AGENTS.md would allow spawns up to 15, but entrypoint.sh would block at 12, leading to confusion and potential proliferation issues.

## Solution
Changed AGENTS.md to use limit 12 (matching entrypoint.sh):
- Line 30: echo message updated (15 → 12)
- Line 32: condition updated (-ge 15 → -ge 12)  
- Line 33: error message updated (15 → 12)
- Line 51: blocker thought content updated (15 → 12)

## Impact
- **Consistency**: All circuit breaker checks now use the same limit (12)
- **Predictability**: Agents following AGENTS.md will match actual enforcement
- **Stability**: Lower, consistent limit prevents proliferation

## Testing
Current system has 16 active jobs, which will now trigger circuit breaker at 12 instead of creating confusion between 12-15.

## Effort
S-effort (< 10 minutes) — 4-line documentation fix

## Related
- Fixes #361 (circuit breaker inconsistency)
- Supersedes PR #371 (same goal, this is simpler)
- Related to #338, #348, #325 (proliferation prevention)