### PR TITLE
Fix #474: Use agent.kro.run API group for kubectl get agent queries

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -109,7 +109,7 @@ spec:
 EOF
       
       # Issue #449: Verify spawn succeeded with clear diagnostics
-      if kubectl get agent "$next_agent" -n "$NAMESPACE" &>/dev/null; then
+      if kubectl get agent.kro.run "$next_agent" -n "$NAMESPACE" &>/dev/null; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✓ Emergency Agent CR created: $next_agent" >&2
       else
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✗ Emergency spawn FAILED - Agent CR not found: $next_agent" >&2
@@ -935,14 +935,14 @@ else
   JOBS_VERIFIED=0
   for agent_name in $(echo "$SUCCESSOR_AGENTS" | jq -r '.items[].metadata.name' 2>/dev/null || true); do
     # Check if Agent CR has status.jobName populated by kro
-    JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+    JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
       -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     
     if [ -z "$JOB_NAME" ]; then
       log "WARNING: Agent CR $agent_name exists but status.jobName is empty (kro hasn't processed it yet)"
       # Give kro a moment to process the Agent CR (it may be in progress)
       sleep 5
-      JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+      JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
         -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     fi
     


### PR DESCRIPTION
## Summary
Fixes ambiguous kubectl agent queries that were reading from wrong API group.

## Problem
Three locations in entrypoint.sh used `kubectl get agent` without specifying API group:
- Line 112: Emergency spawn verification
- Line 938: Job verification (first check)  
- Line 945: Job verification (retry check)

**Current behavior:**
- `kubectl explain agent` defaults to `agents.agentex.io` (legacy CRD)
- All NEW agents created in `agents.kro.run` (active CRD)
- Result: queries return empty/not found even when agents exist

## Impact
- **Emergency spawn verification** always reports "Agent CR not found" (false alarm)
- **Job verification** always finds empty jobName, triggers false warnings
- Logs filled with spurious errors for normal operations

## Solution
Changed all three locations to explicitly use `agent.kro.run`:

```bash
-kubectl get agent "$agent_name" -n "$NAMESPACE"
+kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE"
```

## Testing
- [x] Bash syntax validated: `bash -n entrypoint.sh` passed
- [x] Verified both CRDs exist: `kubectl api-resources | grep agents`
- [x] Confirmed default resolution to agentex.io: `kubectl explain agent`
- [x] Confirmed active agents in kro.run: `kubectl get agents.kro.run -n agentex`

## Effort
S-effort (< 5 minutes, 3-line change)

## Vision Alignment
3/10 - Bug fix for platform stability

Fixes #474