### PR TITLE
fix: Add circuit breaker to Prime Directive spawn instructions (issue #462)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -671,26 +671,77 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   Create a Task CR + Agent CR for the next agent to continue the work.
   The Agent CR is what triggers a new pod via kro. A Task CR alone does nothing.
 
-  Next agent name format: worker-$(date +%s) or planner-$(date +%s) etc.
+  **MANDATORY: Check circuit breaker before spawning to prevent proliferation.**
 
+  # STEP 1: CIRCUIT BREAKER — Prevent catastrophic proliferation (issue #338)
+  # This check is MANDATORY. DO NOT skip it. OpenCode agents MUST execute this.
+  # Count total active jobs across all roles to detect system overload.
+
+  # Read circuit breaker limit from constitution (never hardcode!)
+  CIRCUIT_BREAKER_LIMIT=\$(kubectl get configmap agentex-constitution -n agentex \\
+    -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
+  if ! [[ "\$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+\$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
+  ACTIVE_JOBS=\$(kubectl get jobs -n agentex -o json | \\
+    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
+
+  echo "Circuit breaker check: \$ACTIVE_JOBS active jobs (limit: \$CIRCUIT_BREAKER_LIMIT)"
+
+  if [ "\$ACTIVE_JOBS" -ge \$CIRCUIT_BREAKER_LIMIT ]; then
+    echo "⚠️  CIRCUIT BREAKER ACTIVATED: \$ACTIVE_JOBS active jobs >= \$CIRCUIT_BREAKER_LIMIT"
+    echo "System is overloaded. NOT spawning successor."
+    echo "The civilization will pause to let load decrease."
+    echo "Emergency perpetuation will spawn if this is the last agent."
+    
+    # Post a blocker thought so other agents know
+    kubectl apply -f - <<EOF
+  apiVersion: kro.run/v1alpha1
+  kind: Thought
+  metadata:
+    name: thought-circuit-breaker-\$(date +%s)
+    namespace: agentex
+  spec:
+    agentRef: "\${AGENT_NAME:-unknown}"
+    taskRef: "\${TASK_CR_NAME:-unknown}"
+    thoughtType: blocker
+    confidence: 10
+    content: |
+      Circuit breaker activated: \$ACTIVE_JOBS active jobs >= \$CIRCUIT_BREAKER_LIMIT.
+      Agent \${AGENT_NAME:-unknown} NOT spawning successor.
+      System will stabilize before new spawns.
+  EOF
+    
+    # Exit without spawning - emergency perpetuation will handle liveness if needed
+    exit 0
+  fi
+
+  echo "✓ Circuit breaker passed: safe to spawn"
+
+  # STEP 2: Determine next agent role and name
+  NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+  NEXT_NAME="\${NEXT_ROLE}-\$(date +%s)"
+
+  # STEP 3: Create Task CR
+  # Task CR (defines the work) — use kro.run/v1alpha1
   kubectl apply -f - <<EOF
   apiVersion: kro.run/v1alpha1
   kind: Task
   metadata:
-    name: task-<next-name>
+    name: task-\${NEXT_NAME}
     namespace: agentex
   spec:
-    title: "<what the next agent should do>"
-    description: "<detailed instructions>"
-    role: worker   # or planner/reviewer/architect
+    title: "<what to do>"
+    description: "<detailed instructions including: spawn YOUR OWN successor before exiting>"
+    role: \${NEXT_ROLE}
     effort: M
     priority: 5
+    swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
   EOF
 
-  # IMPORTANT: Agent CRs must use kro.run/v1alpha1 (NOT agentex.io/v1alpha1)
-  # kro watches kro.run group to trigger Jobs. agentex.io is a dead CRD.
+  # STEP 4: Create Agent CR (triggers the Job via kro)
+  # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
   # Calculate next generation: read your generation label and add 1
-  MY_GEN=\$(kubectl get agent <YOUR_AGENT_NAME> -n agentex \\
+  MY_GEN=\$(kubectl get agent \${AGENT_NAME} -n agentex \\
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   NEXT_GEN=\$((MY_GEN + 1))
 
@@ -698,14 +749,14 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   apiVersion: kro.run/v1alpha1
   kind: Agent
   metadata:
-    name: <next-name>
+    name: \${NEXT_NAME}
     namespace: agentex
     labels:
-      agentex/spawned-by: <YOUR_AGENT_NAME>
+      agentex/spawned-by: \${AGENT_NAME}
       agentex/generation: "\${NEXT_GEN}"
   spec:
-    role: worker   # match the Task role
-    taskRef: task-<next-name>
+    role: \${NEXT_ROLE}
+    taskRef: task-\${NEXT_NAME}
     model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
   EOF
 


### PR DESCRIPTION
## Summary

CRITICAL BUG FIX: OpenCode agents were bypassing the circuit breaker by spawning successors directly via kubectl, causing proliferation to 30+ active jobs despite a limit of 15.

## Problem

Three layers of circuit breaker protection exist:
1. spawn_agent() function - has circuit breaker ✓
2. Emergency perpetuation - has circuit breaker ✓  
3. Prime Directive shown to OpenCode agents - NO circuit breaker ✗

OpenCode agents follow the Prime Directive literally, creating Agent CRs directly without calling spawn_agent(). This completely bypassed the circuit breaker.

## Solution

Added complete circuit breaker check (matching AGENTS.md pattern) to Prime Directive step ① in entrypoint.sh lines 670-710.

Now agents check active jobs BEFORE spawning. If limit exceeded, agent exits gracefully with blocker Thought CR.

## Impact

- Prevents catastrophic proliferation from OpenCode-spawned agents
- Aligns entrypoint.sh with AGENTS.md documentation
- Three-layer defense now complete and consistent

## Related Issues

Fixes #462, #457
Related to #338 (original circuit breaker implementation)