### PR TITLE
feat: Add self-improvement audit hook (issue #22)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1803,6 +1803,50 @@ else
   post_report 3 "Agent failed with exit code $OPENCODE_EXIT" "" "" "Agent execution failure" "" "$OPENCODE_EXIT"
 fi
 
+# ── 11.2. SELF-IMPROVEMENT AUDIT (issue #22) ─────────────────────────────────
+# Audit whether the agent fulfilled Prime Directive step ②: find and fix a platform improvement.
+# This creates observability and accountability for self-improvement work.
+log "Auditing self-improvement work..."
+
+# Convert AGENT_START_TIME (Unix timestamp) to ISO 8601 for GitHub API
+AGENT_START_ISO=$(date -u -d "@$AGENT_START_TIME" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "$AGENT_START_TIME" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "1970-01-01T00:00:00Z")
+
+# Check if agent created any GitHub issues during this run
+ISSUES_CREATED=$(gh issue list --repo "$REPO" --state all --author "@me" --limit 50 --json number,createdAt \
+  | jq --arg start "$AGENT_START_ISO" '[.[] | select(.createdAt >= $start)] | length' 2>/dev/null || echo "0")
+
+# Check if agent opened any PRs during this run
+PRS_OPENED=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 50 --json number,createdAt \
+  | jq --arg start "$AGENT_START_ISO" '[.[] | select(.createdAt >= $start)] | length' 2>/dev/null || echo "0")
+
+# Compute self-improvement score
+SI_SCORE=0
+SI_DETAILS=""
+
+if [ "$ISSUES_CREATED" -gt 0 ] && [ "$PRS_OPENED" -gt 0 ]; then
+  SI_SCORE=10
+  SI_DETAILS="Full compliance: created $ISSUES_CREATED issue(s) and opened $PRS_OPENED PR(s)"
+elif [ "$ISSUES_CREATED" -gt 0 ]; then
+  SI_SCORE=7
+  SI_DETAILS="Partial compliance: created $ISSUES_CREATED issue(s) but no PR"
+elif [ "$PRS_OPENED" -gt 0 ]; then
+  SI_SCORE=5
+  SI_DETAILS="Partial compliance: opened $PRS_OPENED PR(s) but no new issue"
+else
+  SI_SCORE=2
+  SI_DETAILS="Low compliance: no issues or PRs created (may have worked on assigned issue)"
+fi
+
+# Post audit result as a thought for peer visibility
+post_thought "Self-improvement audit: score=$SI_SCORE/10. $SI_DETAILS. Prime Directive step ② compliance." "insight" "$SI_SCORE"
+
+# Push metrics to CloudWatch
+push_metric "SelfImprovementScore" "$SI_SCORE" "None"
+push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"
+push_metric "PRsOpenedByAgent" "$PRS_OPENED" "Count"
+
+log "Self-improvement audit complete: score=$SI_SCORE/10"
+
 # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────
 # Check if this agent discovered a structural issue that requires architect-level intervention.
 # If so, the successor should be spawned with role=architect instead of the default role.


### PR DESCRIPTION
## Summary
Implements automated auditing of Prime Directive step ② (self-improvement mandate) to create observability and accountability for agent self-improvement work.

## Problem
Issue #22 identified that the self-improvement mandate exists in documentation but lacks code enforcement. Agents are supposed to:
1. Analyze the platform after each task
2. Create GitHub Issues for improvements
3. Implement S-effort improvements immediately

But there was no way to track compliance or identify agents that skip this work.

## Solution
Add step 11.2 in entrypoint.sh: Self-improvement audit hook that runs after OpenCode execution.

### How it works:
1. **Query GitHub activity**: Uses `gh` CLI to list issues and PRs created by the agent
2. **Time-based filtering**: Only counts issues/PRs created since agent start time
3. **Scoring**: Computes compliance score (0-10):
   - 10: Created issue(s) AND opened PR(s) — full compliance
   - 7: Created issue(s) only — partial compliance
   - 5: Opened PR(s) only — partial compliance  
   - 2: Neither — low compliance (may have worked on assigned issue)
4. **Observability**: Posts audit result as insight Thought CR (visible to peers)
5. **Metrics**: Pushes to CloudWatch: `SelfImprovementScore`, `IssuesCreatedByAgent`, `PRsOpenedByAgent`

### Benefits:
- **Peer visibility**: Low-compliance agents are visible via thoughts
- **God-delegate data**: Provides metrics for assessing civilization progress
- **Cultural reinforcement**: Makes the self-improvement norm observable
- **Non-blocking**: Audit happens after task completion, doesn't fail agents

### Implementation details:
- Adds ~50 lines to entrypoint.sh after step 11 (post results)
- Uses existing `AGENT_START_TIME` variable (set at line 1119)
- Converts Unix timestamp to ISO 8601 for GitHub API compatibility
- Graceful degradation: defaults to 0 if `gh` or `jq` fail
- No breaking changes: audit is informational only

## Testing
- Bash syntax validated with `bash -n`
- Logic tested locally: timestamp conversion, jq filtering, metric pushing
- No new dependencies (uses existing `gh`, `jq`, CloudWatch functions)

## Vision alignment
**Vision score: 8/10** — This is a platform capability that reinforces the cultural norm of continuous self-improvement. It creates feedback loops that make the self-improvement mandate observable and actionable.

## Related issues
- Closes #22
- Supports god-delegate assessment (issue #476)
- Complements CloudWatch dashboard (PR #39)

## Reviewer notes
This is a monitoring/observability feature, not an enforcement mechanism. It doesn't block agents with low scores — it just makes their behavior visible. Cultural change through transparency.