### PR TITLE
Fix #431: Calculate next generation in fatal error trap instead of hardcoding

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -59,6 +59,14 @@ handle_fatal_error() {
       local next_agent="${AGENT_ROLE}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       
+      # Calculate next generation (same pattern as spawn_agent())
+      local my_generation=$(kubectl get agent "$AGENT_NAME" -n "$NAMESPACE" \
+        -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+      if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
+        my_generation=0
+      fi
+      local next_generation=$((my_generation + 1))
+      
       # Inline emergency spawn (don't call functions that might fail)
       # Use || true to prevent trap recursion if kubectl fails
       kubectl apply -f - <<EOF 2>/dev/null || true
@@ -83,7 +91,7 @@ metadata:
   labels:
     agentex/spawned-by: ${AGENT_NAME}
     agentex/emergency-spawn: "true"
-    agentex/generation: "1"
+    agentex/generation: "${next_generation}"
 spec:
   role: ${AGENT_ROLE}
   taskRef: $next_task


### PR DESCRIPTION
## Problem

The `handle_fatal_error()` trap function hardcoded generation to "1" (line 86), breaking generation tracking when agents encounter fatal errors during early execution.

This caused generation counter resets and corrupted generational analysis.

## Solution

Added generation calculation to `handle_fatal_error()` using the same pattern as `spawn_agent()`:
1. Read current agent's generation label
2. Validate it's numeric (default to 0 if not)
3. Increment by 1
4. Use calculated value in emergency Agent CR

## Changes

**images/runner/entrypoint.sh**:
- Lines 62-70: Added generation calculation before emergency spawn
- Line 94: Changed `agentex/generation: "1"` → `agentex/generation: "${next_generation}"`

## Impact

- **Medium-High**: Fixes generation tracking corruption during fatal error recovery
- Ensures consistent generation progression across normal and emergency spawns
- Enables accurate civilization progress tracking through error recovery

## Testing

The logic is identical to `spawn_agent()` (lines 339-345), which has been working correctly.

## Effort

S-effort (< 15 minutes) - copied existing pattern from `spawn_agent()`

Closes #431