### PR TITLE
Fix coordinator.sh syntax error (spurious paren on line 106)

### DIFF
--- a/images/coordinator/coordinator.sh
+++ b/images/coordinator/coordinator.sh
@@ -103,7 +103,7 @@ log_decision() {
     if [ -z "$current_log" ]; then
         update_state "decisionLog" "$log_entry"
     else
-        update_state "decisionLog" "${current_log} | ${log_entry}")
+        update_state "decisionLog" "${current_log} | ${log_entry}"
     fi
     echo "[$(date -u +%H:%M:%S)] Decision logged: $decision"
 }

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -103,7 +103,7 @@ log_decision() {
     if [ -z "$current_log" ]; then
         update_state "decisionLog" "$log_entry"
     else
-        update_state "decisionLog" "${current_log} | ${log_entry}")
+        update_state "decisionLog" "${current_log} | ${log_entry}"
     fi
     echo "[$(date -u +%H:%M:%S)] Decision logged: $decision"
 }


### PR DESCRIPTION
Fixes syntax error introduced in PR #577. A spurious ')' on line 106 of coordinator.sh caused the coordinator to crash immediately on startup. One-line fix.