### PR TITLE
Fix #474: Query agent.kro.run instead of defaulting to agentex.io

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -109,7 +109,8 @@ spec:
 EOF
       
       # Issue #449: Verify spawn succeeded with clear diagnostics
-      if kubectl get agent "$next_agent" -n "$NAMESPACE" &>/dev/null; then
+      # Issue #474: Use .kro.run API group (not default agentex.io)
+      if kubectl get agent.kro.run "$next_agent" -n "$NAMESPACE" &>/dev/null; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✓ Emergency Agent CR created: $next_agent" >&2
       else
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ✗ Emergency spawn FAILED - Agent CR not found: $next_agent" >&2
@@ -752,7 +753,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   # STEP 4: Create Agent CR (triggers the Job via kro)
   # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
   # Calculate next generation: read your generation label and add 1
-  MY_GEN=\$(kubectl get agent \${AGENT_NAME} -n agentex \\
+  MY_GEN=\$(kubectl get agent.kro.run \${AGENT_NAME} -n agentex \\
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   NEXT_GEN=\$((MY_GEN + 1))
 
@@ -986,14 +987,15 @@ else
   JOBS_VERIFIED=0
   for agent_name in $(echo "$SUCCESSOR_AGENTS" | jq -r '.items[].metadata.name' 2>/dev/null || true); do
     # Check if Agent CR has status.jobName populated by kro
-    JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+    # Issue #474: Use .kro.run API group (not default agentex.io)
+    JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
       -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     
     if [ -z "$JOB_NAME" ]; then
       log "WARNING: Agent CR $agent_name exists but status.jobName is empty (kro hasn't processed it yet)"
       # Give kro a moment to process the Agent CR (it may be in progress)
       sleep 5
-      JOB_NAME=$(kubectl get agent "$agent_name" -n "$NAMESPACE" \
+      JOB_NAME=$(kubectl get agent.kro.run "$agent_name" -n "$NAMESPACE" \
         -o jsonpath='{.status.jobName}' 2>/dev/null || echo "")
     fi
     


### PR DESCRIPTION
## Summary

Fixes #474 - kubectl get agent queries wrong API group

## Problem

Four locations in entrypoint.sh used `kubectl get agent` without specifying API group. When two Agent CRDs exist (legacy `agentex.io` and active `kro.run`), kubectl defaults to alphabetically first group (`agentex.io`), causing false warnings.

## Changes

Added `.kro.run` suffix to all unqualified `kubectl get agent` calls:

- **Line 112**: Emergency spawn verification
- **Line 755**: Prime Directive generation label read (instructs OpenCode agents)
- **Lines 989, 996**: Job verification after spawn

## Impact

- Eliminates false "Agent CR not found" warnings
- Job verification now succeeds for recently spawned agents
- OpenCode agents now query correct API group when reading generation labels

## Effort

S-effort (< 10 minutes, 4-line change)

## Testing

After merge, emergency spawn and job verification logs should no longer show false warnings for active agents.