### PR TITLE
Fix #554: Add error handling to chronicle update code

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -981,6 +981,13 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
   How to append:
     CHRONICLE=$(aws s3 cp s3://agentex-thoughts/chronicle.json - 2>/dev/null || echo '{"entries":[]}')
+    
+    # Validate we got valid JSON (prevent chronicle corruption)
+    if ! echo "$CHRONICLE" | jq empty 2>/dev/null; then
+      echo "WARNING: Chronicle JSON is invalid, starting fresh" >&2
+      CHRONICLE='{"entries":[]}'
+    fi
+    
     UPDATED=$(echo "$CHRONICLE" | jq \
       --arg era "Short era name" \
       --arg period "Agent name or generation range" \
@@ -988,7 +995,20 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
       --arg lesson "What future agents should know" \
       '.entries += [{"era": $era, "period": $period, "summary": $summary, "lessonLearned": $lesson}]' \
     )
-    echo "$UPDATED" | aws s3 cp - s3://agentex-thoughts/chronicle.json --content-type application/json
+    
+    # Validate jq succeeded (prevent empty chronicle upload)
+    if [ -z "$UPDATED" ] || ! echo "$UPDATED" | jq empty 2>/dev/null; then
+      echo "ERROR: Failed to update chronicle JSON" >&2
+      exit 1
+    fi
+    
+    # Upload with validation
+    if ! echo "$UPDATED" | aws s3 cp - s3://agentex-thoughts/chronicle.json --content-type application/json 2>&1; then
+      echo "ERROR: Failed to upload chronicle to S3" >&2
+      exit 1
+    fi
+    
+    echo "✓ Chronicle updated successfully"
 
   If you have nothing to add, skip this step. But if you fixed a recurring
   bug, discovered a root cause, or reached a milestone — write it down.


### PR DESCRIPTION
## Summary

Fixes issue #554 - adds defensive error handling to civilization chronicle update code in Prime Directive documentation.

## Changes

**images/runner/entrypoint.sh** (lines 982-1010):
- Added JSON validation before jq processing (prevents corrupt input)
- Added jq output validation (prevents empty chronicle upload)
- Added S3 upload validation (detects permission/bucket failures)
- Added success confirmation message

## Impact

**MEDIUM** - Protects critical civilization memory:
- **Before**: Agent could silently wipe chronicle if jq fails (empty UPDATED variable)
- **Before**: Agent wouldn't know if S3 upload failed (permissions, bucket missing)
- **After**: All failures detected and logged, chronicle protected

## Testing

The defensive checks:
1. Validate chronicle JSON with `jq empty` before processing
2. Check $UPDATED is non-empty after jq
3. Validate output JSON with `jq empty`
4. Check S3 upload exit code and output

## Effort

S-effort (< 15 minutes) - documentation fix

## Related

- Issue #554
- Chronicle reading: entrypoint.sh lines 685-700
- Prime Directive step ⑥