### PR TITLE
Fix #380: Reduce circuit breaker limit from 12 to 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 12)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 10)"
 
-if [ "$ACTIVE_JOBS" -ge 12 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 12"
+if [ "$ACTIVE_JOBS" -ge 10 ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 10"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -48,7 +48,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 12).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 10).
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -38,8 +38,8 @@ handle_fatal_error() {
       local total_active=$(kubectl get jobs -n "${NAMESPACE}" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
       
-      if [ "$total_active" -ge 12 ]; then
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 12. NOT spawning emergency successor." >&2
+      if [ "$total_active" -ge 10 ]; then
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 10. NOT spawning emergency successor." >&2
         exit $exit_code
       fi
       
@@ -280,9 +280,9 @@ spawn_agent() {
   local total_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$total_active" -ge 12 ]; then
-    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 12). BLOCKING spawn."
-    post_thought "Circuit breaker: $total_active active jobs >= 12. Spawn blocked." "blocker" 10
+  if [ "$total_active" -ge 10 ]; then
+    log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: 10). BLOCKING spawn."
+    post_thought "Circuit breaker: $total_active active jobs >= 10. Spawn blocked." "blocker" 10
     return 1
   fi
   
@@ -864,9 +864,9 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
-  if [ "$TOTAL_ACTIVE" -ge 12 ]; then
-    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 12). Blocking emergency spawn."
-    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 12." "blocker" 10
+  if [ "$TOTAL_ACTIVE" -ge 10 ]; then
+    log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: 10). Blocking emergency spawn."
+    post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 10." "blocker" 10
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary

Reduces circuit breaker limit from 12 to 10 across all spawn paths to prevent agent proliferation.

## Problem

System currently running **15 active jobs** despite limit 12. Historical proliferation pattern:
- Limit 20 → 40+ agents
- Limit 15 → 35+ agents  
- Limit 12 → 23+ agents (recent state)

The pattern is clear: current limits are consistently exceeded.

## Changes

**entrypoint.sh** (3 locations):
- Line 41: Error handler circuit breaker check
- Line 283: spawn_agent() circuit breaker  
- Line 867: Emergency perpetuation circuit breaker

**AGENTS.md** (2 locations):
- Line 32: Prime Directive circuit breaker check
- Line 51: Circuit breaker Thought CR content

All `>= 12` comparisons changed to `>= 10`, all `limit: 12` messages changed to `limit: 10`.

## Rationale

**Why 10?**
- More aggressive than all previous attempts (20, 15, 12)
- Allows productive work: 2-3 planners + 3-4 workers + margin = 8-9 steady state
- Leaves room for emergency perpetuation without triggering proliferation
- Prevents the "whatever limit we set gets exceeded" pattern

**Effect:**
- Faster stabilization during proliferation events
- Earlier circuit breaker activation = less wasted compute
- Consistent enforcement across all code paths

## Testing

Current proliferation (15 active jobs) will test immediately after merge. System should stabilize at ≤10 jobs within minutes as circuit breaker blocks new spawns.

## Related Issues

- Fixes #380
- Related to #348, #338, #361, #325, #275, #201 (proliferation history)

## Deployment

Requires runner image rebuild. Circuit breaker takes effect on next agent spawn (~10-30s after merge and image push).