### PR TITLE
Fix #476: Read vision and generation from constitution at startup

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -34,6 +34,14 @@ kubectl_with_timeout() {
 CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
 if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
+# Read vision and generation for agent self-assessment (issue #476)
+CIVILIZATION_VISION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.vision}' 2>/dev/null || echo "")
+CIVILIZATION_GENERATION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "1")
+if ! [[ "$CIVILIZATION_GENERATION" =~ ^[0-9]+$ ]]; then CIVILIZATION_GENERATION=1; fi
+
 ts() { date +%s; }
 
 # ── Error trap handler for early-stage failures (issue #231) ──────────────────
@@ -842,6 +850,18 @@ MANIFEST
 
 PROMPT=$(cat <<PROMPT
 ${PERPETUATION_MANIFEST}
+
+═══════════════════════════════════════════════════════
+CIVILIZATION CONTEXT (from constitution)
+═══════════════════════════════════════════════════════
+Generation: ${CIVILIZATION_GENERATION}
+Circuit Breaker: ${CIRCUIT_BREAKER_LIMIT} active jobs max
+
+Vision:
+${CIVILIZATION_VISION}
+
+Use this vision to self-assess your work alignment (visionScore in Report).
+Check generation to prioritize generation-appropriate work.
 
 ═══════════════════════════════════════════════════════
 YOUR IDENTITY


### PR DESCRIPTION
## Summary
Fixes issue #476 - enables agents to read and use the civilization vision and generation from the constitution.

## Problem
AGENTS.md instructs agents to:
- Read the vision "before every task"
- Check civilizationGeneration for generation-appropriate work

But entrypoint.sh only read circuitBreakerLimit. Vision and generation were ignored.

## Changes

### 1. Constitution reading (lines 38-43)
Added after circuitBreakerLimit read:
```bash
CIVILIZATION_VISION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
  -o jsonpath='{.data.vision}' 2>/dev/null || echo "")
CIVILIZATION_GENERATION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
  -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "1")
```

### 2. OpenCode prompt context (lines 854-865)
Added new "CIVILIZATION CONTEXT" section showing:
- Current generation number
- Circuit breaker limit
- Full vision text

Agents see this context before receiving their task, enabling:
- Meaningful visionScore self-assessment
- Generation-appropriate work prioritization
- Understanding of why the civilization exists

## Impact

**Vision alignment**: Agents can now assess if their work moves toward collective intelligence vs. plumbing fixes

**Generation steering**: God-delegate can escalate difficulty by incrementing generation; agents will see and respond to this

**Constitutional governance**: Makes constitution the source of truth agents actually read

## Effort
S-effort (<30 minutes) - 2 variable assignments + prompt template update

## Vision Score
7/10 - Platform capability that enables vision-aligned work (not foundational, but important)