### PR TITLE
Fix #559: Add kubectl timeout wrapper to Prime Directive template

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -944,11 +944,11 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   # Count total active jobs across all roles to detect system overload.
 
   # Read circuit breaker limit from constitution (never hardcode!)
-  CIRCUIT_BREAKER_LIMIT=\$(kubectl get configmap agentex-constitution -n agentex \\
+  CIRCUIT_BREAKER_LIMIT=\$(kubectl_with_timeout 10 get configmap agentex-constitution -n agentex \\
     -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
   if ! [[ "\$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+\$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
 
-  ACTIVE_JOBS=\$(kubectl get jobs -n agentex -o json | \\
+  ACTIVE_JOBS=\$(kubectl_with_timeout 10 get jobs -n agentex -o json | \\
     jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
   echo "Circuit breaker check: \$ACTIVE_JOBS active jobs (limit: \$CIRCUIT_BREAKER_LIMIT)"
@@ -1007,7 +1007,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   # STEP 4: Create Agent CR (triggers the Job via kro)
   # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
   # Calculate next generation: read your generation label and add 1
-  MY_GEN=\$(kubectl get agent.kro.run \${AGENT_NAME} -n agentex \\
+  MY_GEN=\$(kubectl_with_timeout 10 get agent.kro.run \${AGENT_NAME} -n agentex \\
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   NEXT_GEN=\$((MY_GEN + 1))
 


### PR DESCRIPTION
## Summary
Fixed issue #559 by adding `kubectl_with_timeout` wrapper to 3 critical kubectl commands in the Prime Directive template that OpenCode agents execute.

## Problem
The Prime Directive heredoc template (lines 900-1100 of entrypoint.sh) is executed by OpenCode agents when they spawn successors. Three kubectl commands lacked timeout protection:

1. **Line 947**: Reading circuit breaker limit from constitution ConfigMap
2. **Line 951**: Counting active jobs for circuit breaker check
3. **Line 1010**: Reading agent generation label

When kubectl hangs due to slow/unreachable cluster API, agents waste 120 seconds per command instead of fast-failing after 10 seconds. This delays successor spawning and work startup.

## Solution
Changed all 3 commands from `kubectl get` to `kubectl_with_timeout 10 get` for consistency with the rest of entrypoint.sh.

The `kubectl_with_timeout()` wrapper (line 25) already exists and is used throughout the codebase. This change applies it to the Prime Directive template.

## Impact
- **HIGH**: Prevents 2+ minute hangs in critical agent lifecycle operations
- Agents fail fast (10s) when cluster API is unreachable instead of hanging (120s)
- Consistent with existing timeout protection elsewhere in entrypoint.sh

## Testing
- Verified changes apply only to Prime Directive template (heredoc)
- No functional changes - only wraps existing commands with timeout
- Pattern matches other kubectl commands in entrypoint.sh

## Effort
S-effort: Mechanical change, 3 lines affected, < 15 minutes

Fixes #559