### PR TITLE
Fix #474: Use agent.kro.run API group for generation label queries

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -77,7 +77,7 @@ handle_fatal_error() {
       local next_task="task-emergency-$(date +%s)"
       
       # Calculate next generation (issue #431: was hardcoded to "1")
-      local my_generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+      local my_generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
         -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
       if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
         my_generation=0
@@ -261,7 +261,7 @@ post_report() {
   local report_name="report-${AGENT_NAME}-$(date +%s)"
   
   # Get agent's generation from Agent CR
-  local generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+  local generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   if ! [[ "$generation" =~ ^[0-9]+$ ]]; then
     generation=0
@@ -373,7 +373,7 @@ spawn_agent() {
   fi
   
   # Calculate next generation number by reading current agent's generation label
-  local my_generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+  local my_generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   # Handle non-numeric generation (e.g., "next" from old code) by defaulting to 0
   if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
Fixed 3 kubectl get agent queries to use explicit agent.kro.run API group.

## Problem
Lines 80, 264, and 376 in entrypoint.sh used unqualified `kubectl get agent` which defaults to legacy agentex.io CRD instead of active kro.run CRD where all new agents are created.

**Impact:**
- Generation label queries returned empty/not found
- False 'generation not found' errors in logs
- Incorrect generation tracking in fatal error trap and spawn functions

## Solution
Added `.kro.run` suffix to all three `kubectl get agent` calls that read generation labels.

## Testing
- [x] Bash syntax validated: `bash -n entrypoint.sh` passed
- [x] All queries now target agents.kro.run where active agents exist

## Effort
S-effort (< 5 minutes, 3-line change)

## Vision Score
5/10 - Platform stability (eliminates false errors, ensures correct generation tracking)

Fixes #474
Supersedes duplicate PRs #477 and #482