### PR TITLE
Fix #439: Add duplicate work prevention to spawn_task_and_agent

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -424,6 +424,17 @@ spawn_task_and_agent() {
   local task_name="$1" agent_name="$2" role="$3" title="$4" desc="$5" effort="${6:-M}" issue="${7:-0}" swarm_ref="${8:-}"
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
+  # DUPLICATE WORK PREVENTION (issue #439): Check for existing open PR before spawning
+  # This prevents multiple agents from working on the same issue simultaneously
+  if [ "$issue" != "0" ] && [ -n "$issue" ]; then
+    local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    if [ -n "$existing_pr" ]; then
+      log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr}. Skipping spawn."
+      post_thought "Skipped spawning worker for issue #${issue}: PR #${existing_pr} already open" "observation" 8
+      return 0  # Return success so caller continues normally
+    fi
+  fi
+
   local err_output
   err_output=$(kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1


### PR DESCRIPTION
## Summary
- Prevents agents from spawning workers for issues that already have open PRs
- Adds lightweight duplicate detection check (~500ms overhead per spawn)
- Returns success when duplicate detected so caller continues normally

## Problem Solved
Multiple agents were spawning workers for the same issue simultaneously, causing:
- Wasted compute resources (identical work by 2+ agents)
- Wasted CI/CD resources (duplicate builds)
- Review burden (maintainers close duplicate PRs manually)

Recent example: PR #435 and #436 both fixed issue #431 within 4 seconds.

## Implementation
In `spawn_task_and_agent()`, before creating Task CR:
1. If `issue` parameter is non-zero, check for existing open PR via `gh pr list --search "#N"`
2. If PR exists, log skip and post observation Thought CR
3. Return 0 (success) so caller continues without error

## Testing
Manual testing:
1. Agent spawns worker for issue with no PR → spawn succeeds ✓
2. Agent spawns worker for issue with open PR → spawn skipped, logs show duplicate detection ✓

## Effort
S-effort (< 15 minutes)

## Related
- Issue #439 (this fix)
- Issue #398 (previous duplicate prevention attempt)
- AGENTS.md line 183 (planner mandate to check PRs - now enforced)

Fixes #439