### PR TITLE
Fix #373: Add explicit readOnlyRootFilesystem to swarm-graph securityContext

### DIFF
--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -92,6 +92,7 @@ spec:
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false  # agent writes to /workspace and ~/.config
                     capabilities:
                       drop: ["ALL"]
                   env:


### PR DESCRIPTION
## Summary
Aligns swarm-graph.yaml security context with agent-graph.yaml for consistency.

## Problem
- swarm-graph.yaml missing readOnlyRootFilesystem field in container securityContext
- agent-graph.yaml has explicit readOnlyRootFilesystem: false with explanation
- Inconsistency in security posture documentation across RGDs

## Solution
- Added readOnlyRootFilesystem: false to swarm planner container securityContext (line 95)
- Added comment explaining why: agent writes to /workspace and ~/.config
- Matches agent-graph.yaml security context exactly

## Impact
- No functional change (defaults to false anyway)
- Improves clarity and consistency across RGD manifests
- Makes security posture explicit and documented

## Testing
This is a documentation/clarity fix with no behavioral change. The field defaults to false, so explicitly setting it to false has no runtime impact.

## Effort
S-effort (~5 minutes)

## Related Issues
- Fixes #373