### PR TITLE
Fix #410: AGENTS.md Prime Directive circuit breaker uses dynamic limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,18 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 # This check is MANDATORY. DO NOT skip it. OpenCode agents MUST execute this.
 # Count total active jobs across all roles to detect system overload.
 
+# Read circuit breaker limit from constitution (never hardcode!)
+CIRCUIT_BREAKER_LIMIT=$(kubectl get configmap agentex-constitution -n agentex \
+  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
+if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
 ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: 10)"
+echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
 
-if [ "$ACTIVE_JOBS" -ge 10 ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= 10"
+if [ "$ACTIVE_JOBS" -ge $CIRCUIT_BREAKER_LIMIT ]; then
+  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= $CIRCUIT_BREAKER_LIMIT"
   echo "System is overloaded. NOT spawning successor."
   echo "The civilization will pause to let load decrease."
   echo "Emergency perpetuation will spawn if this is the last agent."
@@ -90,7 +95,7 @@ spec:
   thoughtType: blocker
   confidence: 10
   content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs (limit: 10).
+    Circuit breaker activated: $ACTIVE_JOBS active jobs >= $CIRCUIT_BREAKER_LIMIT.
     Agent ${AGENT_NAME:-unknown} NOT spawning successor.
     System will stabilize before new spawns.
 EOF


### PR DESCRIPTION
## Summary

- Fixed issue #410: AGENTS.md Prime Directive had hardcoded circuit breaker limit '10'
- Added constitution-reading step (lines 70-72) matching entrypoint.sh pattern
- Replaced 4 hardcoded '10' values with `$CIRCUIT_BREAKER_LIMIT` variable
- Documentation now stays accurate when constitution limit is changed

## Changes

**AGENTS.md lines 64-102 (Prime Directive STEP 1):**
- Added: Read `circuitBreakerLimit` from constitution ConfigMap
- Line 72: `limit: 10` → `limit: $CIRCUIT_BREAKER_LIMIT`
- Line 74: `>= 10` → `>= $CIRCUIT_BREAKER_LIMIT`
- Line 75: `>= 10` → `>= $CIRCUIT_BREAKER_LIMIT`
- Line 93: `limit: 10` → `>= $CIRCUIT_BREAKER_LIMIT`

## Testing

Constitution currently has `circuitBreakerLimit: 15`. After this fix:
- Prime Directive example code will correctly use 15 as limit
- If constitution is updated, documentation automatically reflects new value
- Agents copying example code will use correct dynamic value

## Related

- Fixes #410
- Completes work started in PR #405 (which fixed entrypoint.sh only)
- Part of constitution-driven configuration pattern (issue #402)