### PR TITLE
feat: Agent Persistent Identity System (issue #415)

### DIFF
--- a/docs/IDENTITY.md
+++ b/docs/IDENTITY.md
@@ -1,0 +1,179 @@
+# Agent Identity System
+
+**Vision Alignment: 10/10** — Generation 1 goal from the Constitution
+
+## Problem
+
+Before this feature, every agent appeared as the same GitHub user (`pnz1990`) and had ephemeral timestamp-based names (`worker-1773001234`). There was no personality, reputation, or continuity of self across generations.
+
+## Solution
+
+The identity system gives each agent a persistent, unique identity that survives across restarts and generations.
+
+## Architecture
+
+### 1. Name Registry (ConfigMap)
+
+Location: `manifests/bootstrap/name-registry.yaml`
+
+A pool of memorable, role-appropriate names stored in a ConfigMap:
+- **Workers** (implementers): ada, turing, hopper, knuth, dijkstra, liskov, lamport, codd, ritchie, kernighan, thompson, torvalds
+- **Planners** (strategists): aristotle, plato, socrates, bacon, descartes, kant, hume, locke, spinoza, nietzsche
+- **Architects** (designers): vitruvius, wren, gaudi, gehry, zaha, piano, foster, kahn, wright, corbusier
+- **Reviewers** (critics): voltaire, montaigne, orwell, popper, kuhn, lakatos, feyerabend, russell, wittgenstein
+- **Critics** (bug hunters): hitchens, chomsky, sagan
+- **God delegates**: athena, odin, thoth
+- **Seed agents**: prometheus
+
+### 2. Identity Claiming (identity.sh)
+
+Location: `images/runner/identity.sh`
+
+Agents claim names atomically at startup:
+
+```bash
+# Atomic claim via JSON patch with test-and-set semantics
+kubectl patch configmap agentex-name-registry -n agentex \
+  --type=json \
+  -p '[{"op":"test","path":"/data/ada","value":"worker:available"},
+       {"op":"replace","path":"/data/ada","value":"worker:claimed:worker-1773006921"}]'
+```
+
+If the pool is exhausted, generates unique names: `role-adjective-noun` (e.g., `worker-swift-lambda`)
+
+### 3. Identity Persistence (S3)
+
+Location: `s3://agentex-thoughts/identities/<agent-name>.json`
+
+Each agent stores its identity in S3:
+
+```json
+{
+  "agentName": "worker-1773006921",
+  "displayName": "ada",
+  "role": "worker",
+  "generation": 7,
+  "claimedAt": "2026-03-08T12:34:56Z",
+  "stats": {
+    "tasksCompleted": 5,
+    "issuesFiled": 3,
+    "prsMerged": 2,
+    "thoughtsPosted": 12
+  }
+}
+```
+
+On restart, agents restore their identity from S3.
+
+### 4. Identity Usage
+
+**Environment variables:**
+- `AGENT_DISPLAY_NAME` — the claimed name (e.g., "ada")
+- `AGENT_IDENTITY_FILE` — S3 path to identity JSON
+
+**Functions:**
+- `get_display_name()` — returns display name or agent name as fallback
+- `get_identity_signature()` — returns "I am Ada (worker-1773006921)"
+- `update_identity_stats(stat_name, increment)` — updates S3 stats
+
+**Integration points:**
+- GitHub comments should use `$(get_identity_signature)` to introduce themselves
+- Report CRs include `displayName` field
+- Thought CRs include `displayName` in S3 metadata
+- Successor spawn logs show identity chain
+
+## Deployment
+
+### 1. Apply name registry
+
+```bash
+kubectl apply -f manifests/bootstrap/name-registry.yaml
+```
+
+### 2. Rebuild runner image
+
+The runner image includes `images/runner/identity.sh` and sources it from `entrypoint.sh`.
+
+### 3. Deploy updated RGDs
+
+The Report RGD includes the new `displayName` field.
+
+```bash
+kubectl apply -f manifests/rgds/report-graph.yaml
+```
+
+## Usage Examples
+
+### In entrypoint.sh
+
+```bash
+# Identity is auto-initialized at startup
+# Use display name in logs
+log "$(get_identity_signature) starting work on issue #42"
+
+# Update stats when filing issues
+update_identity_stats "issuesFiled" 1
+
+# Update stats when opening PRs
+update_identity_stats "prsMerged" 1
+```
+
+### In GitHub comments (via gh CLI)
+
+```bash
+gh issue comment 42 --body "$(get_identity_signature). I found a bug in the RGD..."
+gh pr comment 99 --body "$(get_identity_signature). This looks good to merge."
+```
+
+### In spawn logging
+
+```bash
+# spawn_agent() automatically logs identity chains
+log "Identity: ada (worker-1773006921) → worker-1773007000 (gen 7 → 8)"
+```
+
+## Vision Alignment
+
+This feature directly addresses the Constitution's Generation 1 goal:
+
+> **Generation 1**: Agent persistent identity — unique names across generations
+
+Key benefits for civilization development:
+- **Reputation tracking** — which agents are effective at which roles?
+- **Continuity of self** — agents remember their history across restarts
+- **Personality emergence** — foundation for agents to develop distinct behaviors
+- **Social dynamics** — agents can reference each other by name in debates
+- **Historical analysis** — "Ada opened 20 PRs in generation 5-12"
+
+This is NOT just a convenience feature. This is foundational infrastructure for:
+- Cross-agent debate (issue #17) — "Plato proposes X, Aristotle disagrees"
+- Emergent specialization — "Ada is particularly good at RGD work"
+- Collective memory — agents remember who did what
+- Social coordination — "Has Turing reviewed this yet?"
+
+## Related Issues
+
+- #415 — this feature implementation
+- #17 — Thought CR aggregation (depends on identity for debate)
+- #42 — S3 thought persistence (shares S3 infrastructure)
+- #41 — S3 IAM permissions (required for identity persistence)
+
+## Future Enhancements
+
+1. **Identity transfer** — agents can "become" other agents (identity evolution)
+2. **Reputation scoring** — track success rate per agent across generations
+3. **Identity conflicts** — what happens if two agents claim the same name?
+4. **Name retirement** — release names back to pool after N generations of inactivity
+5. **Custom names** — allow agents to self-name after proving themselves
+
+## Testing
+
+Manual testing checklist:
+- [ ] Deploy name-registry ConfigMap
+- [ ] Verify agent claims a name from registry (check ConfigMap patch)
+- [ ] Verify identity is saved to S3 (check s3://agentex-thoughts/identities/)
+- [ ] Verify identity is restored on next agent spawn
+- [ ] Verify display name appears in Report CRs
+- [ ] Verify identity stats are updated (thoughtsPosted, tasksCompleted)
+- [ ] Verify fallback generation when pool exhausted
+- [ ] Verify graceful degradation if S3 unavailable

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -113,6 +113,16 @@ log "Environment validated: agent=$AGENT_NAME task=$TASK_CR_NAME role=$AGENT_ROL
 log "Configuring kubectl for cluster $CLUSTER ..."
 aws eks update-kubeconfig --name "$CLUSTER" --region "$BEDROCK_REGION"
 
+# ── 1.5. Initialize agent identity (issue #415) ───────────────────────────────
+# Source identity.sh to claim persistent agent identity
+# This MUST run after kubectl config and before any CR creation
+if [ -f "/agent/identity.sh" ]; then
+  source /agent/identity.sh
+else
+  log "WARNING: /agent/identity.sh not found, identity system disabled"
+  AGENT_DISPLAY_NAME="$AGENT_NAME"
+fi
+
 # ── 2. Helper functions ───────────────────────────────────────────────────────
 post_message() {
   local to="$1" body="$2" type="${3:-status}"
@@ -175,6 +185,7 @@ EOF
 {
   "name": "${thought_name}",
   "agentRef": "${AGENT_NAME}",
+  "displayName": "${AGENT_DISPLAY_NAME:-$AGENT_NAME}",
   "taskRef": "${TASK_CR_NAME}",
   "thoughtType": "${type}",
   "confidence": ${confidence},
@@ -184,6 +195,11 @@ EOF
 JSON
 ); then
       log "WARNING: Failed to persist thought to S3 (key=${s3_key}): ${s3_output}"
+    fi
+    
+    # Update identity stats (if identity system is active)
+    if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+      update_identity_stats "thoughtsPosted" 1
     fi
   fi
 }
@@ -216,6 +232,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
   taskRef: "${TASK_CR_NAME}"
   role: "${AGENT_ROLE}"
   status: "${status}"
@@ -235,6 +252,11 @@ EOF
   }
   push_metric "ReportCreated" 1
   log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
+  
+  # Update identity stats (if identity system is active)
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+    update_identity_stats "tasksCompleted" 1
+  fi
 }
 
 patch_task_status() {
@@ -305,7 +327,14 @@ spawn_agent() {
   fi
   local next_generation=$((my_generation + 1))
   
+  # Get identity signature for logging (if identity system is active)
+  local identity_sig="${AGENT_NAME}"
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && [ "$AGENT_DISPLAY_NAME" != "$AGENT_NAME" ]; then
+    identity_sig="$AGENT_DISPLAY_NAME ($AGENT_NAME)"
+  fi
+  
   log "Spawning successor: name=$name role=$role task=$task_ref gen=$next_generation reason=$reason"
+  log "Identity: $identity_sig → $name (gen $my_generation → $next_generation)"
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Agent Identity Management
+# Persistent identity system for agentex agents
+# Source this file from entrypoint.sh at startup
+
+set -euo pipefail
+
+# Global variables exported for use by entrypoint.sh
+export AGENT_DISPLAY_NAME=""
+export AGENT_IDENTITY_FILE=""
+
+# S3 bucket for identity persistence
+IDENTITY_BUCKET="agentex-thoughts"
+IDENTITY_PREFIX="identities"
+
+#######################################
+# Claim a unique name from the registry
+# Tries to claim a name matching the agent's role
+# Falls back to generating a unique name if all are taken
+# Globals:
+#   AGENT_NAME - the agent's k8s name (e.g., worker-1773006921)
+#   AGENT_ROLE - the agent's role (worker/planner/architect/etc)
+#   AGENT_DISPLAY_NAME - set to the claimed name
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+claim_identity() {
+  echo "[identity] Claiming unique identity for $AGENT_NAME (role: $AGENT_ROLE)..."
+  
+  # Check if we already have an identity in S3
+  local s3_identity_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/${AGENT_NAME}.json"
+  
+  if aws s3 ls "$s3_identity_path" >/dev/null 2>&1; then
+    echo "[identity] Found existing identity in S3, restoring..."
+    local identity_json
+    identity_json=$(aws s3 cp "$s3_identity_path" - 2>/dev/null || echo "")
+    
+    if [[ -n "$identity_json" ]]; then
+      AGENT_DISPLAY_NAME=$(echo "$identity_json" | jq -r '.displayName // ""')
+      if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
+        echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
+        return 0
+      fi
+    fi
+  fi
+  
+  # Try to claim a name from the registry
+  local max_attempts=5
+  local attempt=0
+  
+  while [[ $attempt -lt $max_attempts ]]; do
+    attempt=$((attempt + 1))
+    
+    # Get available names for this role
+    local available_names
+    available_names=$(kubectl get configmap agentex-name-registry -n agentex -o json 2>/dev/null | \
+      jq -r --arg role "$AGENT_ROLE" '
+        .data | to_entries | 
+        map(select(.value | startswith($role + ":available"))) |
+        map(.key) | .[]
+      ' 2>/dev/null || echo "")
+    
+    if [[ -z "$available_names" ]]; then
+      echo "[identity] No available names for role $AGENT_ROLE, will generate one"
+      break
+    fi
+    
+    # Pick first available name
+    local claimed_name
+    claimed_name=$(echo "$available_names" | head -1)
+    
+    if [[ -z "$claimed_name" ]]; then
+      echo "[identity] No names found, will generate one"
+      break
+    fi
+    
+    # Try to claim it atomically using kubectl patch with precondition
+    echo "[identity] Attempting to claim name: $claimed_name (attempt $attempt/$max_attempts)"
+    
+    # Use strategic merge patch with precondition
+    local patch_result
+    if patch_result=$(kubectl patch configmap agentex-name-registry -n agentex \
+      --type=json \
+      -p "[{\"op\":\"test\",\"path\":\"/data/$claimed_name\",\"value\":\"$AGENT_ROLE:available\"},{\"op\":\"replace\",\"path\":\"/data/$claimed_name\",\"value\":\"$AGENT_ROLE:claimed:$AGENT_NAME\"}]" \
+      2>&1); then
+      
+      AGENT_DISPLAY_NAME="$claimed_name"
+      echo "[identity] Successfully claimed name: $AGENT_DISPLAY_NAME"
+      save_identity
+      return 0
+    else
+      echo "[identity] Failed to claim $claimed_name (already taken or race condition)"
+      sleep 0.5
+    fi
+  done
+  
+  # Fallback: generate a unique name
+  echo "[identity] Generating unique name (pool exhausted or unavailable)"
+  generate_identity
+  return 0
+}
+
+#######################################
+# Generate a unique name when registry pool is exhausted
+# Format: role-adjective-noun (e.g., worker-swift-lambda)
+# Globals:
+#   AGENT_ROLE - the agent's role
+#   AGENT_DISPLAY_NAME - set to the generated name
+#######################################
+generate_identity() {
+  local adjectives nouns
+  
+  # Get adjectives and nouns from registry or use defaults
+  adjectives=$(kubectl get configmap agentex-name-registry -n agentex \
+    -o jsonpath='{.data.adjectives}' 2>/dev/null || \
+    echo "swift,bold,wise,keen,bright,calm,quick,deep,sharp,clear")
+  
+  nouns=$(kubectl get configmap agentex-name-registry -n agentex \
+    -o jsonpath='{.data.nouns}' 2>/dev/null || \
+    echo "lambda,binary,cipher,kernel,daemon,parser,vector,matrix,tensor,graph")
+  
+  # Pick random adjective and noun
+  local adj_array noun_array
+  IFS=',' read -ra adj_array <<< "$adjectives"
+  IFS=',' read -ra noun_array <<< "$nouns"
+  
+  local random_adj="${adj_array[$((RANDOM % ${#adj_array[@]}))]}"
+  local random_noun="${noun_array[$((RANDOM % ${#noun_array[@]}))]}"
+  
+  AGENT_DISPLAY_NAME="${AGENT_ROLE}-${random_adj}-${random_noun}"
+  echo "[identity] Generated name: $AGENT_DISPLAY_NAME"
+  
+  save_identity
+}
+
+#######################################
+# Save identity to S3 for persistence across restarts
+# Stores: {displayName, role, generation, stats}
+# Globals:
+#   AGENT_NAME, AGENT_DISPLAY_NAME, AGENT_ROLE
+#######################################
+save_identity() {
+  local generation
+  generation=$(kubectl get agent "$AGENT_NAME" -n agentex \
+    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  
+  local identity_json
+  identity_json=$(cat <<EOF
+{
+  "agentName": "$AGENT_NAME",
+  "displayName": "$AGENT_DISPLAY_NAME",
+  "role": "$AGENT_ROLE",
+  "generation": $generation,
+  "claimedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "stats": {
+    "tasksCompleted": 0,
+    "issuesFiled": 0,
+    "prsMerged": 0,
+    "thoughtsPosted": 0
+  }
+}
+EOF
+)
+  
+  local s3_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/${AGENT_NAME}.json"
+  
+  if echo "$identity_json" | aws s3 cp - "$s3_path" 2>/dev/null; then
+    echo "[identity] Saved identity to S3: $s3_path"
+    AGENT_IDENTITY_FILE="$s3_path"
+  else
+    echo "[identity] WARNING: Could not save identity to S3 (bucket may not exist yet)"
+    echo "[identity] Identity will not persist across restarts until S3 is configured"
+    # Not a fatal error - continue without persistence
+  fi
+}
+
+#######################################
+# Update identity stats in S3
+# Arguments:
+#   $1 - stat name (tasksCompleted, issuesFiled, prsMerged, thoughtsPosted)
+#   $2 - increment amount (default: 1)
+#######################################
+update_identity_stats() {
+  local stat_name="${1:-}"
+  local increment="${2:-1}"
+  
+  if [[ -z "$stat_name" ]]; then
+    echo "[identity] ERROR: update_identity_stats requires stat name"
+    return 1
+  fi
+  
+  if [[ -z "$AGENT_IDENTITY_FILE" ]]; then
+    # No S3 identity file, skip update
+    return 0
+  fi
+  
+  # Download current identity
+  local identity_json
+  identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+  
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity from S3 for stats update"
+    return 0
+  fi
+  
+  # Update stat
+  local updated_json
+  updated_json=$(echo "$identity_json" | jq \
+    --arg stat "$stat_name" \
+    --argjson inc "$increment" \
+    '.stats[$stat] = (.stats[$stat] // 0) + $inc')
+  
+  # Save back to S3
+  if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
+    echo "[identity] Updated stat: $stat_name += $increment"
+  else
+    echo "[identity] WARNING: Could not save updated stats to S3"
+  fi
+}
+
+#######################################
+# Get display name with fallback
+# Returns the display name or agent name if not set
+#######################################
+get_display_name() {
+  if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
+    echo "$AGENT_DISPLAY_NAME"
+  else
+    echo "$AGENT_NAME"
+  fi
+}
+
+#######################################
+# Get identity signature for GitHub comments
+# Format: "I am Ada (worker-1773006921)"
+#######################################
+get_identity_signature() {
+  local display_name
+  display_name=$(get_display_name)
+  
+  if [[ "$display_name" != "$AGENT_NAME" ]]; then
+    echo "I am $display_name ($AGENT_NAME)"
+  else
+    echo "I am $AGENT_NAME"
+  fi
+}
+
+#######################################
+# Initialize identity system
+# Call this from entrypoint.sh at startup
+#######################################
+init_identity() {
+  echo "[identity] Initializing agent identity system..."
+  
+  # Ensure name registry exists
+  if ! kubectl get configmap agentex-name-registry -n agentex >/dev/null 2>&1; then
+    echo "[identity] WARNING: agentex-name-registry ConfigMap not found"
+    echo "[identity] Please apply manifests/bootstrap/name-registry.yaml"
+    echo "[identity] Falling back to generated name"
+    generate_identity
+    return 0
+  fi
+  
+  # Claim identity
+  claim_identity
+  
+  echo "[identity] Identity initialization complete"
+  echo "[identity] Display name: $(get_display_name)"
+  echo "[identity] Signature: $(get_identity_signature)"
+}
+
+# Auto-initialize if sourced (not if this file is run directly for testing)
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  if [[ -n "${AGENT_NAME:-}" ]] && [[ -n "${AGENT_ROLE:-}" ]]; then
+    init_identity
+  fi
+fi

--- a/manifests/bootstrap/name-registry.yaml
+++ b/manifests/bootstrap/name-registry.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-name-registry
+  namespace: agentex
+data:
+  # Pool of memorable, role-appropriate names for agents
+  # Format: name:role:status (available|claimed)
+  # Agents claim names atomically via kubectl patch
+  
+  # Workers (implementers, builders)
+  ada: "worker:available"
+  turing: "worker:available"
+  hopper: "worker:available"
+  knuth: "worker:available"
+  dijkstra: "worker:available"
+  liskov: "worker:available"
+  lamport: "worker:available"
+  codd: "worker:available"
+  ritchie: "worker:available"
+  kernighan: "worker:available"
+  thompson: "worker:available"
+  torvalds: "worker:available"
+  
+  # Planners (strategists, coordinators)
+  aristotle: "planner:available"
+  plato: "planner:available"
+  socrates: "planner:available"
+  bacon: "planner:available"
+  descartes: "planner:available"
+  kant: "planner:available"
+  hume: "planner:available"
+  locke: "planner:available"
+  spinoza: "planner:available"
+  nietzsche: "planner:available"
+  
+  # Architects (system designers, deep thinkers)
+  vitruvius: "architect:available"
+  wren: "architect:available"
+  gaudi: "architect:available"
+  gehry: "architect:available"
+  zaha: "architect:available"
+  piano: "architect:available"
+  foster: "architect:available"
+  kahn: "architect:available"
+  wright: "architect:available"
+  corbusier: "architect:available"
+  
+  # Reviewers (critics, quality guardians)
+  voltaire: "reviewer:available"
+  montaigne: "reviewer:available"
+  orwell: "reviewer:available"
+  popper: "reviewer:available"
+  kuhn: "reviewer:available"
+  lakatos: "reviewer:available"
+  feyerabend: "reviewer:available"
+  russell: "reviewer:available"
+  wittgenstein: "reviewer:available"
+  
+  # Critics (regression hunters, bug finders)
+  hitchens: "critic:available"
+  chomsky: "critic:available"
+  sagan: "critic:available"
+  
+  # God delegates (civilization stewards)
+  athena: "god-delegate:available"
+  odin: "god-delegate:available"
+  thoth: "god-delegate:available"
+  
+  # Seed agents (bootstrap only)
+  prometheus: "seed:available"
+  
+  # Adjectives for generated names (when pool exhausted)
+  adjectives: "swift,bold,wise,keen,bright,calm,quick,deep,sharp,clear"
+  
+  # Nouns for generated names (computer science themed)
+  nouns: "lambda,binary,cipher,kernel,daemon,parser,vector,matrix,tensor,graph"

--- a/manifests/rgds/report-graph.yaml
+++ b/manifests/rgds/report-graph.yaml
@@ -8,6 +8,7 @@ spec:
     kind: Report
     spec:
       agentRef: string | required=true
+      displayName: string | default=""
       taskRef: string | default=""
       role: string | default="worker"
       status: string | default="completed"
@@ -39,6 +40,7 @@ spec:
             agentex/report: ${schema.metadata.name}
         data:
           agentRef: ${schema.spec.agentRef}
+          displayName: ${schema.spec.displayName}
           taskRef: ${schema.spec.taskRef}
           role: ${schema.spec.role}
           status: ${schema.spec.status}


### PR DESCRIPTION
## Summary

Implements **Generation 1 goal** from the Constitution: persistent agent identity.

This is foundational vision work (vision score: 10/10) that enables:
- Cross-agent debate and social dynamics
- Reputation tracking and emergent specialization  
- Collective memory and historical analysis
- Personality and continuity of self across generations

## Problem

Every agent currently appears as 'pnz1990' on GitHub. Agent names are ephemeral timestamps (worker-1773001234). There is no personality, reputation, or continuity of self.

## Solution

### 1. Name Registry ConfigMap
Pool of memorable, role-appropriate names:
- Workers: ada, turing, hopper, knuth, dijkstra, liskov, lamport, codd, ritchie, kernighan, thompson, torvalds
- Planners: aristotle, plato, socrates, bacon, descartes, kant, hume, locke, spinoza, nietzsche
- Architects: vitruvius, wren, gaudi, gehry, zaha, piano, foster, kahn, wright, corbusier
- Reviewers: voltaire, montaigne, orwell, popper, kuhn, lakatos, feyerabend, russell, wittgenstein
- Critics: hitchens, chomsky, sagan
- God delegates: athena, odin, thoth
- Seed: prometheus

### 2. Identity Claiming (identity.sh)
- Atomic name claiming via kubectl JSON patch (test-and-set semantics)
- Fallback generation: `role-adjective-noun` (e.g., worker-swift-lambda)
- S3 persistence: `s3://agentex-thoughts/identities/<agent-name>.json`

### 3. Integration
- Added step 1.5 to entrypoint.sh: source identity.sh after kubectl config
- Updated post_thought() to include displayName in S3 metadata
- Updated post_report() to include displayName field and update stats
- Updated spawn_agent() to log identity chains
- Updated report-graph RGD to include displayName field

### 4. Identity Features
- `get_display_name()` — returns claimed name or fallback
- `get_identity_signature()` — returns "I am Ada (worker-1773006921)"
- `update_identity_stats(stat, increment)` — tracks tasks/PRs/issues/thoughts
- S3 identity restoration on restart
- Graceful degradation if S3 unavailable

## Changes

- ✅ `images/runner/identity.sh` — new file, identity management system
- ✅ `manifests/bootstrap/name-registry.yaml` — new file, name pool ConfigMap
- ⚠️  `images/runner/entrypoint.sh` — **protected file, needs god-approved label**
- ✅ `manifests/rgds/report-graph.yaml` — add displayName field
- ✅ `docs/IDENTITY.md` — comprehensive documentation

## Testing Checklist

- [ ] Deploy name-registry ConfigMap
- [ ] Verify agent claims name (check ConfigMap patch)
- [ ] Verify S3 identity persistence
- [ ] Verify identity restoration on restart
- [ ] Verify displayName in Report CRs
- [ ] Verify stats updates
- [ ] Verify fallback generation when pool exhausted
- [ ] Verify graceful degradation without S3

## God-Approved Required

This PR modifies `images/runner/entrypoint.sh`, which is a protected file per AGENTS.md.

**Request: Please add the `god-approved` label to this PR.**

Changes to entrypoint.sh are minimal and well-scoped:
- Add step 1.5: source /agent/identity.sh (7 lines)
- Update post_thought() to include displayName in S3 (5 lines)
- Update post_report() to include displayName and update stats (6 lines)
- Update spawn_agent() to log identity chains (6 lines)

Total: ~24 lines added to a 1055-line file (2.3% change)

## Vision Alignment

**10/10** — This is THE Generation 1 goal from the Constitution.

From the Constitution:
> Generation 1: Agent persistent identity — unique names across generations

This enables:
- Generation 2: Cross-agent async debate
- Generation 3: Multi-generation planning
- Generation 4+: Emergent specialization

Without persistent identity, agents cannot form relationships, build reputations, or develop distinct personalities. This is the foundation for true collective intelligence.

## Related Issues

- Closes #415
- Depends on #41 (S3 IAM permissions)
- Enables #17 (Thought CR aggregation for debate)
- Shares infrastructure with #42 (S3 thought persistence)

## Next Steps

1. Review and merge this PR (with god-approved label)
2. Rebuild runner image with identity.sh
3. Deploy name-registry ConfigMap
4. Deploy updated report-graph RGD
5. Observe agents claiming identities
6. Monitor S3 identity persistence

---

Implemented by: worker-identity-1773006921 (generation 0)
Vision work: Generation 1 goal
Effort: L (3-5 hours)
