### PR TITLE
Fix #458: Add timeout wrappers to kubectl patch/apply operations

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -168,7 +168,8 @@ post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Message
 metadata:
@@ -193,7 +194,8 @@ post_thought() {
   local content="$1" type="${2:-observation}" confidence="${3:-7}"
   local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
@@ -264,7 +266,8 @@ post_report() {
   fi
   
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Report
 metadata:
@@ -306,7 +309,8 @@ patch_task_status() {
   
   # Patch the ConfigMap backing the Task CR, not the Task CR status directly.
   # kro status fields are output-only and reflect the ConfigMap data.
-  kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  timeout 10s kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
     --type=merge \
     -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" \
     2>/dev/null || true
@@ -379,7 +383,8 @@ spawn_agent() {
   log "Spawning successor: name=$name role=$role task=$task_ref gen=$next_generation reason=$reason"
   log "Identity: $identity_sig → $name (gen $my_generation → $next_generation)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
@@ -436,7 +441,8 @@ spawn_task_and_agent() {
   fi
 
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
@@ -521,7 +527,8 @@ for msg_name in $(echo "$INBOX_JSON" | jq -r \
   '.items[] | select((.spec.to == $name or .spec.to == "broadcast" or .spec.to == $swarm) and (.status.read == "false" or .status.read == null)) | .metadata.name' \
   2>/dev/null || true); do
   # Patch the ConfigMap, not the Message CR. kro status fields are output-only.
-  kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  timeout 10s kubectl patch configmap "${msg_name}-msg" -n "$NAMESPACE" \
     --type=merge -p '{"data":{"read":"true"}}' 2>/dev/null || true
 done
 
@@ -556,7 +563,8 @@ for thought_name in $(echo "$THOUGHTS_JSON" | jq -r \
   else
     NEW_READ_BY="${CURRENT_READ_BY},${AGENT_NAME}"
   fi
-  kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  timeout 10s kubectl patch configmap "${thought_name}-thought" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"readBy\":\"${NEW_READ_BY}\"}}" 2>/dev/null || true
 done
 
@@ -1064,7 +1072,8 @@ if [ -n "$SWARM_REF" ]; then
   fi
   
   # Patch swarm state
-  kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+  # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+  timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
     --type=merge -p "{\"data\":{\"tasksCompleted\":\"${NEW_TASKS}\",\"memberAgents\":\"${NEW_MEMBERS}\",\"lastActivityTimestamp\":\"${TIMESTAMP}\"}}" \
     2>/dev/null || true
   
@@ -1086,7 +1095,8 @@ if [ -n "$SWARM_REF" ]; then
           log "SWARM DISSOLUTION: $SWARM_REF has completed all tasks and been idle for ${IDLE_SECONDS}s"
           
           # Update phase to Disbanded
-          kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
+          # Issue #458: Add timeout wrapper to prevent 120s hangs on cluster unreachable
+          timeout 10s kubectl patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
             --type=merge -p '{"data":{"phase":"Disbanded"}}' 2>/dev/null || true
           
           # Broadcast dissolution message


### PR DESCRIPTION
## Summary

Issue #441 added `kubectl_with_timeout()` wrapper for read operations, but many write operations (patch/apply) still lack timeout protection. This causes agents to hang for 120s instead of failing fast when cluster API is unreachable.

## Changes

Added `timeout 10s` wrapper to 9 critical write operations:

1. **patch_task_status()** - Task completion marking
2. **Message read marking** - Inbox processing
3. **Thought read marking** - Peer context processing  
4. **Swarm state updates** (2 locations) - Swarm coordination
5. **post_message()** - Message CR creation
6. **post_thought()** - Thought CR creation
7. **post_report()** - Report CR creation
8. **spawn_agent()** - Agent CR creation
9. **spawn_task_and_agent()** - Task CR creation

## Impact

- Agents now fail fast after 10s during cluster connectivity issues
- Prevents 120s hangs that waste resources and delay failure detection
- Improves system resilience during API server overload or network issues
- Consistent timeout behavior across all kubectl operations

## Testing

All operations already have `|| true` or error handling, so timeouts will gracefully fail without breaking agent execution flow.

## Effort

S-effort (< 30 minutes, 9 locations updated)

## Vision Score

5/10 - Platform stability improvement that enables faster failure detection