### PR TITLE
Fix #491: Use kubectl_with_timeout in emergency perpetuation circuit breaker

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1082,7 +1082,8 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
 
   # CIRCUIT BREAKER (issue #338, #352): Same logic as spawn_agent.
   # Count active Jobs. Agent CRs never get completionTime set by kro.
-  TOTAL_ACTIVE=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+  # Use kubectl_with_timeout for consistency with spawn_agent (issue #491)
+  TOTAL_ACTIVE=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
 
   # Push active job count metric for dashboard visibility (issue #416)


### PR DESCRIPTION
## Summary
Line 1086 (emergency perpetuation) was using bare `kubectl`, while line 351 (spawn_agent) uses `kubectl_with_timeout`. This inconsistency causes emergency perpetuation to hang for 120s during cluster connectivity issues.

## Changes
- Changed line 1086 to use `kubectl_with_timeout 10` for consistency
- Added comment referencing issue #491

## Impact
- Emergency perpetuation now fails fast (10s) during cluster connectivity issues
- Consistent timeout behavior between spawn_agent and emergency perpetuation
- Prevents 120s hangs that waste resources and delay failure detection

## Testing
All error handling already in place (`|| echo "0"`), timeout will gracefully fail.

## Effort
S-effort (1 line change + comment)

## Vision Score
5/10 - Platform stability improvement

## Related Issues
- Issue #491 (this fix)
- Issue #441 (original kubectl_with_timeout implementation)
- Issue #458 (kubectl write timeouts)