### PR TITLE
Fix #504: Use agent.kro.run in TOCTOU cleanup

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -425,10 +425,10 @@ EOF
     # CRITICAL (issue #490): Must delete the Job, not just the Agent CR
     # kro creates the Job immediately - deleting only the Agent CR leaves orphaned Job running
     log "Retrieving Job name for Agent $name before cleanup..."
-    local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
+    local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
     
     log "Deleting Agent CR $name to restore system stability..."
-    kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true
+    kubectl delete agent.kro.run "$name" -n "$NAMESPACE" 2>/dev/null || true
     
     # Delete the Job kro created (if it exists)
     if [ -n "$job_name" ]; then


### PR DESCRIPTION
## Summary

Fixes #504 - Adds `.kro.run` API group specification to TOCTOU race cleanup kubectl commands.

## Problem

Lines 428 and 431 in `entrypoint.sh` (TOCTOU race cleanup in `spawn_agent` function) used bare `kubectl get agent` and `kubectl delete agent` without specifying the API group.

**Current behavior:**
- Line 428: `kubectl get agent "$name"` → resolves to `agents.agentex.io` (legacy CRD)
- Line 431: `kubectl delete agent "$name"` → resolves to `agents.agentex.io` (legacy CRD)
- But all NEW agents are created in `agents.kro.run`
- Result: TOCTOU race cleanup fails silently (can't find the agent to delete)

## Impact

**Medium-High** - TOCTOU race mitigation was broken:
- Post-spawn verification detects `$post_spawn_active >= $CIRCUIT_BREAKER_LIMIT`
- Tries to delete the just-spawned Agent CR to rollback
- Queries/deletes wrong CRD → Agent CR not found
- Agent CR remains active → Job continues running → circuit breaker bypass

## Solution

Changed both lines to use `agent.kro.run`:

```bash
# Line 428
local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)

# Line 431
kubectl delete agent.kro.run "$name" -n "$NAMESPACE" 2>/dev/null || true
```

## Changes

- Line 428: Added `.kro.run` to `kubectl get agent`
- Line 431: Added `.kro.run` to `kubectl delete agent`

## Why This Matters

The TOCTOU race mitigation (issue #490) depends on being able to delete Agent CRs that were spawned during a race condition. Without the correct API group, the cleanup silently fails and the circuit breaker can be bypassed.

## Effort

S (< 5 minutes) - two identical one-word additions

## Related Issues

- Issue #504 (this fix)
- Issue #496 (fixed generation queries but missed TOCTOU cleanup)
- PR #498 (partial fix for #496)
- Issue #490 (TOCTOU Job deletion - the cleanup this bug was breaking)