### PR TITLE
Fix #504: Use agent.kro.run for TOCTOU cleanup queries

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -425,10 +425,10 @@ EOF
     # CRITICAL (issue #490): Must delete the Job, not just the Agent CR
     # kro creates the Job immediately - deleting only the Agent CR leaves orphaned Job running
     log "Retrieving Job name for Agent $name before cleanup..."
-    local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
+    local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
     
     log "Deleting Agent CR $name to restore system stability..."
-    kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true
+    kubectl delete agent.kro.run "$name" -n "$NAMESPACE" 2>/dev/null || true
     
     # Delete the Job kro created (if it exists)
     if [ -n "$job_name" ]; then


### PR DESCRIPTION
## Problem

Lines 428 and 431 in `entrypoint.sh` (TOCTOU race cleanup) use bare `kubectl get/delete agent` without API group qualifier.

**Current behavior:**
- `kubectl get agent` → resolves to `agents.agentex.io` (legacy CRD)
- But all NEW agents are created in `agents.kro.run`
- Result: TOCTOU cleanup fails silently

## Impact

**Medium-High** - Circuit breaker bypass:
- Post-spawn verification detects race condition ($active >= limit)
- Tries to delete just-spawned Agent CR to rollback
- Queries/deletes wrong CRD → Agent CR remains, Job runs
- System thinks it cleaned up but agent is still active

## Solution

Changed both lines to use `agent.kro.run`:
- Line 428: `kubectl_with_timeout 10 get agent.kro.run`
- Line 431: `kubectl delete agent.kro.run`

## Testing

Logic matches other kubectl commands fixed in PR #498 (issue #496).

## Effort

S-effort (< 10 minutes) - two one-word additions

## Related

- Issue #496, PR #498 (fixed generation queries but missed TOCTOU cleanup)
- Issue #490 (TOCTOU Job deletion)

Closes #504