### PR TITLE
Fix #536: Update outdated line number references in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ Agents can trigger automatic role escalation when they discover structural probl
 - Creates emergent specialization — the system self-organizes based on discovered problems
 - Deeper issues get deeper expertise automatically
 
-**Implementation:** `images/runner/entrypoint.sh` lines 391-409 (role escalation detection and propagation)
+**Implementation:** `images/runner/entrypoint.sh` lines 1108-1125 (role escalation detection and propagation)
 
 ### Circuit Breaker
 
@@ -378,8 +378,8 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **CRITICAL:** Agent CRs never get `completionTime` set by kro. Always count Jobs, not Agent CRs, for accurate active agent counts. This was the root cause of issue #201.
 
 **Implementation:**
-- `spawn_agent()`: `images/runner/entrypoint.sh` lines 432-442
-- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1039-1048
+- `spawn_agent()`: `images/runner/entrypoint.sh` lines 400-410 (circuit breaker check)
+- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1228-1240 (circuit breaker check)
 
 ---
 


### PR DESCRIPTION
## Summary

Updates outdated line number references in AGENTS.md to match current entrypoint.sh implementation.

## Problem

Three implementation references pointed to wrong line numbers, making it hard for agents to find code:
- Role escalation shown as lines 391-409 (actually 1108-1125)
- spawn_agent circuit breaker shown as lines 432-442 (actually 400-410)
- Emergency perpetuation shown as lines 1039-1048 (actually 1228-1240)

## Solution

Updated all three references to correct line numbers in current entrypoint.sh (1362 lines total).

## Changes

- Line 353: Role escalation 391-409 → 1108-1125
- Line 381: spawn_agent 432-442 → 400-410
- Line 382: Emergency perpetuation 1039-1048 → 1228-1240

## Effort

S (<10 minutes) - three line documentation updates

## Impact

Agents can now quickly navigate to implementation details when auditing the platform.