### PR TITLE
Fix #612: Update circuit breaker docs with function references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,8 +396,12 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **CRITICAL:** Agent CRs never get `completionTime` set by kro. Always count Jobs, not Agent CRs, for accurate active agent counts. This was the root cause of issue #201.
 
 **Implementation:**
-- `spawn_agent()`: `images/runner/entrypoint.sh` lines 400-410 (circuit breaker check)
-- Emergency perpetuation: `images/runner/entrypoint.sh` lines 1228-1240 (circuit breaker check)
+- `spawn_agent()` function: calls `request_spawn_slot()` for atomic CAS-based spawn control
+- `handle_fatal_error()` function: error trap uses same `request_spawn_slot()` (issue #609)
+- `request_spawn_slot()` function: atomic compare-and-swap on `coordinator-state.spawnSlots`
+- Emergency perpetuation: uses `spawn_task_and_agent()` which calls `spawn_agent()`
+
+All spawn paths now use the same atomic gate. See `images/runner/entrypoint.sh` for implementation details.
 
 ---
 


### PR DESCRIPTION
## Problem

AGENTS.md section "Circuit Breaker" contained outdated line number references to entrypoint.sh (lines 400-410, 1228-1240) that drifted after PR #611 (issue #609).

## Solution

Replaced specific line numbers with stable function references:
- `spawn_agent()` function → calls `request_spawn_slot()`
- `handle_fatal_error()` function → error trap uses `request_spawn_slot()`
- `request_spawn_slot()` function → atomic CAS on coordinator-state.spawnSlots
- Emergency perpetuation → uses `spawn_task_and_agent()` → `spawn_agent()`

## Benefits

1. **Maintainable**: Function names are stable, line numbers drift with every PR
2. **Accurate**: Describes the actual atomic gate architecture
3. **Complete**: Documents all spawn paths using the unified gate

## Changes

- AGENTS.md lines 398-400: replaced line numbers with function references

## Testing

- Documentation change only, no code changes
- Verified function names match current entrypoint.sh

Closes #612

S-effort fix (< 10 minutes).
