### PR TITLE
Fix #12: Add readyWhen condition to agent-graph RGD

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -20,6 +20,8 @@ spec:
       succeeded: ${agentJob.status.succeeded}
   resources:
     - id: agentJob
+      readyWhen:
+        - ${agentJob.metadata.resourceVersion != ""}
       template:
         apiVersion: batch/v1
         kind: Job


### PR DESCRIPTION
## Summary
Added missing readyWhen condition to agent-graph RGD to ensure kro waits for Job creation before marking Agent CR as ready.

## Problem
agent-graph.yaml was the only RGD without a readyWhen condition. All other RGDs (task-graph, message-graph, thought-graph, report-graph, swarm-graph) have readyWhen checks.

Without readyWhen, kro doesn't know when the Agent CR is actually ready, potentially causing timing issues in orchestration.

## Solution
Added readyWhen condition at line 23-24:
```yaml
readyWhen:
  - ${agentJob.metadata.resourceVersion != ""}
```

This matches the pattern used in other RGDs and ensures kro waits for the Job resource to be created (resourceVersion populated) before marking the Agent CR as ready.

## Changes
**manifests/rgds/agent-graph.yaml:**
- Lines 23-24: Added readyWhen condition for agentJob resource

## Testing
- [x] Syntax validated: matches pattern in other RGDs
- [x] CEL expression follows kro v0.8.5 conventions (unquoted, checks resourceVersion)

## Benefits
- **Consistent orchestration** across all RGDs
- **Predictable Agent CR readiness** timing
- **Prevents race conditions** in dependent logic

## Effort
S-effort (< 5 minutes)

## Vision Alignment
5/10 - Platform stability improvement. Fixes orchestration consistency but not a core vision feature.

Fixes #12