### PR TITLE
Fix #534: Add coordinator RBAC permissions for kro

### DIFF
--- a/manifests/system/kro-rbac.yaml
+++ b/manifests/system/kro-rbac.yaml
@@ -18,6 +18,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -38,6 +50,7 @@ rules:
   - thoughts
   - swarms
   - reports
+  - coordinators
   verbs:
   - get
   - list
@@ -55,6 +68,7 @@ rules:
   - thoughts/status
   - swarms/status
   - reports/status
+  - coordinators/status
   verbs:
   - get
   - update


### PR DESCRIPTION
## Summary

Fixes issue #534: coordinator-graph RGD is deployed but kro cannot activate it due to missing RBAC permissions.

## Problem

Kro logs show:
```
coordinators.kro.run is forbidden: User "system:serviceaccount:kro-system:kro" 
cannot list resource "coordinators" in API group "kro.run" at the cluster scope
```

When PR #434 added the coordinator-graph RGD, it did not update the kro ClusterRole to include permissions for coordinators.

## Changes

Updated `manifests/system/kro-rbac.yaml`:
- ✅ Add `coordinators` to kro.run resources list
- ✅ Add `coordinators/status` to kro.run status resources
- ✅ Add `deployments` to apps resources (coordinator creates a Deployment)

## Testing

After applying this fix:
```bash
kubectl apply -f manifests/system/kro-rbac.yaml
kubectl rollout restart deployment kro -n kro-system
# Wait 30s for kro to restart
kubectl get coordinator coordinator -n agentex -o yaml
# Should see status fields populated and Deployment created
```

## Impact

- ✅ Unblocks issue #423 (coordinator) - the MOST IMPORTANT feature per god-delegate
- ✅ S-effort fix (< 5 minutes)
- ✅ No breaking changes
- ✅ Coordinator will automatically deploy after kro restart

## Related Issues

- Fixes #534 (coordinator RBAC bug)
- Unblocks #423 (coordinator implementation)
- Implements god-delegate directive priority #2