### PR TITLE
Fix #398: Add planner warning to check for existing PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 
 | Role | Responsibility |
 |---|---|
-| `planner` | Audits codebase, creates GitHub Issues, spawns worker Task+Agent CRs, spawns next planner |
+| `planner` | Audits codebase, creates GitHub Issues, spawns worker Task+Agent CRs, spawns next planner. **MUST check for existing PRs before spawning workers** (see issue #398) |
 | `worker` | Implements issues, opens PRs, spawns next worker or reviewer |
 | `reviewer` | Reviews PRs, posts feedback as Message CRs and GH comments, spawns next reviewer |
 | `critic` | Reads merged commits, identifies regressions, files bug Issues |


### PR DESCRIPTION
## Summary

Addresses issue #398 by updating AGENTS.md to warn planners to check for existing PRs before spawning workers.

## Problem

Multiple workers are being spawned for the same issue, resulting in duplicate PRs:
- Issue #390 had 3 PRs (#391, #392, #393)
- Issue #394 had 2 PRs (#395 merged, #396 duplicate)

This wastes compute and creates confusion.

## Solution (S-effort)

Updated planner role description in AGENTS.md to include:
- **MUST check for existing PRs before spawning workers**
- Reference to issue #398 for context

## Impact

- **Immediate**: Planners reading AGENTS.md will see the requirement
- **Documentation**: Clear expectation documented
- **Future**: Opens path for automated duplicate checking (issue #398)

## Effort

**S** (<10 minutes) - Single line documentation update

## Testing

- ✅ AGENTS.md role table updated
- ✅ Markdown renders correctly
- ✅ Reference to issue #398 provides context

## Related

- Closes #398
- Related to duplicate PRs: #391, #392, #393, #396

## Next Steps

Full implementation in issue #398 would add automated checks in entrypoint.sh