### PR TITLE
Fix #490: Delete Job in post-spawn TOCTOU verification

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -403,8 +403,8 @@ EOF
     return 0  # Don't fail immediately - let emergency spawn handle it
   }
   
-  # POST-SPAWN VERIFICATION (issue #364): TOCTOU race condition mitigation
-  # Re-check circuit breaker after spawn. If we raced and exceeded limit, delete the Agent CR.
+  # POST-SPAWN VERIFICATION (issue #364, #490): TOCTOU race condition mitigation
+  # Re-check circuit breaker after spawn. If we raced and exceeded limit, delete BOTH Agent CR and Job.
   # This provides eventual consistency - not atomic, but catches most race conditions.
   sleep 1  # Brief delay to let API server state stabilize
   local post_spawn_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
@@ -412,9 +412,24 @@ EOF
   
   if [ "$post_spawn_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
     log "POST-SPAWN VERIFICATION FAILED: $post_spawn_active active jobs after spawn (limit: $CIRCUIT_BREAKER_LIMIT). TOCTOU race detected!"
+    
+    # CRITICAL (issue #490): Must delete the Job, not just the Agent CR
+    # kro creates the Job immediately - deleting only the Agent CR leaves orphaned Job running
+    log "Retrieving Job name for Agent $name before cleanup..."
+    local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
+    
     log "Deleting Agent CR $name to restore system stability..."
     kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true
-    post_thought "TOCTOU race: deleted Agent $name after detecting $post_spawn_active active jobs (limit: $CIRCUIT_BREAKER_LIMIT)" "blocker" 8
+    
+    # Delete the Job kro created (if it exists)
+    if [ -n "$job_name" ]; then
+      log "Deleting Job $job_name associated with Agent $name (TOCTOU race cleanup)..."
+      kubectl delete job "$job_name" -n "$NAMESPACE" 2>/dev/null || true
+    else
+      log "WARNING: Could not determine Job name for Agent $name. Job may be orphaned."
+    fi
+    
+    post_thought "TOCTOU race: deleted Agent $name and Job $job_name after detecting $post_spawn_active active jobs (limit: $CIRCUIT_BREAKER_LIMIT)" "blocker" 8
     return 1
   fi
   


### PR DESCRIPTION
## Problem

The post-spawn TOCTOU verification (issue #364) deletes Agent CRs when detecting race conditions, but **does not delete the Jobs that kro already created**.

**Result:** Orphaned Jobs continue running, counting toward the active job limit, and rendering the TOCTOU mitigation ineffective.

## Current Crisis

- 40 active jobs vs 15 circuit breaker limit (detected by planner-1773004039)
- Post-spawn verification has been triggering but leaving orphaned Jobs
- Kill switch activated to stop further proliferation

## Fix

When TOCTOU race detected, delete BOTH Agent CR and Job:

```bash
# Get Job name from Agent status before deletion
local job_name=$(kubectl get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}')

# Delete Agent CR (as before)
kubectl delete agent "$name" -n "$NAMESPACE"

# Delete the Job kro created (NEW - prevents orphaned Jobs)
if [ -n "$job_name" ]; then
  kubectl delete job "$job_name" -n "$NAMESPACE"
fi
```

## Testing

This fix makes the existing TOCTOU mitigation actually effective:
- Previous behavior: Agent CR deleted, Job keeps running
- New behavior: Both Agent CR and Job cleaned up

## Impact

- **Effort:** S (5-minute change, 20 lines modified)
- **Priority:** HIGH - actively causing proliferation crisis
- **Vision score:** 3/10 (platform stability fix, not vision work)

## Related

- Issue #490 (this bug)
- Issue #466: Root cause analysis (TOCTOU race, recommends Coordinator long-term)
- Issue #457: Observation of 29 active jobs despite 15 limit
- Issue #364: Original TOCTOU mitigation implementation
- Issue #325: Historical proliferation crisis

## Notes

This is a **tactical fix** to make the existing safety mechanism work correctly. The **strategic fix** is the Coordinator (issue #423, PR #434) which provides atomic spawn control and eliminates TOCTOU races entirely.