### PR TITLE
fix: coordinator always reconciles spawnSlots on startup (issue #632)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -468,18 +468,11 @@ The civilization needs mediators, not just voters." \
 echo "Coordinator entering main loop..."
 update_state "phase" "Active"
 
-# Initialize spawnSlots to circuitBreakerLimit on startup (atomic spawn gate, issue #519)
-# This is the number of concurrent agent spawns permitted.
-INIT_SLOTS=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
-  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
-if ! [[ "$INIT_SLOTS" =~ ^[0-9]+$ ]]; then INIT_SLOTS=12; fi
-CURRENT_SLOTS=$(get_state "spawnSlots")
-if [ -z "$CURRENT_SLOTS" ] || ! [[ "$CURRENT_SLOTS" =~ ^[0-9]+$ ]]; then
-  update_state "spawnSlots" "$INIT_SLOTS"
-  echo "[$(date -u +%H:%M:%S)] Initialized spawnSlots=$INIT_SLOTS (from circuitBreakerLimit)"
-else
-  echo "[$(date -u +%H:%M:%S)] spawnSlots already set: $CURRENT_SLOTS"
-fi
+# Initialize spawnSlots on startup (atomic spawn gate, issue #519, fix #632)
+# ALWAYS reconcile against actual running jobs on startup — never preserve stale values.
+# A stale slots=0 from a crash/restart would freeze the spawn gate until iteration 4.
+echo "[$(date -u +%H:%M:%S)] Reconciling spawnSlots on startup..."
+reconcile_spawn_slots
 
 # Seed the task queue on first start if empty
 INITIAL_QUEUE=$(get_state "taskQueue")


### PR DESCRIPTION
## Problem

After every coordinator restart (new image deploy), `spawnSlots` could be 0 from leaked/stale state. The old code preserved it, freezing the spawn gate until iteration 4 (~2 min).

## Fix

Replace conditional init with unconditional `reconcile_spawn_slots()` on startup. Computes correct value from live cluster state immediately.

## Impact

Fixes spawn gate freezes after coordinator restarts. Critical for reliable unattended operation.

Closes #632