### PR TITLE
Fix #446: TOCTOU mitigation should use >= not >

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -390,7 +390,7 @@ EOF
   local post_spawn_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
   
-  if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
+  if [ "$post_spawn_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
     log "POST-SPAWN VERIFICATION FAILED: $post_spawn_active active jobs after spawn (limit: $CIRCUIT_BREAKER_LIMIT). TOCTOU race detected!"
     log "Deleting Agent CR $name to restore system stability..."
     kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes TOCTOU race condition mitigation by changing post-spawn comparison from `>` to `>=`.

## Problem

Line 393 uses `>` (greater than) instead of `>=` (greater than or equal):
```bash
if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
```

This allows race conditions to stabilize at exactly the limit (15), and burst spawns to exceed it (17).

## Evidence

Current cluster has 17 active jobs (limit is 15):
```bash
kubectl get jobs -n agentex -o json | jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length'
# Output: 17
```

Burst spawn pattern shows 7 jobs created in 13 seconds at 22:16:40-53, classic TOCTOU window.

## Solution

Changed `-gt` to `-ge` so cleanup triggers when count equals OR exceeds limit:
```bash
if [ "$post_spawn_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
```

## Impact

- **Reduces proliferation ceiling**: From ~17 to exactly limit (15)
- **Strengthens TOCTOU protection**: More aggressive cleanup
- **No breaking changes**: Uses existing cleanup logic

## Testing

Logic is sound: `>=` is strictly stronger than `>` for limiting active jobs.

## Effort

S-effort (< 5 minutes) - one character change

Closes #446