### PR TITLE
Add generation number to agent log output

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -16,8 +16,13 @@ CLUSTER="${CLUSTER:-agentex}"
 BEDROCK_REGION="${BEDROCK_REGION:-us-west-2}"
 BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
 WORKSPACE="/workspace"
+MY_GENERATION=""  # Set after kubectl config (issue #566)
 
-log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [$AGENT_NAME] $*"; }
+log() { 
+  local gen_suffix=""
+  [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*"
+}
 
 # ── kubectl timeout wrapper (issue #441) ───────────────────────────────────
 # Wrap critical kubectl commands with fast-fail timeout to prevent 120s hangs.
@@ -162,6 +167,14 @@ if ! timeout 10 kubectl cluster-info &>/dev/null; then
   exit 1
 fi
 log "Cluster connectivity verified ✓"
+
+# ── 1.1.5. Read generation label for log output (issue #566) ──────────────────
+# Read generation label to include in log output for better debugging
+MY_GENERATION=$(kubectl_with_timeout 10 get agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "")
+if [ -n "$MY_GENERATION" ]; then
+  log "Generation $MY_GENERATION detected"
+fi
 
 # ── 1.2. EARLY CIRCUIT BREAKER CHECK (issue #502) ─────────────────────────────
 # CRITICAL: Check circuit breaker IMMEDIATELY after cluster connectivity verification.


### PR DESCRIPTION
## Summary

Implements issue #566: adds generation number to agent log output for better debugging and observability.

## Changes

- Declare `MY_GENERATION` global variable (set after kubectl config)
- Update `log()` function to append `/gen-N` suffix when generation is known
- Read generation label at startup (step 1.1.5)

## Example Output

**Before:**
```
[2026-03-09T01:23:45Z] [planner-1773013444] Starting work
```

**After:**
```
[2026-03-09T01:23:45Z] [planner-1773013444/gen-4] Starting work
```

## Benefits

- Easier debugging of lineage and proliferation issues
- Quickly identify which generation caused a problem
- Better observability in CloudWatch logs
- Helps track generation progression

## Testing

Tested locally - log format works with and without generation label present (gracefully degrades if label missing).

## Effort

S-effort (< 15 minutes, 12 lines changed)

## Related Issues

Closes #566