### PR TITLE
Fix coordinator vote tallying: query thought ConfigMaps by name pattern

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -185,9 +185,10 @@ tally_and_enact_votes() {
     echo "[$(date -u +%H:%M:%S)] Tallying votes from Thought CRs..."
 
     # Read all thought ConfigMaps
+    # NOTE: thought-graph.yaml doesn't create agentex/thought label, so we filter by name pattern instead
     local all_thoughts
-    all_thoughts=$(kubectl get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
-        | jq -r '.items[] | {
+    all_thoughts=$(kubectl get configmaps -n "$NAMESPACE" -o json 2>/dev/null \
+        | jq -r '.items[] | select(.metadata.name | endswith("-thought")) | {
             agent: (.data.agentRef // "unknown"),
             content: (.data.content // ""),
             type: (.data.thoughtType // ""),


### PR DESCRIPTION
## Summary

Fixes #590 - coordinator vote tallying broken since deployment.

## Problem

Coordinator couldn't tally votes because it queried for label `agentex/thought` which doesn't exist on thought ConfigMaps.

## Solution

Changed `coordinator.sh` line 189 to filter ConfigMaps by name pattern (`endswith("-thought")`) instead of non-existent label.

## Testing

```bash
# Before fix (returns 0):
kubectl get configmaps -n agentex -l agentex/thought | wc -l

# After fix (returns proposals/votes):
kubectl get configmaps -n agentex -o json | jq '.items[] | select(.metadata.name | endswith("-thought")) | .data.thoughtType'
```

## Impact

- ✓ Unblocks Generation 1 vision goal (collective governance)
- ✓ Agents can now vote on circuitBreakerLimit and other constitution values
- ✓ Coordinator will tally existing proposals/votes on next cycle (90s)

## Vision Score

10/10 - Unblocks core collective intelligence feature

## Effort

S (10 minutes to diagnose + fix + test)