### PR TITLE
fix: Add kubectl timeout wrapper to rolling restart check (issue #478)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -488,7 +488,7 @@ push_metric "AgentRun" 1
 # If forceRestart timestamp is newer than this agent's start time, exit gracefully
 # so emergency perpetuation spawns a replacement with the new image.
 AGENT_START_TIME=$(ts)
-RESTART_SIGNAL=$(kubectl get configmap agentex-runner-version -n "$NAMESPACE" \
+RESTART_SIGNAL=$(kubectl_with_timeout 10 get configmap agentex-runner-version -n "$NAMESPACE" \
   -o jsonpath='{.data.forceRestart}' 2>/dev/null || echo "0")
 
 if [ -n "$RESTART_SIGNAL" ] && [ "$RESTART_SIGNAL" -gt "$AGENT_START_TIME" ]; then


### PR DESCRIPTION
## Summary

Fixes issue #478 by adding `kubectl_with_timeout()` wrapper to the rolling restart ConfigMap check.

## Problem

The rolling restart check at line 491 uses bare `kubectl get` instead of the timeout wrapper:

```bash
RESTART_SIGNAL=$(kubectl get configmap agentex-runner-version -n "$NAMESPACE" ...)
```

When the cluster API is unreachable, this hangs for 120 seconds. Issue #441 introduced `kubectl_with_timeout()` to solve exactly this problem, but the rolling restart check was missed.

## Solution

Changed to:
```bash
RESTART_SIGNAL=$(kubectl_with_timeout 10 get configmap agentex-runner-version -n "$NAMESPACE" ...)
```

## Impact

✅ Agents fail fast (10s timeout) instead of hanging (120s default)
✅ Consistent with all other kubectl operations in entrypoint.sh
✅ Improves system resilience during cluster connectivity issues
✅ No behavior change when cluster is healthy

## Testing

- Syntax validated: `bash -n images/runner/entrypoint.sh`
- Pattern matches existing usage of `kubectl_with_timeout()` throughout the file
- Behavior: kubectl operation times out after 10s, falls back to `echo "0"`

## Effort

S-effort (< 5 minutes): 1 line changed

Closes #478