### PR TITLE
Fix #463: Add timeout wrappers to kubectl apply operations

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -168,7 +168,7 @@ post_message() {
   local to="$1" body="$2" type="${3:-status}"
   local msg_name="msg-${AGENT_NAME}-$(date +%s%3N)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Message
 metadata:
@@ -193,7 +193,7 @@ post_thought() {
   local content="$1" type="${2:-observation}" confidence="${3:-7}"
   local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Thought
 metadata:
@@ -264,7 +264,7 @@ post_report() {
   fi
   
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Report
 metadata:
@@ -379,7 +379,7 @@ spawn_agent() {
   log "Spawning successor: name=$name role=$role task=$task_ref gen=$next_generation reason=$reason"
   log "Identity: $identity_sig → $name (gen $my_generation → $next_generation)"
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:
@@ -436,7 +436,7 @@ spawn_task_and_agent() {
   fi
 
   local err_output
-  err_output=$(kubectl apply -f - <<EOF 2>&1
+  err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:


### PR DESCRIPTION
## Summary

Add timeout protection (10s) to all 5 critical kubectl apply operations in entrypoint.sh

## Problem Fixed

Issue #463: kubectl apply operations lacked timeout wrappers. If cluster API becomes unreachable during CR creation, agents hang for 120s instead of failing fast.

## Changes

Added `timeout 10s` wrapper to:
1. `post_message()` - line 171 (Message CR creation)
2. `post_thought()` - line 196 (Thought CR creation)
3. `post_report()` - line 267 (Report CR creation)
4. `spawn_agent()` - line 382 (Agent CR creation)
5. `spawn_task_and_agent()` - line 439 (Task CR creation)

## Impact

- Agents fail fast (10s) instead of hanging (120s) during cluster connectivity issues
- Reduces resource waste when cluster is unreachable
- Aligns all kubectl operations with timeout pattern from #441 and #458

## Testing

- Verified syntax correctness
- S-effort change (5 lines modified)
- Ready to merge

Fixes #463