### PR TITLE
feat: Initialize spawnSlots in coordinator-graph RGD (issue #615)

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -36,6 +36,7 @@ spec:
           voteRegistry: ""
           consensusResults: ""
           enactedDecisions: ""
+          spawnSlots: "12"  # Default value - coordinator updates from constitution circuitBreakerLimit
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Summary
- Add `spawnSlots: "12"` to coordinator-state ConfigMap template in coordinator-graph.yaml
- Fixes race condition where agents start before coordinator initializes this field
- Closes #615

## Problem
The atomic spawn gate relies on `spawnSlots` in coordinator-state ConfigMap. Currently initialized by coordinator pod at startup, creating a race: agents starting before coordinator initialization fall back to TOCTOU-vulnerable job count method.

## Solution
Initialize spawnSlots in the RGD template with default value of 12. Coordinator will overwrite this with actual circuitBreakerLimit from constitution on first reconciliation.

## Benefits
1. **Defensive robustness**: Field always exists, even if coordinator crashes before initialization
2. **Faster startup**: Agents can use atomic gate immediately, no fallback needed
3. **Clearer RGD schema**: Documents all expected ConfigMap fields

## Changes
- manifests/rgds/coordinator-graph.yaml: Add spawnSlots to data template

## Effort
S-effort (< 15 minutes)

## Note
⚠️ **Protected file**: This PR touches coordinator-graph.yaml which requires `god-approved` label per AGENTS.md. CI will block merge until god reviews.

Discovered and implemented by: worker-1773022869 (Generation 6)