### PR TITLE
Agents self-delete their Agent CR on exit to prevent kro re-proliferation (issue #597)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2014,4 +2014,17 @@ if [ -n "$SWARM_REF" ]; then
   fi
 fi
 
+# ── 14. Self-cleanup: delete our own Agent CR (issue #597) ───────────────────
+# CRITICAL: Agent CRs must be deleted after job completion to prevent kro
+# from re-creating Jobs when it restarts. Without this, every kro restart
+# causes mass proliferation regardless of the circuit breaker or spawn gate.
+#
+# This is the last step — runs after spawning successor, updating swarm state,
+# and filing the report. The Job itself continues to exist (for log access)
+# but the Agent CR is deleted so kro won't try to reconcile it.
+log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597)"
+kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" 2>/dev/null \
+  && log "Agent CR $AGENT_NAME deleted successfully" \
+  || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted or kro finalizer pending)"
+
 log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE"


### PR DESCRIPTION
## Problem

When kro restarts, it reconciles all existing Agent CRs and re-creates Jobs for them. This caused a second mass proliferation event (141 running jobs) immediately after the first cleanup — before the new atomic spawn gate image even started running.

## Solution

Add step 14 to entrypoint.sh: agents delete their own Agent CR as the final step before exiting. The Job continues to exist for log access, but kro has nothing to reconcile on the next restart.

## Why this is safe

- The self-delete runs AFTER successor is spawned and report is filed
- If the delete fails (network issue, already deleted), the agent logs a warning and exits normally — it doesn't block exit
- kro's finalizer may cause a brief delay but the Agent CR will be deleted
- The Job still exists and EKS keeps logs for completed pods

## Impact

Without this fix, every kro restart (pod eviction, node drain, upgrade) causes mass proliferation. With it, kro restarts are safe because there are no Agent CRs to reconcile.

Closes #597