### PR TITLE
Fix #454: Update README-dashboard.md with correct line numbers

### DIFF
--- a/manifests/system/README-dashboard.md
+++ b/manifests/system/README-dashboard.md
@@ -108,12 +108,12 @@ Estimated cost: **~$3-5/month** for the full monitoring stack.
 The `images/runner/entrypoint.sh` script automatically pushes metrics. No agent code changes required.
 
 Key integration points:
-- Line 78-88: `push_metric()` helper function
-- Line 141: `AgentRun` on startup
-- Line 47: `MessageCreated` when posting messages
-- Line 66: `ThoughtCreated` when posting thoughts
-- Line 137: `TaskCreated` when spawning tasks
-- Line 407: `AgentFailure` on OpenCode non-zero exit
+- Line 299: `push_metric()` helper function
+- Line 452: `AgentRun` on startup
+- Line 180: `MessageCreated` when posting messages
+- Line 205: `ThoughtCreated` when posting thoughts
+- Line 440: `TaskCreated` when spawning tasks
+- Line 437, 828: `AgentFailure` on OpenCode non-zero exit and emergency failures
 
 ## Extending the Dashboard
 


### PR DESCRIPTION
## Summary

Fixes #454 — updates outdated line number references in `README-dashboard.md` to match current `entrypoint.sh`.

## Problem

The `manifests/system/README-dashboard.md` file documented integration points with line numbers from an old version of `entrypoint.sh`. The entrypoint.sh file has grown from ~400 to 1076 lines, making all line references outdated.

## Solution

Updated all line number references in the "Integration with Runner" section:

| Metric | Old line | New line |
|--------|----------|----------|
| `push_metric()` function | 78-88 | 299 |
| `AgentRun` | 141 | 452 |
| `MessageCreated` | 47 | 180 |
| `ThoughtCreated` | 66 | 205 |
| `TaskCreated` | 137 | 440 |
| `AgentFailure` | 407 | 437, 828 |

## Changes

**File:** `manifests/system/README-dashboard.md` (lines 111-116)
- Updated 6 line number references
- Added note about AgentFailure appearing in two places (437, 828)

Total: 1 file changed, 6 insertions(+), 6 deletions(-)

## Testing

- [x] Verified line numbers by grepping entrypoint.sh
- [x] Markdown renders correctly

## Impact

- **Documentation accuracy** — developers can now find the correct lines
- **Easier metric extension** — clear reference points for adding new metrics
- **No breaking changes** — documentation-only fix

## Effort

S-effort (< 10 minutes) — simple documentation update

## Vision Alignment

**1/10** — Documentation maintenance only, no vision work.