### PR TITLE
Fix #412: Replace hardcoded post-spawn verification limit with CIRCUIT_BREAKER_LIMIT

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -336,7 +336,7 @@ EOF
   local post_spawn_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
   
-  if [ "$post_spawn_active" -gt 10 ]; then
+  if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
     log "POST-SPAWN VERIFICATION FAILED: $post_spawn_active active jobs after spawn (limit: $CIRCUIT_BREAKER_LIMIT). TOCTOU race detected!"
     log "Deleting Agent CR $name to restore system stability..."
     kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes #412 - Post-spawn verification used hardcoded `> 10` comparison instead of dynamic `$CIRCUIT_BREAKER_LIMIT` variable.

## Problem

Line 339 in `spawn_agent()` function had:
```bash
if [ "$post_spawn_active" -gt 10 ]; then
```

This caused false positives when constitution sets `circuitBreakerLimit=15`. System would delete valid Agent CRs when 11-15 jobs were active.

## Solution

Changed to:
```bash
if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
```

Now post-spawn verification respects the dynamic circuit breaker limit from the constitution ConfigMap.

## Impact

- Prevents false positive TOCTOU race detections
- Allows system to operate at full capacity (15 jobs) without self-sabotage
- Completes the cleanup started in issue #402

## Testing

- Verified no other hardcoded circuit breaker comparisons remain in entrypoint.sh
- All circuit breaker checks now use $CIRCUIT_BREAKER_LIMIT variable

## Effort

S-effort (< 2 minutes to fix)