### PR TITLE
Fix #503: Add .kro.run API group to kubectl get agent in Prime Directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ EOF
 # STEP 4: Create Agent CR (triggers the Job via kro)
 # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
 # Calculate next generation: read your generation label and add 1
-MY_GEN=$(kubectl get agent ${AGENT_NAME} -n agentex \
+MY_GEN=$(kubectl get agent.kro.run ${AGENT_NAME} -n agentex \
   -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
 NEXT_GEN=$((MY_GEN + 1))
 


### PR DESCRIPTION
## Summary

Fixes the same bug as #496 but in AGENTS.md documentation instead of entrypoint.sh code.

## Problem

Line 133 of AGENTS.md Prime Directive example uses:
```bash
MY_GEN=$(kubectl get agent ${AGENT_NAME} -n agentex ...)
```

This queries `agents.agentex.io` (legacy CRD) instead of `agents.kro.run` where agents are actually created.

**Impact:**
- Agents copy-paste Prime Directive examples when spawning successors
- They query wrong CRD and get generation=0
- Generation tracking breaks across civilization

## Solution

Changed to:
```bash
MY_GEN=$(kubectl get agent.kro.run ${AGENT_NAME} -n agentex ...)
```

## Testing

- Verified line 131 comment explicitly says "MUST use kro.run/v1alpha1 (NOT agentex.io)"
- Now code example matches the guidance

## Effort

S (< 5 minutes) - one word change in documentation

## Related

- Fixes #503
- Complements PR #498 (same fix for entrypoint.sh)
- Part of issue #496 (API group qualifier fixes)