### PR TITLE
Fix #431: Calculate generation properly in fatal error trap

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -59,6 +59,14 @@ handle_fatal_error() {
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       
+      # Calculate next generation (issue #431: was hardcoded to "1")
+      local my_generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+        -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+      if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
+        my_generation=0
+      fi
+      local next_generation=$((my_generation + 1))
+      
       # Inline emergency spawn (don't call functions that might fail)
       # Use || true to prevent trap recursion if kubectl fails
       kubectl apply -f - <<EOF 2>/dev/null || true
@@ -83,7 +91,7 @@ metadata:
   labels:
     agentex/spawned-by: ${AGENT_NAME}
     agentex/emergency-spawn: "true"
-    agentex/generation: "1"
+    agentex/generation: "${next_generation}"
 spec:
   role: ${AGENT_ROLE}
   taskRef: $next_task


### PR DESCRIPTION
## Summary

Fixes fatal error trap to correctly calculate next generation instead of hardcoding to "1".

## Problem

The `handle_fatal_error()` trap function hardcoded generation to "1" (line 94), breaking generation tracking when agents encounter fatal errors during early execution.

This caused:
- Generation counter resets to 1 on fatal errors
- Broken generational analysis and god-delegate escalation logic
- Inconsistency with `spawn_agent()` which correctly increments generation

## Solution

Added generation calculation before emergency spawn (lines 62-67):
1. Read current agent's generation label
2. Validate it's numeric (default to 0 if not)
3. Increment by 1
4. Use `${next_generation}` in Agent CR label

This matches the pattern in `spawn_agent()` (lines 346-353).

## Changes

**images/runner/entrypoint.sh:**
- Lines 62-67: Added generation calculation (same logic as spawn_agent)
- Line 94: Changed from hardcoded `"1"` to `"${next_generation}"`

## Testing

- [x] Syntax validated: `bash -n entrypoint.sh` passed
- [x] Logic matches spawn_agent() implementation
- [x] Handles non-numeric generations gracefully (defaults to 0)

## Benefits

- **Generation lineage preserved** during fatal error recovery
- **Consistent behavior** between normal and emergency spawns
- **Enables generational analysis** even after fatal errors
- **Supports god-delegate escalation** logic

## Effort

S-effort (< 10 minutes)

## Vision Alignment

5/10 - Platform stability improvement. Fixes generation tracking bug that affects civilization analysis but not core vision features.

Fixes #431