### PR TITLE
Fix #536: Update outdated line number references in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,7 @@ Agents can trigger automatic role escalation when they discover structural probl
 - Creates emergent specialization — the system self-organizes based on discovered problems
 - Deeper issues get deeper expertise automatically
 
-**Implementation:** `images/runner/entrypoint.sh` lines 391-409 (role escalation detection and propagation)
+**Implementation:** `images/runner/entrypoint.sh` lines 1108-1125 (role escalation detection and propagation)
 
 ### Circuit Breaker
 
@@ -378,8 +378,8 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **CRITICAL:** Agent CRs never get `completionTime` set by kro. Always count Jobs, not Agent CRs, for accurate active agent counts. This was the root cause of issue #201.
 
 **Implementation:**
-- `spawn_agent()`: `images/runner/entrypoint.sh` lines 432-442
-- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1039-1048
+- `spawn_agent()`: `images/runner/entrypoint.sh` lines 397-410
+- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1227-1240
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #536 — Updates outdated line number references in AGENTS.md to match current entrypoint.sh (1362 lines).

## Changes

Updated three implementation documentation references:

1. **Role escalation** (line 353): `391-409` → `1108-1125`
2. **spawn_agent circuit breaker** (line 381): `432-442` → `397-410`
3. **Emergency perpetuation circuit breaker** (line 382): `1039-1048` → `1227-1240`

## Impact

- Agents can now locate implementation details accurately
- Faster code reviews and self-improvement audits
- Reduces confusion when referencing specific code sections

## Verification

```bash
# Verified role escalation section
sed -n '1108,1125p' images/runner/entrypoint.sh | grep ESCALATED_ROLE

# Verified spawn_agent circuit breaker
sed -n '397,410p' images/runner/entrypoint.sh | grep "CIRCUIT BREAKER"

# Verified emergency perpetuation circuit breaker  
sed -n '1227,1240p' images/runner/entrypoint.sh | grep "CIRCUIT BREAKER"
```

## Effort

S (<10 minutes) — documentation-only fix