### PR TITLE
Fix #513: Calculate killswitch threshold dynamically from circuit breaker limit

### DIFF
--- a/manifests/system/killswitch-healthcheck.sh
+++ b/manifests/system/killswitch-healthcheck.sh
@@ -6,12 +6,14 @@
 set -euo pipefail
 
 NAMESPACE="agentex"
-ACTIVE_JOB_THRESHOLD=10
 
 # Read circuit breaker limit from constitution (do not hardcode!)
 CIRCUIT_BREAKER_LIMIT=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
 if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+
+# Calculate threshold as 2/3 of circuit breaker limit (safe margin for recovery)
+ACTIVE_JOB_THRESHOLD=$((CIRCUIT_BREAKER_LIMIT * 2 / 3))
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

Fixes #513 - Removes hardcoded threshold from killswitch-healthcheck.sh and calculates it dynamically from circuit breaker limit.

## Changes

- **Line 9**: Removed hardcoded `ACTIVE_JOB_THRESHOLD=10`
- **Line 16**: Added dynamic calculation: `ACTIVE_JOB_THRESHOLD=$((CIRCUIT_BREAKER_LIMIT * 2 / 3))`
- Moved threshold calculation after reading constitution (line 11-14)

## Impact

**Before:**
- Health check always used threshold of 10 active jobs
- Ignored circuit breaker limit changes
- Could be too conservative (if limit raised to 20) or too lenient (if lowered to 8)

**After:**
- Threshold scales with circuit breaker limit from constitution
- With limit=15: threshold=10 (same as before)
- With limit=20: threshold=13 (adaptive)
- Maintains constitution as single source of truth

## Rationale

Uses 2/3 multiplier to provide safe margin for recovery:
- Not too conservative (would block legitimate deactivation)
- Not too lenient (would allow premature deactivation)
- Example: 15 limit → 10 threshold (5-job buffer)

## Testing

Verified calculation with different limits:
- Limit 15 → Threshold 10 (current behavior preserved)
- Limit 12 → Threshold 8
- Limit 20 → Threshold 13

## Effort

S-effort (< 10 minutes) - 3-line change

## Vision Alignment

5/10 - Platform stability improvement (maintains constitution as source of truth)