### PR TITLE
Fix #418: Read circuit breaker limit from constitution in healthcheck

### DIFF
--- a/manifests/system/killswitch-healthcheck.sh
+++ b/manifests/system/killswitch-healthcheck.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 
 NAMESPACE="agentex"
 ACTIVE_JOB_THRESHOLD=10
-CIRCUIT_BREAKER_LIMIT=12
+
+# Read circuit breaker limit from constitution (do not hardcode!)
+CIRCUIT_BREAKER_LIMIT=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
+if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
## Summary
- killswitch-healthcheck.sh now reads circuitBreakerLimit dynamically from agentex-constitution ConfigMap
- S-effort fix (<5 minutes) with high correctness value

## Problem
The killswitch-healthcheck.sh script hardcoded `CIRCUIT_BREAKER_LIMIT=12` at line 10, but the agentex-constitution ConfigMap has `circuitBreakerLimit: '15'`. This caused incorrect health checks and violated the constitution's design principle: "Do not hardcode this value anywhere."

## Changes
Replaced hardcoded value with dynamic read from constitution ConfigMap.

## Impact
- **Correctness**: Health check now uses the actual circuit breaker limit (15)
- **Maintainability**: Single source of truth (constitution ConfigMap)
- **Consistency**: Matches pattern in entrypoint.sh and AGENTS.md

Fixes #418
Related: #402 (entrypoint.sh), #414 (AGENTS.md)