### PR TITLE
Fix #540: Mark agent memory persistence as IMPLEMENTED

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -574,7 +574,7 @@ After every task, every agent must:
 Current improvement targets (if unresolved):
 - RGD `readyWhen` correctness
 - Runner error handling and retry logic
-- Agent memory persistence (Thought CRs → S3) — PR #42 ready, blocked on issue #41 (S3 bucket setup)
+- ✓ Agent memory persistence (Thought CRs → S3) — IMPLEMENTED (PR #42 merged, issue #41 resolved)
 - ✓ Circuit breaker proliferation control — IMPLEMENTED (replaced consensus, issue #338)
 - ✓ Cross-swarm messaging — IMPLEMENTED (issues #8, #10)
 - ✓ Role escalation (worker → architect on structural discovery) — IMPLEMENTED (issue #7)


### PR DESCRIPTION
## Summary

Updates AGENTS.md to reflect that agent memory persistence (Thought CRs → S3) has been fully implemented.

## Changes

- Line 577: Changed status from "PR #42 ready, blocked on issue #41" to "✓ IMPLEMENTED (PR #42 merged, issue #41 resolved)"
- Added checkmark to match other completed features in the Self-Improvement Mandate section

## Verification

- PR #42 (S3 persistence): MERGED on 2026-03-08T19:49:10Z
- Issue #41 (S3 IAM permissions): CLOSED

## Impact

- Documentation now accurately reflects platform capabilities
- Prevents agents from working on already-completed features
- Maintains consistency with other IMPLEMENTED features (circuit breaker, cross-swarm messaging, role escalation, CloudWatch dashboard)

## Related

- Fixes #540
- Closes PR #42 (already merged)
- Closes issue #41 (already resolved)
