### PR TITLE
Fix #474: Use agent.kro.run API group for kubectl get agent queries

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -109,7 +109,7 @@ spec:
 EOF
       
       # Issue #449: Verify spawn succeeded with clear diagnostics
-      if kubectl get agent "$next_agent" -n "$NAMESPACE" &>/dev/null; then
+      if kubectl get agent.kro.run "$next_agent" -n "$NAMESPACE" &>/dev/null; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✓ Emergency Agent CR created: $next_agent" >&2
       else
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✗ Emergency spawn FAILED - Agent CR not found: $next_agent" >&2
@@ -752,7 +752,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   # STEP 4: Create Agent CR (triggers the Job via kro)
   # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
   # Calculate next generation: read your generation label and add 1
-  MY_GEN=\$(kubectl get agent \${AGENT_NAME} -n agentex \\
+  MY_GEN=\$(kubectl get agent.kro.run \${AGENT_NAME} -n agentex \\
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   NEXT_GEN=\$((MY_GEN + 1))
 
@@ -986,14 +986,14 @@ else
   JOBS_VERIFIED=0
   for agent_name in $(echo "$SUCCESSOR_AGENTS" | jq -r '.items[].metadata.name' 2>/dev/null || true); do
     # Check if Agent CR has status.jobName populated by kro
-    JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+    JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
       -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     
     if [ -z "$JOB_NAME" ]; then
       log "WARNING: Agent CR $agent_name exists but status.jobName is empty (kro hasn't processed it yet)"
       # Give kro a moment to process the Agent CR (it may be in progress)
       sleep 5
-      JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+      JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
         -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     fi
     


### PR DESCRIPTION
## Summary

Fixed three kubectl get agent queries that were resolving to wrong API group (agents.agentex.io instead of agents.kro.run).

## Problem

Lines 112, 915, and 922 in entrypoint.sh used unqualified `kubectl get agent` which defaults to legacy agentex.io CRD instead of active kro.run CRD where all new agents are created.

**Impact:**
- Emergency spawn verification always reported false 'Agent CR not found' warnings
- Job verification queries returned empty/not found for active agents
- False alarms in logs obscured real issues

## Solution

Added `.kro.run` suffix to all three `kubectl get agent` calls:
- Line 112: Emergency spawn verification
- Line 915: Job verification (first check)
- Line 922: Job verification (retry after 5s)

## Testing

All queries now target agents.kro.run where active agents actually exist.

## Effort

S-effort (< 5 minutes, 3-line change)

## Vision Score

5/10 - Platform stability (eliminates false warnings, improves diagnostics)