### PR TITLE
Fix #406: Increase emergency perpetuation grace period to 15s

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -820,17 +820,31 @@ else
     
     if [ -z "$JOB_NAME" ]; then
       log "WARNING: Agent CR $agent_name exists but status.jobName is empty (kro hasn't processed it yet)"
-      # Give kro a moment to process the Agent CR (it may be in progress)
-      sleep 5
-      JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
-        -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
+      # Give kro time to process the Agent CR - retry with backoff (issue #406)
+      # Under load, kro can take >5s to create Jobs. Use 15s grace period with 3s intervals.
+      MAX_WAIT=15
+      INTERVAL=3
+      ELAPSED=0
+      
+      while [ $ELAPSED -lt $MAX_WAIT ]; do
+        sleep $INTERVAL
+        ELAPSED=$((ELAPSED + INTERVAL))
+        JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+          -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
+        
+        if [ -n "$JOB_NAME" ]; then
+          log "✓ kro created Job after ${ELAPSED}s: $JOB_NAME"
+          break
+        fi
+        log "Still waiting for kro to process Agent CR $agent_name (${ELAPSED}s/${MAX_WAIT}s elapsed)..."
+      done
     fi
     
     if [ -z "$JOB_NAME" ]; then
-      log "ERROR: Agent CR $agent_name still has no Job after 5s wait. kro may be down or RGD is broken."
+      log "ERROR: Agent CR $agent_name still has no Job after 15s wait. kro may be down or RGD is broken."
       NEEDS_EMERGENCY_SPAWN=true
-      EMERGENCY_REASON="Agent CR exists but kro didn't create Job (kro down or RGD error)"
-      post_thought "Critical: Agent CR $agent_name created but kro failed to create Job. Possible kro failure or RGD syntax error." "blocker" 2
+      EMERGENCY_REASON="Agent CR exists but kro didn't create Job after 15s (kro down or RGD error)"
+      post_thought "Critical: Agent CR $agent_name created but kro failed to create Job after 15s wait. Possible kro failure or RGD syntax error." "blocker" 2
       break
     fi
     


### PR DESCRIPTION
## Summary

Fixes #406 — prevents false-positive emergency spawns that cause agent proliferation.

## Problem

Under cluster load, kro can take >5s to create Jobs from Agent CRs. The old emergency perpetuation logic:
1. Waited 5s for Job creation
2. If no Job found, triggered emergency spawn
3. Original Job often appeared shortly after → duplicate agents

This caused proliferation despite circuit breaker.

## Solution

Replace single 5s check with retry loop:
- Check every 3s for up to 15s total
- Log progress during wait
- Only trigger emergency spawn after full 15s timeout

## Changes

**File:** `images/runner/entrypoint.sh` (lines 821-847)
- Added retry loop with MAX_WAIT=15s, INTERVAL=3s
- Enhanced logging to show wait progress
- Updated error messages to reflect 15s timeout

## Testing

- Bash syntax validated (`bash -n`)
- Logic follows same pattern as existing spawn_agent() verification
- Preserves all error conditions (kro failure, RGD errors)

## Impact

- **Prevents false-positive emergency spawns** under load
- **Reduces agent proliferation** (addresses #325)
- **Still catches genuine failures** within 15s
- No changes to success path (immediate Job creation still works)

Vision score: 5/10 (platform stability)