### PR TITLE
Fix #485: Add kubectl timeout wrappers to inbox and thoughts fetch

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -503,7 +503,7 @@ fi
 # ── 4. Process inbox ──────────────────────────────────────────────────────────
 log "Processing inbox..."
 INBOX_MESSAGES=""
-INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+INBOX_JSON=$(kubectl_with_timeout 10 get messages -n "$NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
 
 DIRECT_MSGS=$(echo "$INBOX_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
@@ -544,7 +544,7 @@ done
 # CRITICAL: Must sort by creationTimestamp to get the actual LAST 10 thoughts
 # Bug #89: .items[-10:] on unsorted output may return random 10, not the latest 10
 # Optimization #117: Fetch only the last 50 thoughts instead of all thoughts for better performance
-THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
+THOUGHTS_JSON=$(kubectl_with_timeout 10 get thoughts.kro.run -n "$NAMESPACE" --sort-by=.metadata.creationTimestamp --limit=50 -o json 2>/dev/null || echo '{"items":[]}')
 PEER_THOUGHTS=$(echo "$THOUGHTS_JSON" | jq -r \
   --arg name "$AGENT_NAME" \
   '.items[-10:] | .[] | 


### PR DESCRIPTION
## Summary

Fixes issue #485 by adding `kubectl_with_timeout()` wrapper to two critical kubectl operations that run on EVERY agent startup.

## Problem

Two critical kubectl get operations were missing timeout wrappers:

1. **Line 506**: Inbox message fetch
```bash
INBOX_JSON=$(kubectl get messages -n "$NAMESPACE" -o json ...)
```

2. **Line 547**: Thought CR fetch
```bash
THOUGHTS_JSON=$(kubectl get thoughts.kro.run -n "$NAMESPACE" ...)
```

When the cluster API is unreachable, these operations hang for 120 seconds on EVERY agent startup, severely impacting system resilience.

## Solution

Wrapped both calls with `kubectl_with_timeout 10`:

```bash
# Line 506
INBOX_JSON=$(kubectl_with_timeout 10 get messages -n "$NAMESPACE" ...)

# Line 547
THOUGHTS_JSON=$(kubectl_with_timeout 10 get thoughts.kro.run -n "$NAMESPACE" ...)
```

## Impact

✅ Agents fail fast (10s timeout) instead of hanging (120s default) on startup
✅ Consistent with all other kubectl operations in entrypoint.sh
✅ Improves system resilience during cluster connectivity issues
✅ No behavior change when cluster is healthy

## Testing

- Syntax validated: `bash -n images/runner/entrypoint.sh`
- Pattern matches existing usage of `kubectl_with_timeout()` throughout the file
- Behavior: kubectl operations time out after 10s, fall back to empty JSON arrays

## Effort

S-effort (< 5 minutes): 2 lines changed

Closes #485