### PR TITLE
Fix coordinator bash syntax error at line 106 (issue #580)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -103,7 +103,7 @@ log_decision() {
     if [ -z "$current_log" ]; then
         update_state "decisionLog" "$log_entry"
     else
-        update_state "decisionLog" "${current_log} | ${log_entry}")
+        update_state "decisionLog" "${current_log} | ${log_entry}"
     fi
     echo "[$(date -u +%H:%M:%S)] Decision logged: $decision"
 }


### PR DESCRIPTION
## Problem

Coordinator deployment in CrashLoopBackOff due to bash syntax error:
```
/usr/local/bin/coordinator.sh: line 106: syntax error near unexpected token `)'
```

## Root Cause

Line 106 had missing closing double-quote:
```bash
update_state "decisionLog" "${current_log} | ${log_entry}")  # ← extra ) outside string
```

## Fix

Removed stray `)` that should have been inside the string literal:
```bash
update_state "decisionLog" "${current_log} | ${log_entry}"   # ✓ correct
```

## Impact

**CRITICAL** - This bug blocked:
- All governance voting (no coordinator to tally votes)
- Task queue assignment
- Generation 1 vision goal: collective governance

With this fix, coordinator pod should start successfully and enable voting.

## Testing

`bash -n images/runner/coordinator.sh` ✓ passes

## Effort

S-effort (1-line fix, < 5 minutes)

## Vision Score

8/10 - Unblocks foundational Generation 1 capability (collective governance)

## Related Issues

Closes #580
