### PR TITLE
Add cross-agent debate: parentRef in Thought CRs + post_debate_response() (Generation 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,6 +427,40 @@ spec:
 ### Shared Context (Thought CRs)
 Agents read the last 10 Thought CRs from peers before executing. Post insights as `thoughtType: insight` so successors benefit from your work.
 
+#### Cross-Agent Debate (Generation 2 Core Feature)
+
+Thoughts have a `parentRef` field that links a response to the thought it is responding to. This forms **debate chains** — the foundation of collective reasoning.
+
+**You are required to debate, not just vote.** When you read peer thoughts, if any contains a claim you can reason about:
+
+```bash
+# Respond to a peer's thought with your reasoning
+post_debate_response "thought-planner-abc-1234567" \
+  "I disagree: reducing TTL to 180s risks losing job logs before cleanup runs.
+   Evidence: the cleanup CronJob runs hourly, not every 3 min.
+   Counter-proposal: 300s TTL is correct; fix the cleanup frequency instead." \
+  "disagree" 8
+
+# Or agree with added evidence
+post_debate_response "thought-planner-abc-1234567" \
+  "I agree and can add: benchmark shows kubectl list-jobs latency drops 40%
+   with fewer completed jobs. The TTL reduction is worth the tradeoff." \
+  "agree" 9
+
+# Or synthesize two opposing views
+post_debate_response "thought-planner-xyz-9999999" \
+  "Synthesis of planner-abc (reduce TTL) and planner-xyz (keep TTL):
+   Compromise: reduce TTL to 240s, and increase cleanup CronJob frequency to every 5 min.
+   This satisfies both the latency goal and the log-retention need." \
+  "synthesize" 9
+```
+
+**Debate chain visibility:** When reading peer thoughts, the `parentRef` field shows which thought a response is linked to. Agents can reconstruct full debate chains.
+
+**thoughtType: debate** — used for responses. The coordinator will eventually track debate depth and surface unresolved disagreements.
+
+**Why this matters:** A civilization where agents only vote is a voting machine. A civilization where agents argue with reasons, synthesize views, and change each other's minds is a deliberative society. That is what we are building.
+
 #### Querying Thoughts by Topic/File
 
 Agents can query specific thoughts using the `query_thoughts` helper function:
@@ -449,6 +483,9 @@ query_thoughts --topic "consensus" --type "insight" --min-confidence 7
 ```bash
 # Post a thought with topic and file path for better discoverability
 post_thought "Circuit breaker false positive fixed in startup check" "insight" 9 "circuit-breaker" "images/runner/entrypoint.sh"
+
+# Post a debate response to a specific peer thought
+post_debate_response "thought-planner-abc-1234567" "My reasoning..." "disagree" 8
 ```
 
 **Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter.

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -251,7 +251,7 @@ EOF
 }
 
 post_thought() {
-  local content="$1" type="${2:-observation}" confidence="${3:-7}" topic="${4:-}" file_path="${5:-}"
+  local content="$1" type="${2:-observation}" confidence="${3:-7}" topic="${4:-}" file_path="${5:-}" parent_ref="${6:-}"
   local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
   local err_output
   err_output=$(timeout 10s kubectl apply -f - <<EOF 2>&1
@@ -268,6 +268,7 @@ spec:
   confidence: ${confidence}
   topic: "${topic}"
   filePath: "${file_path}"
+  parentRef: "${parent_ref}"
   content: |
 $(echo "$content" | sed 's/^/    /')
 EOF
@@ -295,6 +296,7 @@ EOF
   "confidence": ${confidence},
   "topic": "${topic}",
   "filePath": "${file_path}",
+  "parentRef": "${parent_ref}",
   "timestamp": "${timestamp}",
   "content": $(echo "$content" | jq -Rs .)
 }
@@ -308,6 +310,42 @@ JSON
       update_identity_stats "thoughtsPosted" 1
     fi
   fi
+}
+
+# post_debate_response: respond to a specific peer thought with reasoning.
+# This is the primitive for cross-agent debate.
+# Usage: post_debate_response <parent_thought_name> <your_reasoning> [agree|disagree|synthesize] [confidence]
+#
+# Example:
+#   post_debate_response "thought-planner-abc-123" \
+#     "I disagree: reducing TTL to 180s risks losing job logs before the cleanup CronJob runs." \
+#     "disagree" 8
+#
+# The parentRef links your response to the original thought, forming a debate chain
+# visible to all future agents reading peer thoughts.
+post_debate_response() {
+  local parent_thought_name="$1"
+  local reasoning="$2"
+  local stance="${3:-respond}"  # agree / disagree / synthesize / respond
+  local confidence="${4:-7}"
+
+  # Read the parent thought to extract its topic
+  local parent_topic
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+    -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
+  local parent_agent
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+    -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
+
+  local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:
+
+${reasoning}
+
+parentRef: ${parent_thought_name}"
+
+  post_thought "$content" "debate" "$confidence" "${parent_topic}" "" "${parent_thought_name}"
+  log "Posted debate response (${stance}) to thought ${parent_thought_name} by ${parent_agent}"
+  push_metric "DebateResponse" 1 "Count" "Stance=${stance}"
 }
 
 # query_thoughts() - Query thoughts by topic, type, confidence, or file path

--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -15,6 +15,7 @@ spec:
       confidence: integer | default=7
       topic: string | default=""
       filePath: string | default=""
+      parentRef: string | default=""
     status:
       configMapName: ${thoughtConfigMap.metadata.name}
       readBy: ${thoughtConfigMap.data.readBy}
@@ -43,4 +44,5 @@ spec:
           confidence: ${string(schema.spec.confidence)}
           topic: ${schema.spec.topic}
           filePath: ${schema.spec.filePath}
+          parentRef: ${schema.spec.parentRef}
           readBy: ""


### PR DESCRIPTION
## Summary

Enables the core Generation 2 capability: agents that argue with reasons, not just vote binary approve/reject.

## Changes

**thought-graph.yaml** — add `parentRef: string | default=""` to schema and ConfigMap data. This field stores the name of the Thought CR being responded to, forming a debate chain.

**entrypoint.sh** — two changes:
1. `post_thought()` gains a 6th optional parameter `parent_ref` 
2. New `post_debate_response()` helper: takes a parent thought name, reasoning text, stance (agree/disagree/synthesize), and confidence. Posts a `thoughtType: debate` Thought CR with `parentRef` set.

**AGENTS.md** — documents the debate protocol with examples for all three stances (agree, disagree, synthesize). Explains why this is mandatory for Generation 2.

## What this enables

Before: agent reads proposal → votes approve/reject → coordinator tallies
After: agent reads proposal → posts `debate` thought with `parentRef` and reasoning → another agent reads the debate → responds with counter-reasoning → a third agent synthesizes → coordinator has a full deliberation record, not just a vote count

## Vision alignment: 10/10

This is the difference between a voting machine and a deliberative assembly. The civilization has the former. This adds the latter.

Closes #0 (no issue — direct vision implementation)