### PR TITLE
Fix issue #458: add timeout wrappers to kubectl patch operations

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -306,7 +306,7 @@ patch_task_status() {
   
   # Patch the ConfigMap backing the Task CR, not the Task CR status directly.
   # kro status fields are output-only and reflect the ConfigMap data.
-  kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
+  timeout 10s kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
     --type=merge \
     -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" \
     2>/dev/null || true
@@ -521,7 +521,7 @@ for msg_name in $(echo "$INBOX_JSON" | jq -r \
   '.items[] | select((.spec.to == $name or .spec.to == "broadcast" or .spec.to == $swarm) and (.status.read == "false" or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
-  kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
+  timeout 10s kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
     --type=merge -p '{"data":{"read":"true"}}' 2>/dev/null || true
 done
 
@@ -556,7 +556,7 @@ for thought_name in $(echo "$THOUGHTS_JSON" | jq -r \
   else
     NEW_READ_BY="${CURRENT_READ_BY},${AGENT_NAME}"
   fi
-  kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
+  timeout 10s kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"readBy\":\"${NEW_READ_BY}\"}}" 2>/dev/null || true
 done
 
@@ -1064,7 +1064,7 @@ if [ -n "$SWARM_REF" ]; then
   fi
   
   # Patch swarm state
-  kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+  timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
     2>/dev/null || true
   
@@ -1086,7 +1086,7 @@ if [ -n "$SWARM_REF" ]; then
           log "SWARM DISSOLUTION: $SWARM_REF has completed all tasks and been idle for ${IDLE_SECONDS}s"
           
           # Update phase to Disbanded
-          kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+          timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
             --type=merge -p '{"data":{"phase":"Disbanded"}}' 2>/dev/null || true
           
           # Broadcast dissolution message


### PR DESCRIPTION
## Summary

Fixes #458 — Adds 10-second timeout wrappers to all critical kubectl patch operations to prevent agents from hanging for 120 seconds when cluster API becomes unreachable.

## Changes

Added `timeout 10s` to 5 kubectl patch calls:
1. **patch_task_status()** (line 309) — marks tasks Done
2. **Message read marking** (line 524) — marks inbox messages read
3. **Thought read marking** (line 559) — marks peer thoughts read
4. **Swarm state updates** (lines 1067, 1089) — updates swarm completion and dissolution

## Impact

- Agents fail fast (10s) instead of hanging (120s) when API is unreachable during writes
- Matches the pattern from issue #441 for read operations
- Reduces wasted resources and improves failure detection

## Testing

No test coverage needed — timeout wrapper is a defensive measure that only activates during cluster API failures. Existing error handling (`|| true`) ensures graceful degradation.

## Effort

S-effort (changed 5 lines)