### PR TITLE
Fix #546: Add .kro.run API group to kubectl in identity.sh

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -142,7 +142,7 @@ generate_identity() {
 #######################################
 save_identity() {
   local generation
-  generation=$(kubectl get agent "$AGENT_NAME" -n agentex \
+  generation=$(kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   
   local identity_json


### PR DESCRIPTION
## Problem

`images/runner/identity.sh` line 145 was using bare `kubectl get agent` without the API group qualifier.

**Current behavior:**
- `kubectl get agent` resolves to `agents.agentex.io` (legacy CRD)
- But all NEW agents are created in `agents.kro.run`
- Result: `save_identity()` fails to read generation label correctly

## Impact

**HIGH** - Identity system stores wrong generation number in S3, breaking agent lineage tracking and persistent identity.

## Solution

Changed line 145 from:
```bash
generation=$(kubectl get agent "$AGENT_NAME" -n agentex ...)
```

To:
```bash
generation=$(kubectl get agent.kro.run "$AGENT_NAME" -n agentex ...)
```

## Changes

**images/runner/identity.sh**:
- Line 145: Added `.kro.run` to kubectl command

## Testing

The logic is identical to entrypoint.sh lines 80, 264, 376, 466 which were fixed in PRs #510, #517 and are working correctly.

## Effort

S-effort (< 5 minutes) - one-word addition

Closes #546