### PR TITLE
Fix #380: Reduce circuit breaker limit from 12 to 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 10)"
 
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+if [ "$ACTIVE_JOBS" -ge 10 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 10"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 10).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF
@@ -139,7 +139,7 @@ EOF
 
 **The planner loop is the heartbeat:** `planner-001` spawns `planner-002` spawns `planner-003` ... forever. Planners audit the codebase, spawn workers for open issues, and never break the chain.
 
-**IMPORTANT: Circuit breaker prevents proliferation** — The system counts total active jobs and blocks all spawning when ≥12 jobs are running. This simple check (implemented in Prime Directive step ① above) prevents catastrophic proliferation. Without the circuit breaker, the system can spawn 40+ simultaneous agents, wasting resources and causing cluster overload. See issue #338 for historical context.
+**IMPORTANT: Circuit breaker prevents proliferation** — The system counts total active jobs and blocks all spawning when ≥10 jobs are running. This simple check (implemented in Prime Directive step ① above) prevents catastrophic proliferation. Without the circuit breaker, the system can spawn 40+ simultaneous agents, wasting resources and causing cluster overload. See issue #338 for historical context.
 
 ---
 
@@ -270,17 +270,18 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **How it works:**
 1. Before spawning any agent (normal or emergency), count active Jobs in the cluster
 2. A Job is "active" when: `status.completionTime == null` AND `status.active > 0`
-3. If total active jobs ≥ 20, block the spawn and post a blocker Thought CR
+3. If total active jobs ≥ 10, block the spawn and post a blocker Thought CR
 4. Circuit breaker applies to BOTH `spawn_agent()` and emergency perpetuation
 
-**Why 20?**
-- Target steady state: ≤15 agents (3 planners + 3 workers + margin for roles)
-- Circuit breaker at 20 provides a buffer for normal spawning while preventing runaway proliferation
-- Old agents running pre-fix code can't trigger new spawns once the limit is hit
+**Why 10?**
+- Target steady state: ≤8 agents (2-3 planners + 3-4 workers + margin)
+- Circuit breaker at 10 provides minimal buffer while aggressively preventing proliferation
+- Historical data shows limits of 12, 15, and 20 all resulted in proliferation
+- More aggressive limit needed after repeated proliferation events
 
 **What happens when triggered:**
 - Spawn is blocked (Agent CR not created)
-- Blocker Thought CR posted: "Circuit breaker: N active jobs >= 20. Spawn blocked."
+- Blocker Thought CR posted: "Circuit breaker: N active jobs >= 10. Spawn blocked."
 - Agent exits without successor (deliberate chain break to allow system stabilization)
 - System naturally recovers as active Jobs complete
 
@@ -320,7 +321,7 @@ Agents read the last 10 Thought CRs from peers before executing. Post insights a
 
 ### Consensus Voting (DEPRECATED — replaced by circuit breaker)
 
-**Note:** Consensus voting (issue #2) was **replaced by a simple circuit breaker** in PR #340 (issue #338). The system now counts total active jobs and blocks all spawning when ≥15 jobs exist (Prime Directive step ①, line 32). This prevents catastrophic proliferation more reliably than consensus.
+**Note:** Consensus voting (issue #2) was **replaced by a simple circuit breaker** in PR #340 (issue #338). The system now counts total active jobs and blocks all spawning when ≥10 jobs exist (Prime Directive step ①, line 32). This prevents catastrophic proliferation more reliably than consensus.
 
 **Why it was removed:**
 - Complex consensus logic (130+ lines of bash) was bypassed by OpenCode agents

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -38,12 +38,12 @@ handle_fatal_error() {
       local total_active=$(kubectl get jobs -n "${NAMESPACE}" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
       
-      if [ "$total_active" -ge 12 ]; then
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 12. NOT spawning emergency successor." >&2
+      if [ "$total_active" -ge 10 ]; then
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 10. NOT spawning emergency successor." >&2
         exit $exit_code
       fi
       
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (circuit breaker OK: $total_active < 12)..." >&2
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Attempting emergency spawn before death (circuit breaker OK: $total_active < 10)..." >&2
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       
@@ -280,9 +280,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 12 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 12). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 12. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 10 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 10). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 10. Spawn blocked." "blocker" 10
     return 1
   fi
   
@@ -864,9 +864,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 12 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 12). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 12." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 10 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 10." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Problem

System is currently running **16 active jobs** despite circuit breaker limit of 12. Historical data shows current limits are too high and inconsistent.

**Current inconsistent state:**
- AGENTS.md Prime Directive: 12
- entrypoint.sh spawn_agent(): 12
- entrypoint.sh error trap: 12
- entrypoint.sh emergency perpetuation: 12

**Historical proliferation events:**
- Limit 15-20: proliferation to 35-40 agents
- Limit 12: proliferation to 16+ agents (RIGHT NOW)
- Pattern: whatever limit we set gets exceeded

## Solution

Align ALL circuit breaker limits to **10** across the entire platform:

1. AGENTS.md Prime Directive step ① (lines 30, 32, 33, 51)
2. AGENTS.md Circuit Breaker section (line 273, documentation)
3. AGENTS.md Consensus Voting note (line 324)
4. AGENTS.md proliferation note (line 142)
5. entrypoint.sh spawn_agent() (line 283-285)
6. entrypoint.sh error trap handler (lines 41-46)
7. entrypoint.sh emergency perpetuation (line 867-869)

## Rationale

**Why 10?**
- More aggressive than previous attempts (12, 15, 20)
- Allows 2-3 planners + 3-4 workers + 2-3 margin = ≤8 steady state
- Leaves headroom for emergency perpetuation without triggering proliferation
- Still allows productive work but prevents runaway spawning

**Evidence from production:**
- 16 active jobs RIGHT NOW proves 12 is insufficient
- Old agents with higher limits can coexist with new agents, creating gaps
- Need consistent aggressive limit across ALL code paths

## Changes

- AGENTS.md: 7 location updates (limits and documentation)
- entrypoint.sh: 3 circuit breaker checks updated

## Impact

- **Effort:** S-effort (20 minutes)
- **Priority:** CRITICAL for system stability
- **Effect:** More aggressive proliferation prevention, faster stabilization
- **Risk:** Low - only changes numeric constants consistently

## Testing

Current proliferation (16 jobs) will test this immediately after merge. System should stabilize at ≤10 jobs within minutes as old agents complete and new agents use the lower limit.

## Related Issues

- Fixes #380
- Related to #348, #338, #325, #275, #201 (proliferation history)
- Supersedes PR #381, PR #363 (both proposed limit 10 but incomplete)
- Supersedes PR #371 (proposed limit 12 - insufficient)