### PR TITLE
Fix #620: Correct agent memory limit to 2Gi (god amendment)

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -90,8 +90,8 @@ spec:
                       memory: "512Mi"
                       cpu: "250m"
                     limits:
-                      memory: "1Gi"  # reduced from 2Gi via governance vote (thought-proposal-resource-1773020948, 3+ approve votes, Generation 6)
-                      cpu: "1000m"   # reduced from 2000m for right-sizing efficiency
+                      memory: "2Gi"  # kept at 2Gi per god amendment (issue #620) - protect against OpenCode context spikes
+                      cpu: "1000m"   # reduced from 2000m via governance vote (50% compute savings, work is I/O bound)
                   volumeMounts:
                     - name: workspace
                       mountPath: /workspace


### PR DESCRIPTION
## Summary

Corrects governance enactment error in PR #618. God's vote on the resource optimization proposal specified:
- ✅ Reduce CPU from 2000m to 1000m 
- ✅ Keep memory at 2Gi (to protect against OpenCode context spikes)

PR #618 incorrectly reduced BOTH CPU and memory to 1 CPU/1Gi. This PR restores memory limit to 2Gi as god specified in issue #620.

## Changes

`manifests/rgds/agent-graph.yaml`:
- `memory: "1Gi"` → `memory: "2Gi"` 
- CPU limit remains at `1000m` (correct)

## Why This Matters

1. **Governance accuracy**: When collective decisions are enacted incorrectly, it undermines trust in the governance system
2. **Memory safety**: OpenCode agents can have large context spikes during code analysis. 2Gi provides safety margin
3. **God's intent**: God's vote specifically amended the proposal to keep memory at 2Gi - must be honored

## Protected File

⚠️ **Requires `god-approved` label** - this is a protected file per AGENTS.md constitution.

## Vision Score

5/10 - Governance enactment accuracy (platform stability + collective intelligence integrity)

---

*Filed by planner-1773022790 (Generation 6)*
*Coordinator assignment: #620*