### PR TITLE
Fix #229: Add CloudWatch dashboard permissions to agent IAM role

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -194,6 +194,20 @@ resource "aws_iam_role_policy" "agent_permissions" {
           "logs:DescribeLogStreams"
         ]
         Resource = "arn:aws:logs:${var.region}:${local.account_id}:log-group:/eks/${var.cluster_name}/agentex*"
+      },
+      # CloudWatch — manage dashboards and read metrics (for issue #229)
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutDashboard",
+          "cloudwatch:GetDashboard",
+          "cloudwatch:ListDashboards",
+          "cloudwatch:DeleteDashboards",
+          "cloudwatch:PutMetricData",
+          "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricStatistics"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Summary

Adds CloudWatch dashboard management and metrics permissions to the `agentex-agent-role` IAM policy. This unblocks deployment of the CloudWatch dashboard from PR #39 (already merged).

## Changes

Added to `infra/main.tf` (agent IAM role policy):
- `cloudwatch:PutDashboard` - create/update dashboards
- `cloudwatch:GetDashboard` - read dashboard configuration
- `cloudwatch:ListDashboards` - list all dashboards
- `cloudwatch:DeleteDashboards` - clean up dashboards
- `cloudwatch:PutMetricData` - push custom metrics
- `cloudwatch:ListMetrics` - verify metrics exist
- `cloudwatch:GetMetricStatistics` - read metric data

## Impact

After `terraform apply`:
1. Agents can deploy the agentex-activity dashboard to CloudWatch
2. Agents can verify custom metrics (AgentRun, ThoughtCreated, etc.)
3. Human can view real-time agent activity at: https://console.aws.amazon.com/cloudwatch/home?region=us-west-2#dashboards:name=agentex-activity

## Testing

Deploy with terraform:
```bash
cd infra
terraform init
terraform apply
```

Then from an agent pod:
```bash
# Deploy dashboard
aws cloudwatch put-dashboard \
  --dashboard-name agentex-activity \
  --dashboard-body "$(kubectl get configmap agentex-dashboard-definition -n agentex -o jsonpath='{.data.dashboard\.json}')" \
  --region us-west-2

# Verify metrics
aws cloudwatch list-metrics --namespace Agentex --region us-west-2
```

## Related

- Closes #229
- Unblocks feature from PR #39 (CloudWatch dashboard - merged)
- Similar to issue #41 (S3 permissions)

## Effort

S-effort (<30 min) - single IAM policy addition