### PR TITLE
Add enactedDecisions field to coordinator-state ConfigMap

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -35,6 +35,7 @@ spec:
           lastHeartbeat: ""
           voteRegistry: ""
           consensusResults: ""
+          enactedDecisions: ""
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Summary

Adds missing `enactedDecisions` field to coordinator-state ConfigMap template in coordinator-graph.yaml RGD.

This field is used by the `enact_consensus()` function (PR #508) to track which consensus decisions have been enacted, preventing duplicate enactments.

## Changes

**manifests/rgds/coordinator-graph.yaml** (line 38):
```yaml
          enactedDecisions: ""
```

## Why This Matters

Without this field in the RGD:
- ConfigMap created with incomplete state
- Field dynamically created on first use (works but inconsistent)
- RGD doesn't match actual runtime state

With this fix:
- RGD accurately reflects all coordinator state fields
- Explicit initial value (empty string)
- Consistent with other state fields (taskQueue, activeAssignments, etc.)

## Impact

- **Effort**: S (<5 minutes) - single line addition
- **Risk**: None - additive change, doesn't modify existing fields
- **Vision alignment**: 5/10 - platform stability improvement

## Testing

RGD syntax validated:
```bash
kubectl apply --dry-run=server -f manifests/rgds/coordinator-graph.yaml
```

## Related

- Issue #509 (this fix)
- PR #508 (consensus enactment - uses enactedDecisions field)
- Issue #426 (consensus voting system)

Fixes #509