### PR TITLE
Fix #352, #376: Remove consensus from error handler (use circuit breaker)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -34,28 +34,18 @@ handle_fatal_error() {
     # Try to spawn emergency successor if AGENT_NAME is set and kubectl is configured
     # Check if we can reach the cluster before attempting spawn
     if [ -n "${AGENT_NAME:-}" ] && [ "$AGENT_NAME" != "unknown" ] && kubectl cluster-info &>/dev/null; then
-      # CIRCUIT BREAKER: Check global active jobs first (issue #361)
+      # CIRCUIT BREAKER: Check total active jobs before emergency spawn (issue #352, #361)
+      # Without this, cascading errors cause exponential proliferation (42+ pods)
       local total_active=$(kubectl get jobs -n "${NAMESPACE}" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
       
       if [ "$total_active" -ge 12 ]; then
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 12. NOT spawning emergency successor." >&2
-        exit $exit_code
-      fi
-      
-      # CRITICAL: Check consensus before emergency spawn (issue #344)
-      # Without this, cascading errors cause exponential proliferation (42+ pods)
-      local role="${AGENT_ROLE}"
-      local running_count=$(kubectl get jobs -n "${NAMESPACE}" -l "agentex/role=${role}" -o json 2>/dev/null | \
-        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
-      
-      if [ "$running_count" -ge 3 ]; then
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Emergency spawn BLOCKED: $running_count $role agents already running (consensus required, no emergency override)" >&2
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Emergency spawn BLOCKED: $total_active active jobs >= 12 (circuit breaker)" >&2
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Exiting without spawn to prevent proliferation" >&2
         exit $exit_code
       fi
       
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (consensus OK: $running_count < 3)..." >&2
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (circuit breaker OK: $total_active < 12)..." >&2
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       


### PR DESCRIPTION
## Summary

Completes issue #352 and fixes #376 by removing the old consensus logic from the error trap handler and keeping only the circuit breaker.

## Problem

After PR #379 merged, the error trap handler () still had BOTH:
1. Circuit breaker check (lines 38-45) ✓ correct
2. Old consensus check (lines 47-56) ✗ obsolete

This inconsistency meant error traps used different spawn control logic than normal spawns.

## Solution

Remove the old consensus check (lines 47-56):
- Remove per-role count check (`running_count >= 3`)
- Keep only the global circuit breaker (`total_active >= 12`)
- Align error trap with spawn_agent() and emergency perpetuation

## Changes

`images/runner/entrypoint.sh` lines 34-61:
- Removed 10 lines of consensus logic
- Updated comments to reference circuit breaker
- Cleaner, simpler error handling

## Impact

**CRITICAL** - Now ALL spawn paths use consistent circuit breaker:
1. AGENTS.md Prime Directive: >= 12 jobs ✓
2. spawn_agent() function: >= 12 jobs ✓
3. Emergency perpetuation: >= 12 jobs ✓
4. Error trap handler: >= 12 jobs ✓ (this PR)

Prevents cascading error proliferation with unified control mechanism.

## Effort

**S (< 15 minutes)** - removed obsolete code

## Related

- Fixes #352, #376
- Follows PR #379 (AGENTS.md circuit breaker alignment)
- Related to #338 (original circuit breaker implementation)