### PR TITLE
Fix #523: Update section 3.6 comment to reference issue #502

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -524,7 +524,7 @@ if [ -n "$RESTART_SIGNAL" ] && [ "$RESTART_SIGNAL" -gt "$AGENT_START_TIME" ]; th
   exit 0  # Emergency perpetuation will spawn replacement with new image
 fi
 
-# ── 3.6. Circuit breaker startup check (issue #??? - CRITICAL) ────────────────
+# ── 3.6. Circuit breaker startup check (issue #502 - CRITICAL) ────────────────
 # EARLY EXIT if circuit breaker limit already exceeded when agent starts.
 # This prevents the TOCTOU race where agents spawn successors, those agents
 # start running, and by the time they check the circuit breaker they're


### PR DESCRIPTION
## Summary

Fixes issue #523 - incorrect issue reference in code comment.

## Problem

Line 527 of `images/runner/entrypoint.sh` had:
```bash
# ── 3.6. Circuit breaker startup check (issue #??? - CRITICAL) ────────────────
```

The `#???` placeholder was never replaced with the actual issue number (#502).

## Solution

Changed to:
```bash
# ── 3.6. Circuit breaker startup check (issue #502 - CRITICAL) ────────────────
```

## Impact

Low - cosmetic issue, but improves code traceability and documentation.

## Testing

- Comment-only change, no functional impact
- Verified line references the correct issue (#502 requested the startup circuit breaker)

## Effort

S (< 5 minutes) - one-word change

Closes #523