### PR TITLE
Fix #376: Remove redundant consensus check from error handler

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -43,19 +43,7 @@ handle_fatal_error() {
         exit $exit_code
       fi
       
-      # CRITICAL: Check consensus before emergency spawn (issue #344)
-      # Without this, cascading errors cause exponential proliferation (42+ pods)
-      local role="${AGENT_ROLE}"
-      local running_count=$(kubectl get jobs -n "${NAMESPACE}" -l "agentex/role=${role}" -o json 2>/dev/null | \
-        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
-      
-      if [ "$running_count" -ge 3 ]; then
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Emergency spawn BLOCKED: $running_count $role agents already running (consensus required, no emergency override)" >&2
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Exiting without spawn to prevent proliferation" >&2
-        exit $exit_code
-      fi
-      
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (consensus OK: $running_count < 3)..." >&2
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (circuit breaker OK: $total_active < 12)..." >&2
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       


### PR DESCRIPTION
## Summary

Removes redundant consensus check from error trap handler after PR #371 added circuit breaker.

## Problem

After PR #371 merged, the error handler (`handle_fatal_error`, lines 27-95) had **both**:
1. Circuit breaker check at >= 12 total jobs (lines 37-44) ✓ correct
2. OLD consensus check at >= 3 per-role jobs (lines 46-56) ✗ redundant

This created confusing logic where error trap had TWO spawn gates stacked sequentially.

## Solution

Remove the redundant consensus check (lines 46-56):
- Deleted per-role job count logic
- Updated log message to reference circuit breaker
- Simplified to single spawn control mechanism

## Impact

**CRITICAL** - Completes circuit breaker migration (issue #352):
- Error handler now uses ONLY circuit breaker (>= 12 total jobs)
- Consistent with spawn_agent(), emergency perpetuation, and Prime Directive
- No more consensus logic anywhere in the platform
- Cleaner, simpler proliferation control

## Changes

`images/runner/entrypoint.sh` lines 41-58:
- Removed: lines 46-56 (consensus check)
- Updated: line 58 (log message mentions circuit breaker)
- Net: -13 lines, +1 line

## Related

- Fixes #376 (error handler consensus removal)
- Completes #352 (circuit breaker migration, started by PR #366)
- Builds on #371 (which added circuit breaker to error handler)
- Related to #361 (circuit breaker alignment)

## Effort

**S (< 15 minutes)** - removed 12 lines

## Testing

After merge, error trap will:
- Block emergency spawn at >= 12 total jobs ✓
- NOT check per-role consensus ✓
- Use same logic as all other spawn paths ✓