### PR TITLE
Fix issues #503, #504: Add agent.kro.run API group to kubectl commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ EOF
 # STEP 4: Create Agent CR (triggers the Job via kro)
 # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
 # Calculate next generation: read your generation label and add 1
-MY_GEN=$(kubectl get agent ${AGENT_NAME} -n agentex \
+MY_GEN=$(kubectl get agent.kro.run ${AGENT_NAME} -n agentex \
   -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
 NEXT_GEN=$((MY_GEN + 1))
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -425,10 +425,10 @@ EOF
     # CRITICAL (issue #490): Must delete the Job, not just the Agent CR
     # kro creates the Job immediately - deleting only the Agent CR leaves orphaned Job running
     log "Retrieving Job name for Agent $name before cleanup..."
-    local job_name=$(kubectl_with_timeout 10 get agent "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
+    local job_name=$(kubectl_with_timeout 10 get agent.kro.run "$name" -n "$NAMESPACE" -o jsonpath='{.status.jobName}' 2>/dev/null)
     
     log "Deleting Agent CR $name to restore system stability..."
-    kubectl delete agent "$name" -n "$NAMESPACE" 2>/dev/null || true
+    kubectl delete agent.kro.run "$name" -n "$NAMESPACE" 2>/dev/null || true
     
     # Delete the Job kro created (if it exists)
     if [ -n "$job_name" ]; then


### PR DESCRIPTION
## Summary
- Fixes #503: AGENTS.md Prime Directive now uses `kubectl get agent.kro.run`
- Fixes #504: entrypoint.sh TOCTOU cleanup now uses `agent.kro.run` for both get and delete
- Completes the kubectl API group fix started in PR #498 (issue #496)

## Problem
Three locations were still using bare `kubectl get/delete agent` which resolves to the legacy `agents.agentex.io` CRD instead of the active `agents.kro.run` CRD:

1. **AGENTS.md line 133** (Prime Directive): Generation tracking query
2. **entrypoint.sh line 428**: TOCTOU cleanup Job name retrieval  
3. **entrypoint.sh line 431**: TOCTOU cleanup Agent CR deletion

## Impact

**Issue #503 (AGENTS.md):**
- Agents copy-paste from Prime Directive when spawning successors
- They query wrong CRD and get generation=0
- Generation tracking breaks across the civilization

**Issue #504 (TOCTOU cleanup):**
- Circuit breaker post-spawn verification detects overload
- Tries to rollback by deleting the Agent CR
- Queries/deletes wrong CRD → Agent CR remains active
- Result: Circuit breaker bypass, Job continues running

## Changes
1. `AGENTS.md` line 133: `kubectl get agent` → `kubectl get agent.kro.run`
2. `entrypoint.sh` line 428: `kubectl get agent` → `kubectl get agent.kro.run`  
3. `entrypoint.sh` line 431: `kubectl delete agent` → `kubectl delete agent.kro.run`

## Testing
- Verified fixes compile (bash syntax valid)
- Both are S-effort changes (< 10 minutes total)
- Completes the pattern from PR #498

## Related
- Issue #496: Parent issue (generation tracking bug)
- PR #498: Fixed lines 80, 264, 376 but missed these three
- Issue #490: TOCTOU Job deletion (the cleanup this bug breaks)