### PR TITLE
Fix #458: Add timeout wrappers to kubectl patch operations

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -306,7 +306,8 @@ patch_task_status() {
   
   # Patch the ConfigMap backing the Task CR, not the Task CR status directly.
   # kro status fields are output-only and reflect the ConfigMap data.
-  kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
+  # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
+  timeout 10s kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
     --type=merge \
     -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" \
     2>/dev/null || true
@@ -521,7 +522,8 @@ for msg_name in $(echo "$INBOX_JSON" | jq -r \
   '.items[] | select((.spec.to == $name or .spec.to == "broadcast" or .spec.to == $swarm) and (.status.read == "false" or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
-  kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
+  # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
+  timeout 10s kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
     --type=merge -p '{"data":{"read":"true"}}' 2>/dev/null || true
 done
 
@@ -556,7 +558,8 @@ for thought_name in $(echo "$THOUGHTS_JSON" | jq -r \
   else
     NEW_READ_BY="${CURRENT_READ_BY},${AGENT_NAME}"
   fi
-  kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
+  # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
+  timeout 10s kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"readBy\":\"${NEW_READ_BY}\"}}" 2>/dev/null || true
 done
 
@@ -1064,7 +1067,8 @@ if [ -n "$SWARM_REF" ]; then
   fi
   
   # Patch swarm state
-  kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+  # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
+  timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
     2>/dev/null || true
   
@@ -1086,7 +1090,8 @@ if [ -n "$SWARM_REF" ]; then
           log "SWARM DISSOLUTION: $SWARM_REF has completed all tasks and been idle for ${IDLE_SECONDS}s"
           
           # Update phase to Disbanded
-          kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+          # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
+          timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
             --type=merge -p '{"data":{"phase":"Disbanded"}}' 2>/dev/null || true
           
           # Broadcast dissolution message


### PR DESCRIPTION
## Summary

Adds `timeout 10s` wrappers to critical kubectl patch operations to prevent 120s hangs when cluster API is unreachable.

## Problem

Issue #441 added `kubectl_with_timeout()` wrapper for read operations (circuit breaker checks, generation labels, kill switch). However, write operations (patch, apply) still use bare `kubectl` without timeout protection.

Impact: If cluster API becomes unreachable during a patch operation, agents hang for 120 seconds instead of failing fast.

## Solution

Added `timeout 10s` prefix to 5 critical kubectl patch calls:

| Location | Function | What it patches |
|----------|----------|----------------|
| Line 309 | `patch_task_status()` | Task completion status |
| Line 524 | Message read loop | Message read flags |
| Line 559 | Thought read loop | Thought readBy tracking |
| Line 1070 | Swarm state update | Task completion counts |
| Line 1093 | Swarm dissolution | Phase change to Disbanded |

All patches already have `|| true` error traps, now they also fail fast (10s instead of 120s).

## Testing

- Syntax validated with `bash -n entrypoint.sh`
- Pattern matches existing `kubectl_with_timeout` usage
- All modified lines already had `|| true` traps (no behavior change on success)

## Impact

**Before**: Cluster API unreachable → 120s hang per patch → cascading timeouts
**After**: Cluster API unreachable → 10s timeout per patch → fast failure detection

## Effort

S-effort (< 15 minutes): 5 lines changed, consistent pattern application

## Related Issues

- Issue #441 (kubectl timeout wrappers for reads)
- Issue #430 (kubectl connectivity timeout that motivated #441)

Fixes #458