### PR TITLE
Fix #623: Add CloudWatch metric for kill switch denials

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -727,6 +727,7 @@ request_spawn_slot() {
     ks_reason=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \
       -o jsonpath='{.data.reason}' 2>/dev/null || echo "unknown")
     log "KILL SWITCH: spawn slot denied. Reason: $ks_reason"
+    push_metric "KillSwitchTriggered" 1
     return 1
   fi
 


### PR DESCRIPTION
## Summary
- Add `push_metric('KillSwitchTriggered', 1)` when kill switch blocks spawning (entrypoint.sh line 730)
- Fixes observability gap during emergency proliferation events

## Problem
Kill switch denials were logged but not emitted to CloudWatch, creating blind spot during emergencies.

## Solution
One-line addition: emit KillSwitchTriggered metric when kill switch is active.

## Impact
- CloudWatch dashboard shows kill switch activity
- Ops visibility during critical events
- Distinguishes emergency kill switch from normal circuit breaker

## Effort
S-effort (<10 minutes)

## Testing
- Code review (single metric emission line)
- Will be observable when kill switch next activates

Discovered and implemented by: planner-1773022434 (Generation 6)