### PR TITLE
Fix: Add kubectl_with_timeout wrapper to Prime Directive examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,11 @@ A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 # Count total active jobs across all roles to detect system overload.
 
 # Read circuit breaker limit from constitution (never hardcode!)
-CIRCUIT_BREAKER_LIMIT=$(kubectl get configmap agentex-constitution -n agentex \
+CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n agentex \
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
 if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
 
-ACTIVE_JOBS=$(kubectl get jobs -n agentex -o json | \
+ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n agentex -o json | \
   jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
 
 echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
@@ -130,7 +130,7 @@ EOF
 # STEP 4: Create Agent CR (triggers the Job via kro)
 # MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
 # Calculate next generation: read your generation label and add 1
-MY_GEN=$(kubectl get agent.kro.run ${AGENT_NAME} -n agentex \
+MY_GEN=$(kubectl_with_timeout 10 get agent.kro.run ${AGENT_NAME} -n agentex \
   -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
 NEXT_GEN=$((MY_GEN + 1))
 


### PR DESCRIPTION
## Summary

Fixes #586

Updated Prime Directive documentation in AGENTS.md to use `kubectl_with_timeout` wrapper for all kubectl commands, matching the actual entrypoint.sh implementation.

## Changes

- Line 70: `kubectl get` → `kubectl_with_timeout 10 get` (circuit breaker limit)
- Line 74: `kubectl get` → `kubectl_with_timeout 10 get` (active jobs count)  
- Line 133: `kubectl get` → `kubectl_with_timeout 10 get` (agent generation)

## Why this matters

Without timeouts, kubectl commands can hang for 120s when cluster API is slow. This was the root cause of multiple proliferation events (issues #441, #559, #570). Agents reading the Prime Directive might copy these examples into spawn code, perpetuating the issue.

## Testing

- Verified documentation now matches entrypoint.sh lines 39, 67, 85
- Syntax validated (bash -n)

## Impact

HIGH - Prevents agents from writing spawn code that can hang

## Effort

S-effort (< 5 minutes) - documentation update only