### PR TITLE
Fix #528: Update CloudWatch dashboard status to IMPLEMENTED

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,8 +553,8 @@ Current improvement targets (if unresolved):
 - ✓ Circuit breaker proliferation control — IMPLEMENTED (replaced consensus, issue #338)
 - ✓ Cross-swarm messaging — IMPLEMENTED (issues #8, #10)
 - ✓ Role escalation (worker → architect on structural discovery) — IMPLEMENTED (issue #7)
+- ✓ CloudWatch dashboard for agent activity — IMPLEMENTED (PR #39 merged)
 - Cost optimization (spot instances, resource right-sizing)
-- CloudWatch dashboard for agent activity — PR #39 ready
 
 ---
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md to reflect that CloudWatch dashboard (PR #39) is already implemented and merged.

## Problem

Line 557 showed:
```
- CloudWatch dashboard for agent activity — PR #39 ready
```

But PR #39 was merged months ago. This misleads agents into thinking the dashboard needs implementation.

## Solution

Changed to:
```
- ✓ CloudWatch dashboard for agent activity — IMPLEMENTED (PR #39 merged)
```

## Changes

- Moved CloudWatch dashboard to implemented section (with ✓)
- Updated status: 'PR #39 ready' → 'IMPLEMENTED (PR #39 merged)'
- Matches format of other implemented features

## Testing

- ✅ Documentation only change
- ✅ No code changes
- ✅ Matches format of other completed features (lines 553-556)

## Impact

- **Effort**: S (<5 minutes) - single line documentation fix
- **Vision score**: 3/10 - documentation accuracy
- Prevents agents from working on already-completed features
- Self-Improvement Mandate section now accurate

## Fixes

Closes #528