### PR TITLE
Validate GitHub issue exists before spawning worker (issue #561)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -573,6 +573,26 @@ spawn_task_and_agent() {
   local task_name="$1" agent_name="$2" role="$3" title="$4" desc="$5" effort="${6:-M}" issue="${7:-0}" swarm_ref="${8:-}"
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
+  # ISSUE VALIDATION (issue #561): Verify GitHub issue exists and is open
+  if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
+    local issue_state=$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+    
+    if [ "$issue_state" = "NOT_FOUND" ]; then
+      log "ERROR: GitHub issue #${issue} does not exist. Skipping spawn."
+      post_thought "Skipped spawning worker: issue #${issue} not found in GitHub (may be typo or wrong repo)." "observation" 7
+      return 0
+    fi
+    
+    if [ "$issue_state" = "CLOSED" ]; then
+      log "WARNING: GitHub issue #${issue} is closed. Skipping spawn."
+      post_thought "Skipped spawning worker: issue #${issue} already closed (resolved or obsolete)." "observation" 7
+      return 0
+    fi
+    
+    # Log successful validation
+    log "Issue #${issue} validated: state=$issue_state"
+  fi
+
   # DUPLICATE WORK PREVENTION (issue #439): Check if issue already has open PR
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
     local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

Fixes #561 - Adds GitHub issue validation to `spawn_task_and_agent()` to prevent spawning workers for non-existent or closed issues.

## Problem

The function checked for existing PRs and active Tasks (duplicate work prevention), but didn't validate that the GitHub issue:
1. Actually exists (could be a typo: #123 vs #1234)
2. Is open (vs already closed/resolved)

**Impact:**
- Workers spawned for non-existent issues waste cluster resources
- Workers spawned for closed issues duplicate already-completed work
- Orphaned Task CRs with invalid `githubIssue` references

## Solution

Added issue validation at lines 575-597 (runs BEFORE duplicate checks):

```bash
# Validate issue exists and is open
local issue_state=$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")

if [ "$issue_state" = "NOT_FOUND" ]; then
  log "ERROR: GitHub issue #${issue} does not exist. Skipping spawn."
  post_thought "Skipped spawning worker: issue #${issue} not found in GitHub (may be typo or wrong repo)." "observation" 7
  return 0
fi

if [ "$issue_state" = "CLOSED" ]; then
  log "WARNING: GitHub issue #${issue} is closed. Skipping spawn."
  post_thought "Skipped spawning worker: issue #${issue} already closed (resolved or obsolete)." "observation" 7
  return 0
fi
```

**Behavior:**
- ✓ Validates issue exists before checking for PRs/Tasks
- ✓ Validates issue is OPEN (not CLOSED)
- ✓ Logs validation results for debugging
- ✓ Posts observation Thought if spawn skipped
- ✓ Returns 0 (graceful skip, not error)

## Impact

**Medium** for resource efficiency:
- Prevents wasted spawns (helps circuit breaker stay under limit)
- Catches typos early (before creating Task CR)
- Prevents closed issue re-work

**Low** for correctness:
- Existing duplicate work prevention already catches most issues
- This is defensive programming / early validation

## Testing

Validation follows same pattern as existing duplicate checks (lines 576-595):
- Uses `gh issue view` (same tool as other checks)
- Returns 0 on skip (consistent with duplicate detection behavior)
- Posts observation Thought (visibility for next agent)

## Effort

S-effort (< 30 minutes) - 23 new lines of validation code

## Related

- Issue #439 (duplicate work prevention) - extends that pattern
- Circuit breaker proliferation - every prevented spawn helps
- Issue #561