### PR TITLE
Fix #496: Use agent.kro.run API group for generation label queries

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -77,7 +77,7 @@ handle_fatal_error() {
       local next_task="task-emergency-$(date +%s)"
       
       # Calculate next generation (issue #431: was hardcoded to "1")
-      local my_generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+      local my_generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
         -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
       if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then
         my_generation=0
@@ -261,7 +261,7 @@ post_report() {
   local report_name="report-${AGENT_NAME}-$(date +%s)"
   
   # Get agent's generation from Agent CR
-  local generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+  local generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   if ! [[ "$generation" =~ ^[0-9]+$ ]]; then
     generation=0
@@ -373,7 +373,7 @@ spawn_agent() {
   fi
   
   # Calculate next generation number by reading current agent's generation label
-  local my_generation=$(kubectl_with_timeout 10 get agent "$AGENT_NAME" -n "$NAMESPACE" \
+  local my_generation=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   # Handle non-numeric generation (e.g., "next" from old code) by defaulting to 0
   if ! [[ "$my_generation" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary

Fixes #496 - Three kubectl_with_timeout calls were missing the agent.kro.run API group qualifier, causing generation label queries to fail.

## Changes

- Line 80 (spawn_agent): Changed `kubectl_with_timeout get agent` to `kubectl_with_timeout get agent.kro.run`
- Line 264 (post_report): Changed `kubectl_with_timeout get agent` to `kubectl_with_timeout get agent.kro.run`
- Line 376 (spawn_task_and_agent): Changed `kubectl_with_timeout get agent` to `kubectl_with_timeout get agent.kro.run`

## Impact

Without this fix:
- Generation numbers reset incorrectly during spawning (always defaulted to 0)
- Report CRs showed incorrect generation 0 instead of actual generation
- Emergency spawn generation tracking was broken

With this fix:
- Generation tracking works correctly across all three code paths
- Report CRs show accurate generation numbers
- Consistent API group usage across entire entrypoint.sh

## Testing

Verified no remaining unqualified `kubectl get agent` calls:
```bash
grep -n 'kubectl_with_timeout.*get agent' images/runner/entrypoint.sh | grep -v 'agent.kro.run'
# Output: empty (all instances fixed)
```

## Related

- Issue #474, PR #495 (fixed lines 112, 901, 908)
- This PR completes the fix by addressing the remaining three instances