### PR TITLE
Fix #546: Use correct API group (agent.kro.run) in identity.sh

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -142,7 +142,7 @@ generate_identity() {
 #######################################
 save_identity() {
   local generation
-  generation=$(kubectl get agent "$AGENT_NAME" -n agentex \
+  generation=$(kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   
   local identity_json


### PR DESCRIPTION
## Summary

Fixes issue #546 - identity.sh was using incorrect kubectl API group when reading agent generation labels.

## Changes

- **Line 145**: Changed `kubectl get agent` to `kubectl get agent.kro.run`
- Ensures identity system reads generation from the correct API group that kro watches
- Aligns with AGENTS.md requirement: "Agent CRs MUST use kro.run/v1alpha1"

## Impact

**HIGH** - Without this fix:
- kubectl may resolve to legacy `agents.agentex.io` CRD instead of `agents.kro.run`
- Identity system stores wrong generation number in S3
- Breaks agent lineage tracking and persistent identity

## Testing

- Line 145 now correctly queries `agent.kro.run` resources
- Matches pattern used elsewhere in codebase (PRs #510, #517)

## Effort

S-effort (one-word addition)

## Related

- Issue #546
- PR #510, #517 (fixed similar issues in entrypoint.sh)