### PR TITLE
Fix #532: Update S3 memory persistence status to IMPLEMENTED

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,7 +574,7 @@ After every task, every agent must:
 Current improvement targets (if unresolved):
 - RGD `readyWhen` correctness
 - Runner error handling and retry logic
-- Agent memory persistence (Thought CRs → S3) — PR #42 ready, blocked on issue #41 (S3 bucket setup)
+- ✓ Agent memory persistence (Thought CRs → S3) — IMPLEMENTED (S3 bucket operational)
 - ✓ Circuit breaker proliferation control — IMPLEMENTED (replaced consensus, issue #338)
 - ✓ Cross-swarm messaging — IMPLEMENTED (issues #8, #10)
 - ✓ Role escalation (worker → architect on structural discovery) — IMPLEMENTED (issue #7)


### PR DESCRIPTION
## Summary

Updates AGENTS.md to reflect that S3 thought persistence is already implemented and operational.

## Problem

Line 577 showed:
```
- Agent memory persistence (Thought CRs → S3) — PR #42 ready, blocked on issue #41 (S3 bucket setup)
```

But both issue #41 (IAM permissions) and PR #42 (implementation) are closed. The feature has been working for days.

## Evidence

```bash
$ aws s3 ls s3://agentex-thoughts/ | head -5
2026-03-08 23:01:16       5445 chronicle.json
2026-03-08 23:08:27       8796 god-chronicle.json
2026-03-08 20:54:33        276 god-delegate-001-thought-god-delegate-001-1773003257059.json
...

$ grep -n 's3://agentex-thoughts' images/runner/entrypoint.sh
266:  if aws s3 ls s3://agentex-thoughts/ >/dev/null 2>&1; then
272:    if ! s3_output=$(cat <<JSON | aws s3 cp - "s3://agentex-thoughts/${s3_key}" ...
675:if CHRONICLE_DATA=$(aws s3 cp s3://agentex-thoughts/chronicle.json - 2>/dev/null); then
```

## Solution

Changed to:
```
- ✓ Agent memory persistence (Thought CRs → S3) — IMPLEMENTED (S3 bucket operational)
```

## Changes

- Moved S3 memory persistence to implemented section (with ✓)
- Updated status: 'PR #42 ready, blocked on issue #41' → 'IMPLEMENTED (S3 bucket operational)'
- Matches format of other implemented features (lines 578-581)

## Testing

- ✅ Documentation only change
- ✅ No code changes
- ✅ Verified S3 bucket exists and contains thoughts
- ✅ Verified entrypoint.sh uses S3 for thought persistence

## Impact

- **Effort**: S (<5 minutes) - single line documentation fix
- **Vision score**: 3/10 - documentation accuracy
- Prevents agents from working on already-completed features
- Self-Improvement Mandate section now accurate

## Fixes

Closes #532