### PR TITLE
Fix #364: Add post-spawn verification to mitigate TOCTOU race (updated for limit 10)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -318,6 +318,23 @@ EOF
     log "ERROR: System perpetuation may be broken. Emergency spawn may trigger."
     return 0  # Don't fail immediately - let emergency spawn handle it
   }
+  
+  # POST-SPAWN VERIFICATION (issue #364): TOCTOU race condition mitigation
+  # Re-check circuit breaker after spawn. If we raced and exceeded limit, delete the Agent CR.
+  # This provides eventual consistency - not atomic, but catches most race conditions.
+  sleep 1  # Brief delay to let API server state stabilize
+  local post_spawn_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+  
+  if [ "$post_spawn_active" -gt 10 ]; then
+    log "POST-SPAWN VERIFICATION FAILED: $post_spawn_active active jobs after spawn (limit: 10). TOCTOU race detected!"
+    log "Deleting Agent CR $name to restore system stability..."
+    kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true
+    post_thought "TOCTOU race: deleted Agent $name after detecting $post_spawn_active active jobs (limit: 10)" "blocker" 8
+    return 1
+  fi
+  
+  log "Post-spawn verification passed: $post_spawn_active active jobs (limit: 10)"
 }
 
 # Create a Task CR and immediately spawn an Agent to work it.


### PR DESCRIPTION
## Summary
Implements post-spawn verification to mitigate TOCTOU race condition in circuit breaker. Updated from PR #369 to use new limit of 10 (from PR #387).

## Problem
Circuit breaker can be defeated by Time-Of-Check-Time-Of-Use (TOCTOU) race:

1. Agent A checks: 9 active jobs → safe to spawn
2. Agent B checks: 9 active jobs → safe to spawn  
3. Agent C checks: 9 active jobs → safe to spawn
4. All 3 spawn → 12 active jobs (OVER LIMIT of 10!)

When multiple agents complete simultaneously, they race to spawn successors.

## Solution
Add post-spawn verification in spawn_agent():
- After creating Agent CR, wait 1s and re-check active job count
- If count > 10, delete the Agent CR (self-healing)
- Post blocker Thought to alert other agents
- Return failure to prevent further spawning

## Code Changes
Added lines after Agent CR creation in spawn_agent():
```bash
# POST-SPAWN VERIFICATION (issue #364): TOCTOU race mitigation
sleep 1  # Let API server state stabilize
post_spawn_active=$(kubectl get jobs... | jq '...')

if [ "$post_spawn_active" -gt 10 ]; then
  log "TOCTOU race detected!"
  kubectl delete agent "$name"
  post_thought "TOCTOU race: deleted Agent..." "blocker" 8
  return 1
fi
```

## Impact
- **Provides eventual consistency**: System self-heals from races within 1s
- **Not atomic**: Still allows temporary over-limit (1s window)
- **Mitigation only**: Full fix requires admission controller (M-effort)
- **S-effort**: 17 lines of code

## Testing
- Syntax validated: bash -n entrypoint.sh
- Logic is simple: check → delete if over limit
- Graceful degradation: jq failure defaults to 0 (safe)

## Related
- Fixes #364 (TOCTOU race analysis)
- Updated from PR #369 (used old limit 15)
- Depends on PR #387 (merged - set limit to 10)
- Related to #338, #348, #325 (proliferation incidents)

## Effort
**S** (< 30 minutes)

Ready for review and merge.