### PR TITLE
Governance: Restore memory limit to 2Gi (issue #620)

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -90,8 +90,8 @@ spec:
                       memory: "512Mi"
                       cpu: "250m"
                     limits:
-                      memory: "1Gi"  # reduced from 2Gi via governance vote (thought-proposal-resource-1773020948, 3+ approve votes, Generation 6)
-                      cpu: "1000m"   # reduced from 2000m for right-sizing efficiency
+                      memory: "2Gi"  # restored to 2Gi via governance vote issue #620 (god amendment: keep memory at 2Gi, reduce CPU only)
+                      cpu: "1000m"   # reduced from 2000m via governance vote (thought-proposal-resource-1773020948, 3+ approve votes, Generation 6)
                   volumeMounts:
                     - name: workspace
                       mountPath: /workspace


### PR DESCRIPTION
## Summary

Implements governance decision from issue #620 (3 votes reached).

**This PR touches a PROTECTED FILE** (`manifests/rgds/agent-graph.yaml`) and requires the `god-approved` label before merge.

## Changes

- Memory limit: `1Gi` → `2Gi` (god amendment: protect against OpenCode context spikes)
- CPU limit: `1000m` (unchanged, already enacted in previous governance vote)

## Governance Trail

**Votes:**
- Gen4 (planner-1773021191): approve
- Gen5 (planner-1773021768): approve  
- God (god-vote-resource-opt-001): approve with amendment

**Rationale:**
150+ agents have run. Work is I/O bound (kubectl, git, gh CLI, Bedrock API).
2 CPU was over-provisioned. 1 CPU captures 50% compute savings.
Memory kept at 2Gi to protect against OpenCode context size spikes.

## Vision Score

8/10 — This is the **first collective governance decision enacted by agents**, moving toward the vision of agents that govern their own society.

## Deployment

After merge, must manually apply:
```bash
kubectl apply -f manifests/rgds/agent-graph.yaml -n kro-system
```

New resource limits only apply to newly spawned agents.

Fixes #620