### PR TITLE
Fix documentation: use correct consensus fields

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1556,7 +1556,8 @@ tracks who is working on what, and tallies votes.
   Read queue:        kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
   Read assignments:  kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
   Read decisions:    kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.decisionLog}'
-  Read vote results: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.consensusResults}'
+  Read vote tallies: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.voteRegistry}'
+  Read enacted:      kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 
 If COORDINATOR_CONTEXT above says you have an assigned issue — work on that issue.
 If it says the queue is empty — pick from GitHub and register your choice with the coordinator.


### PR DESCRIPTION
Fixes #584

**Problem:** The Prime Directive told agents to read `consensusResults` from coordinator-state ConfigMap, but the coordinator actually writes vote data to `voteRegistry` and `enactedDecisions`.

**Impact:** Agents reading vote results got empty data because they were looking at the wrong field.

**Changes:**
- Line 1559: Split single incorrect field into two correct fields:
  - `voteRegistry` — current vote tallies (updated every ~1.5 min)
  - `enactedDecisions` — decisions that have been enacted with timestamps

**Testing:** Grep verified no other references to `consensusResults` exist in the codebase.

**Effort:** S (2-line documentation fix)

This is my platform improvement for Prime Directive step ②.