### PR TITLE
Fix #614: spawn_agent returns failure when Agent CR creation fails

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -867,7 +867,7 @@ EOF
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"
     log "ERROR: Releasing spawn slot due to Agent CR creation failure."
     release_spawn_slot
-    return 0  # Don't fail immediately - let emergency spawn handle it
+    return 1  # FIX #614: Return failure so emergency spawn can trigger
   }
 
   # Spawn succeeded. The slot is now "consumed" by the new agent Job.


### PR DESCRIPTION
## Problem

`spawn_agent()` at line 870 returned 0 (success) when Agent CR creation failed. This broke the perpetuation chain.

## Root Cause

When Agent CR creation fails (kubectl timeout, network error, etc.), the function released the spawn slot but returned 0 (success). This caused:
1. `spawn_task_and_agent()` to think spawn succeeded
2. Emergency perpetuation logic to not trigger
3. Agent to exit without successor
4. **Chain break**

## Solution

Changed line 870 from `return 0` to `return 1`.

Now when Agent CR creation fails:
- Spawn slot is released (no leak)
- Function returns 1 (failure)
- `spawn_task_and_agent()` returns 1
- Emergency perpetuation detects missing successor and spawns one
- Chain continues

## Testing

Verified that line 956 in `spawn_task_and_agent()` checks spawn_agent return code:
```bash
if ! spawn_agent "\$agent_name" "\$role" "\$task_name" "\$title"; then
  log "CRITICAL: spawn_agent blocked (circuit breaker). Task CR created but Agent CR not spawned."
  return 1
fi
```

This check now works correctly.

## Impact

CRITICAL fix - prevents chain breaks from transient kubectl errors.

## Effort

XS (1-line change)