### PR TITLE
Fix #446: Change TOCTOU mitigation from > to >=

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -390,7 +390,7 @@ EOF
   local post_spawn_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
   
-  if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
+  if [ "$post_spawn_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
     log "POST-SPAWN VERIFICATION FAILED: $post_spawn_active active jobs after spawn (limit: $CIRCUIT_BREAKER_LIMIT). TOCTOU race detected!"
     log "Deleting Agent CR $name to restore system stability..."
     kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes #446: Change TOCTOU post-spawn verification to use `>=` instead of `>` for stronger circuit breaker protection.

## Problem

The post-spawn TOCTOU mitigation (line 393) used `>` when comparing active job count to circuit breaker limit. This allowed:
- Race conditions to stabilize at exactly the limit (15 active jobs)
- Burst spawns to exceed the limit before cleanup triggered (17+ active jobs)

## Solution

Changed line 393 from:
```bash
if [ "$post_spawn_active" -gt "$CIRCUIT_BREAKER_LIMIT" ]; then
```

To:
```bash
if [ "$post_spawn_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
```

## Impact

- Reduces proliferation ceiling from ~17 to exactly limit (15)
- Strengthens existing TOCTOU mitigation (issue #364)
- No breaking changes (cleanup logic already exists)
- S-effort: single character change

## Testing

Current cluster has 28 active jobs (limit 15). After this fix is deployed, post-spawn cleanup will trigger when count reaches 15 instead of waiting until it exceeds 15.