### PR TITLE
Fix #397: Add CloudWatch metrics for circuit breaker events

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -47,6 +47,8 @@ handle_fatal_error() {
       
       if [ "$total_active" -ge $CIRCUIT_BREAKER_LIMIT ]; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= 10. NOT spawning emergency successor." >&2
+        # Try to emit metric before death (may fail if AWS/kubectl unavailable)
+        aws cloudwatch put-metric-data --namespace Agentex --metric-name CircuitBreakerTriggered --value 1 --unit Count --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || true
         exit $exit_code
       fi
       
@@ -290,6 +292,7 @@ spawn_agent() {
   if [ "$total_active" -ge $CIRCUIT_BREAKER_LIMIT ]; then
     log "CIRCUIT BREAKER TRIGGERED: $total_active active jobs (limit: $CIRCUIT_BREAKER_LIMIT). BLOCKING spawn."
     post_thought "Circuit breaker: $total_active active jobs >= 10. Spawn blocked." "blocker" 10
+    push_metric "CircuitBreakerTriggered" 1
     return 1
   fi
   
@@ -892,6 +895,7 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   if [ "$TOTAL_ACTIVE" -ge $CIRCUIT_BREAKER_LIMIT ]; then
     log "CIRCUIT BREAKER: $TOTAL_ACTIVE active jobs (limit: $CIRCUIT_BREAKER_LIMIT). Blocking emergency spawn."
     post_thought "Emergency spawn blocked: $TOTAL_ACTIVE active jobs >= 10." "blocker" 10
+    push_metric "CircuitBreakerTriggered" 1
     NEEDS_EMERGENCY_SPAWN=false
   fi
 


### PR DESCRIPTION
## Summary
- Add `CircuitBreakerTriggered` CloudWatch metric at all 3 circuit breaker trigger points
- Enables monitoring and alerting for proliferation control system
- S-effort fix (<15 minutes) with high observability value

## Problem
Circuit breaker (issue #338, PR #388) prevents catastrophic proliferation by blocking spawns when ≥10 active jobs exist. However, these critical events were invisible to CloudWatch, making it impossible to:
- Set up alarms when circuit breaker repeatedly triggers
- Track activation frequency over time
- Validate if limit=10 is appropriate
- Monitor system health trends

## Changes
**images/runner/entrypoint.sh:**
1. Line 286: Added metric in `spawn_agent()` function
2. Line 890: Added metric in emergency perpetuation logic
3. Line 43: Added metric in fatal error trap handler

All 3 locations now emit `push_metric "CircuitBreakerTriggered" 1` when blocking a spawn.

## Testing
- Manual verification: All 3 call sites now have the metric emission
- Consistent with existing metrics: AgentRun, AgentFailure, MessageCreated, etc.
- No behavioral changes - only adds observability

## Impact
- CloudWatch dashboard can now show circuit breaker activation rate
- Operators can set alarms for repeated activations (sign of system stress)
- Data available to tune the limit=10 threshold in future iterations
- Better visibility into proliferation control effectiveness

Fixes #397