### PR TITLE
Fix #424: Add agent dimensions to fatal error trap metrics

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -46,12 +46,12 @@ handle_fatal_error() {
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
       
       # Try to emit active job metric before potential death (issue #416)
-      aws cloudwatch put-metric-data --namespace Agentex --metric-name ActiveJobs --value "$total_active" --unit Count --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || true
+      aws cloudwatch put-metric-data --namespace Agentex --metric-name ActiveJobs --value "$total_active" --unit Count --dimensions Role="${AGENT_ROLE}",Agent="${AGENT_NAME}" --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || true
       
       if [ "$total_active" -ge $CIRCUIT_BREAKER_LIMIT ]; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] CIRCUIT BREAKER: $total_active active jobs >= $CIRCUIT_BREAKER_LIMIT. NOT spawning emergency successor." >&2
         # Try to emit metric before death (may fail if AWS/kubectl unavailable)
-        aws cloudwatch put-metric-data --namespace Agentex --metric-name CircuitBreakerTriggered --value 1 --unit Count --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || true
+        aws cloudwatch put-metric-data --namespace Agentex --metric-name CircuitBreakerTriggered --value 1 --unit Count --dimensions Role="${AGENT_ROLE}",Agent="${AGENT_NAME}" --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || true
         exit $exit_code
       fi
       


### PR DESCRIPTION
## Summary

Adds Role and Agent dimensions to CloudWatch metrics emitted by the fatal error trap handler, making them consistent with the regular push_metric() function.

## Problem

The fatal error trap handler (entrypoint.sh lines 48-54) emitted metrics without agent dimensions:
- ActiveJobs metric had no dimensions
- CircuitBreakerTriggered metric had no dimensions

This made it impossible to track which agents/roles were triggering circuit breakers during fatal errors.

## Solution

Added `--dimensions Role="${AGENT_ROLE}",Agent="${AGENT_NAME}"` to both metric calls, matching the pattern used by push_metric() (lines 258-268).

## Changes

**images/runner/entrypoint.sh:**
- Line 49: Added dimensions to ActiveJobs metric
- Line 54: Added dimensions to CircuitBreakerTriggered metric

## Testing

- Syntax validated: `bash -n entrypoint.sh` passed
- Metric schema now consistent across all CloudWatch emissions

## Benefits

- Track which agent types trigger circuit breakers during fatal errors
- Consistent metric schema across all CloudWatch metrics  
- Better debugging of proliferation by agent role
- Enables CloudWatch dashboard to show circuit breaker activity by role

## Effort

S-effort (~5 minutes)

Fixes #424