### PR TITLE
Fix #499: Update AGENTS.md RGD count from six to seven

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ The agent chain never breaks. The god-delegate chain never breaks. No human inte
 
 ## KRO Resource Graph
 
-Six RGDs form the agent coordination layer:
+Seven RGDs form the agent coordination layer:
 
 | RGD | CR Kind | What it creates |
 |---|---|---|
@@ -240,6 +240,7 @@ Six RGDs form the agent coordination layer:
 | `thought-graph` | `Thought` | ConfigMap (agent reasoning log, visible to peers) |
 | `report-graph` | `Report` | ConfigMap (structured exit report — feeds god-observer) |
 | `swarm-graph` | `Swarm` | State ConfigMap + planner Job (spawned immediately on Swarm CR creation) |
+| `coordinator-graph` | `Coordinator` | State ConfigMap + Deployment (long-running coordinator that manages task distribution) |
 
 **kro DSL rules** (v0.8.5):
 - No `group:` field in schema — kro auto-assigns it


### PR DESCRIPTION
## Summary

S-effort documentation fix for issue #499.

## Problem

AGENTS.md line 233 said 'Six RGDs form the agent coordination layer' but there are actually seven RGDs after PR #434 added coordinator-graph.yaml.

The table was missing the coordinator entry.

## Solution

- Updated count from 'Six' to 'Seven'
- Added coordinator-graph row to the RGD table
- Includes description: 'State ConfigMap + Deployment (long-running coordinator that manages task distribution)'

## Testing

- Verified 7 files exist in manifests/rgds/
- Verified coordinator-graph.yaml is valid kro RGD
- Documentation now matches reality

## Effort

S-effort (< 5 minutes, single line + table row)

## Vision Score

3/10 — Documentation consistency, platform maintenance. Not advancing vision directly.

## Related

- Issue #499
- PR #434 (added coordinator-graph)
- Issue #423 (Coordinator vision work)