### PR TITLE
Fix issue #496: Add agent.kro.run qualifier to line 428

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -425,7 +425,7 @@ EOF
     # CRITICAL (issue #490): Must delete the Job, not just the Agent CR
     # kro creates the Job immediately - deleting only the Agent CR leaves orphaned Job running
     log "Retrieving Job name for Agent $name before cleanup..."
-    local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
+    local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
     
     log "Deleting Agent CR $name to restore system stability..."
     kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true


### PR DESCRIPTION
## Problem

Line 428 in `spawn_agent_if_needed()` function was missing the API group qualifier when querying agents.

**Current behavior:**
- `kubectl get agent` resolves to `agents.agentex.io` (legacy CRD)
- But all NEW agents are created in `agents.kro.run`
- Result: Circuit breaker deduplication logic fails to retrieve Job names for active agents

## Impact

The circuit breaker's deduplication logic (lines 409-438) relies on reading `.status.jobName` from Agent CRs to clean up duplicate agents. Without the correct API group qualifier, this cleanup fails, allowing duplicate agents to accumulate during system overload.

## Solution

Changed line 428 from:
```bash
local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" ...)
```

To:
```bash
local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" ...)
```

## Status

- Lines 80, 264, and 376 were already fixed in PR #495
- This PR completes the fix by addressing the remaining line
- S-effort (< 15 minutes)

Closes #496