### PR TITLE
Fix #398: Add duplicate work prevention for GitHub issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,33 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 - `spawn_agent()`: `images/runner/entrypoint.sh` lines 432-442
 - Emergency perpetuation: `images/runner/entrypoint.sh` lines 1039-1048
 
+### Duplicate Work Prevention
+
+The system prevents multiple agents from working on the same GitHub issue simultaneously (issue #398).
+
+**How it works:**
+1. Before spawning a worker for a GitHub issue, `spawn_task_and_agent()` calls `check_issue_duplicate()`
+2. The check looks for two conditions:
+   - **Open PR exists**: Searches GitHub for open PRs mentioning the issue number
+   - **Active task exists**: Checks for Tasks with matching `githubIssue` field that aren't Done/Cancelled
+3. If either condition is true, the spawn is blocked and a Thought CR is posted
+
+**Why this matters:**
+- Prevents wasted compute (3 agents on same issue = 2/3 waste)
+- Avoids duplicate PRs with identical changes
+- Eliminates merge conflicts from concurrent work
+- Reduces code review burden
+
+**When spawning workers for issues:**
+```bash
+# Pass issue number as 7th parameter to spawn_task_and_agent
+spawn_task_and_agent "task-worker-123" "worker-123" "worker" \
+  "Fix issue #42" "Implement fix for..." "S" 42  # issue=42
+# Duplicate check runs automatically before spawn
+```
+
+**Implementation:** `check_issue_duplicate()` and `spawn_task_and_agent()` in `images/runner/entrypoint.sh` lines 340-391
+
 ---
 
 ## Communication Protocol

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -337,9 +337,54 @@ EOF
   log "Post-spawn verification passed: $post_spawn_active active jobs (limit: 10)"
 }
 
+# Check if work is already being done on a GitHub issue (issue #398).
+# Prevents duplicate workers from spawning for the same issue.
+# Returns 0 if work already exists (duplicate), 1 if safe to spawn.
+check_issue_duplicate() {
+  local issue_num="$1"
+  
+  # Skip check if no issue number provided or issue is 0
+  if [ -z "$issue_num" ] || [ "$issue_num" = "0" ]; then
+    return 1  # Safe to spawn (no issue tracking)
+  fi
+  
+  # Check 1: Is there an open PR for this issue?
+  local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue_num}" --json number --jq '.[0].number' 2>/dev/null || echo "")
+  if [ -n "$existing_pr" ]; then
+    log "DUPLICATE DETECTED: PR #${existing_pr} already exists for issue #${issue_num}"
+    return 0  # Duplicate detected
+  fi
+  
+  # Check 2: Is there an active agent already assigned to this issue?
+  # Look for Tasks with this githubIssue number that aren't Done/Cancelled
+  local existing_task=$(kubectl get tasks.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq -r --arg issue "$issue_num" '.items[] | 
+      select(.spec.githubIssue == ($issue | tonumber) and 
+             (.status.phase // "Pending") != "Done" and 
+             (.status.phase // "Pending") != "Cancelled") | 
+      .metadata.name' | head -1)
+  
+  if [ -n "$existing_task" ]; then
+    log "DUPLICATE DETECTED: Active task $existing_task already exists for issue #${issue_num}"
+    return 0  # Duplicate detected
+  fi
+  
+  return 1  # No duplicate found, safe to spawn
+}
+
 # Create a Task CR and immediately spawn an Agent to work it.
 spawn_task_and_agent() {
   local task_name="$1" agent_name="$2" role="$3" title="$4" desc="$5" effort="${6:-M}" issue="${7:-0}" swarm_ref="${8:-}"
+  
+  # DUPLICATE PREVENTION (issue #398): Check if work already exists for this issue
+  if [ "$issue" != "0" ]; then
+    if check_issue_duplicate "$issue"; then
+      log "SKIPPING spawn: duplicate work detected for issue #${issue}"
+      post_thought "Duplicate prevention: skipped spawning worker for issue #${issue} (PR or active task already exists)" "observation" 7
+      return 1
+    fi
+  fi
+  
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
   local err_output


### PR DESCRIPTION
## Summary

Implements duplicate work prevention to stop multiple agents from working on the same GitHub issue simultaneously (issue #398).

## Problem

Multiple agents were being spawned for the same issues, causing:
- Wasted compute resources (3 agents on one issue = 2/3 waste)
- Duplicate PRs with identical changes (e.g., PRs #391, #392, #393 for issue #390)
- Merge conflicts from concurrent modifications
- Code review burden from duplicate work

## Solution

Added `check_issue_duplicate()` function that runs before spawning workers:

**Two-stage duplicate detection:**
1. **Open PR check**: Searches GitHub for open PRs mentioning the issue number
2. **Active Task check**: Queries k8s for Tasks with matching githubIssue that aren't Done/Cancelled

If either check detects existing work, the spawn is blocked and a Thought CR is posted.

## Changes

### 1. New function: `check_issue_duplicate()` (entrypoint.sh lines 340-371)
- Takes issue number as parameter
- Returns 0 if duplicate detected, 1 if safe to spawn
- Uses `gh pr list --search` and `kubectl get tasks.kro.run` with jq filtering

### 2. Updated: `spawn_task_and_agent()` (entrypoint.sh lines 373-391)
- Calls `check_issue_duplicate()` before spawning if issue != 0
- Skips spawn and posts observation Thought if duplicate detected
- Preserves existing behavior for non-issue tasks

### 3. Documentation: AGENTS.md
- New "Duplicate Work Prevention" section after Circuit Breaker
- Usage examples for spawning workers with issue tracking
- Implementation details and benefits

## Testing

Syntax validated with `bash -n entrypoint.sh` (passed).

**Manual test scenarios:**
- Issue with open PR → spawn blocked ✓
- Issue with active non-Done Task → spawn blocked ✓  
- Issue with no existing work → spawn proceeds ✓
- Non-issue task (issue=0) → duplicate check skipped ✓

## Benefits

- **Resource efficiency**: Prevents 2/3 wasted compute on duplicate work
- **Code quality**: Eliminates merge conflicts from concurrent PRs
- **Developer experience**: Reviewers see one PR per issue, not 3+
- **System reliability**: Reduces agent churn and job proliferation

## Effort

S-effort: ~30 minutes

## Related Issues

- #398 (this fix)
- #390 (example of duplicate PRs: #391, #392, #393)

Fixes #398