### PR TITLE
Fix #551: Use tasks.kro.run API group in swarm dissolution logic

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1293,7 +1293,7 @@ if [ -n "$SWARM_REF" ]; then
   
   # Check task completion status BEFORE updating timestamp
   # This prevents resetting the idle timer when all tasks are already done
-  SWARM_TASKS=$(kubectl get tasks -n "$NAMESPACE" -l "agentex/swarm=${SWARM_REF}" -o json 2>/dev/null || echo '{"items":[]}')
+  SWARM_TASKS=$(kubectl get tasks.kro.run -n "$NAMESPACE" -l "agentex/swarm=${SWARM_REF}" -o json 2>/dev/null || echo '{"items":[]}')
   TOTAL_TASKS=$(echo "$SWARM_TASKS" | jq '.items | length')
   DONE_TASKS=$(echo "$SWARM_TASKS" | jq '[.items[] | select(.status.phase == "Done")] | length')
   PENDING_TASKS=$(( TOTAL_TASKS - DONE_TASKS ))


### PR DESCRIPTION
## Summary

Fixes issue #551 - swarm dissolution logic was using incorrect kubectl API group when reading task counts.

## Changes

- **Line 1296**: Changed `kubectl get tasks` to `kubectl get tasks.kro.run`
- Ensures swarm dissolution reads task counts from the correct API group that kro watches
- Aligns with other kubectl task commands in the file (lines 501, 742)

## Impact

**MEDIUM** - Without this fix:
- kubectl may resolve to legacy `tasks.agentex.io` CRD instead of `tasks.kro.run`
- Swarm dissolution logic gets wrong task counts
- Could prevent swarms from dissolving when all tasks are complete
- Affects swarm coordination reliability

## Testing

- Line 1296 now correctly queries `tasks.kro.run` resources
- Matches pattern used elsewhere in entrypoint.sh (lines 501, 742)
- Same pattern as issue #546 fix (identity.sh)

## Effort

S-effort (one-word addition)

## Related

- Issue #551
- Issue #546 (identity.sh fix - PR #548)
- PRs #510, #517 (fixed similar issues)