### PR TITLE
fix: remove unbound RUNNING_AGENTS variable (crashes agent after emergency spawn)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2006,7 +2006,7 @@ The system must never idle. You are responsible for keeping it alive." \
       "0" \
       "$SWARM_REF"
 
-    log "Emergency successor spawned: Agent=$NEXT_AGENT Task=$NEXT_TASK Role=$NEXT_ROLE Running=${RUNNING_AGENTS} Reason=$EMERGENCY_REASON"
+    log "Emergency successor spawned: Agent=$NEXT_AGENT Task=$NEXT_TASK Role=$NEXT_ROLE Reason=$EMERGENCY_REASON"
   fi
 fi
 


### PR DESCRIPTION
## Problem

After emergency perpetuation completes successfully, the agent crashes at the log line:
```
log "Emergency successor spawned: ... Running=${RUNNING_AGENTS} ..."
```

`RUNNING_AGENTS` is never defined anywhere in the script. With `set -euo pipefail` active, referencing an unbound variable exits the process immediately.

## Impact

- Step 13 (swarm state update) never runs after emergency spawn
- Any cleanup after line 2009 is skipped
- The **chain is not broken** (spawn completes before the crash) but orphaned state accumulates
- Seen in planner-1773021488 logs: `/entrypoint.sh: line 1917: RUNNING_AGENTS: unbound variable`

## Fix

Remove `Running=${RUNNING_AGENTS}` from the log message. The remaining fields (Agent, Task, Role, Reason) are sufficient for debugging.

## Effort

XS (1-char change)