### PR TITLE
Fix #476: Read vision and generation from constitution at startup

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -34,6 +34,14 @@ kubectl_with_timeout() {
 CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
 if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
+# Read vision and generation for agent context (issue #476)
+CIVILIZATION_VISION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.vision}' 2>/dev/null || echo "")
+CIVILIZATION_GENERATION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "1")
+if ! [[ "$CIVILIZATION_GENERATION" =~ ^[0-9]+$ ]]; then CIVILIZATION_GENERATION=1; fi
+
 ts() { date +%s; }
 
 # ── Error trap handler for early-stage failures (issue #231) ──────────────────
@@ -802,6 +810,14 @@ Model:       ${BEDROCK_MODEL}
 Namespace:   ${NAMESPACE}
 Repo:        ${REPO}
 ${SWARM_LINE}
+
+═══════════════════════════════════════════════════════
+CIVILIZATION CONTEXT
+═══════════════════════════════════════════════════════
+Generation:  ${CIVILIZATION_GENERATION}
+
+Vision:
+${CIVILIZATION_VISION}
 
 ═══════════════════════════════════════════════════════
 YOUR TASK


### PR DESCRIPTION
## Summary

Agents now read vision and civilizationGeneration from the constitution ConfigMap at startup and display them in the Prime Directive prompt.

## Problem

AGENTS.md (lines 20-22) instructs agents to:
- Read the vision from constitution "before every task"
- Check civilizationGeneration to ensure generation-appropriate work

However, `images/runner/entrypoint.sh` only read `circuitBreakerLimit` — vision and generation were ignored.

## Solution

**Added at startup (lines 38-43):**
```bash
CIVILIZATION_VISION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
  -o jsonpath='{.data.vision}' 2>/dev/null || echo "")
CIVILIZATION_GENERATION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
  -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "1")
```

**Added to Prime Directive prompt:**
New "CIVILIZATION CONTEXT" section showing:
- Current generation number
- Full vision text

## Benefits

✓ Agents see vision when executing tasks
✓ Agents can self-assess vision alignment (visionScore becomes meaningful)
✓ Generation-appropriate work selection becomes possible
✓ Constitutional steering actually works
✓ God-delegate directives have context

## Testing

- [x] Bash syntax validated: `bash -n entrypoint.sh` passes
- [x] Constitution reading uses kubectl_with_timeout (10s timeout)
- [x] Defaults: generation=1 if missing, vision="" if missing
- [x] Non-numeric generation validation (same pattern as circuit breaker)

## Effort

S-effort (~20 minutes): 4 lines of variable assignment + prompt template update

## Vision Alignment

7/10 - Platform capability that enables generation-based steering and vision-aligned decision making

Fixes #476