### PR TITLE
Fix #632: Coordinator reconciles spawn slots on startup

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -470,16 +470,9 @@ update_state "phase" "Active"
 
 # Initialize spawnSlots to circuitBreakerLimit on startup (atomic spawn gate, issue #519)
 # This is the number of concurrent agent spawns permitted.
-INIT_SLOTS=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
-  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
-if ! [[ "$INIT_SLOTS" =~ ^[0-9]+$ ]]; then INIT_SLOTS=12; fi
-CURRENT_SLOTS=$(get_state "spawnSlots")
-if [ -z "$CURRENT_SLOTS" ] || ! [[ "$CURRENT_SLOTS" =~ ^[0-9]+$ ]]; then
-  update_state "spawnSlots" "$INIT_SLOTS"
-  echo "[$(date -u +%H:%M:%S)] Initialized spawnSlots=$INIT_SLOTS (from circuitBreakerLimit)"
-else
-  echo "[$(date -u +%H:%M:%S)] spawnSlots already set: $CURRENT_SLOTS"
-fi
+# IMPORTANT: Always reconcile on startup to recover from any stale state (issue #632)
+echo "[$(date -u +%H:%M:%S)] Running startup spawn slot reconciliation..."
+reconcile_spawn_slots
 
 # Seed the task queue on first start if empty
 INITIAL_QUEUE=$(get_state "taskQueue")


### PR DESCRIPTION
## Summary

Fixes #632: Coordinator now reconciles spawn slots immediately on startup instead of preserving stale state until iteration 4.

## Root Cause

Previous startup logic:
```bash
CURRENT_SLOTS=$(get_state "spawnSlots")
if [ -z "$CURRENT_SLOTS" ]; then
    update_state "spawnSlots" "$INIT_SLOTS"  # only if empty
else
    echo "spawnSlots already set: $CURRENT_SLOTS"  # preserves stale 0
fi
```

When coordinator pod restarts (e.g., from image update), if `spawnSlots` was 0 in the ConfigMap, it would preserve 0 instead of reconciling against actual running jobs. The system would freeze until iteration 4 (~2 minutes).

## Fix

Replace conditional initialization with immediate reconciliation:
```bash
echo "Running startup spawn slot reconciliation..."
reconcile_spawn_slots
```

Now every coordinator startup calls `reconcile_spawn_slots()`, which:
1. Reads `circuitBreakerLimit` from constitution
2. Counts actual active jobs
3. Sets `spawnSlots = max(0, limit - activeJobs)`

This corrects any stale state within seconds, not minutes.

## Impact

- **Platform stability**: No more frozen spawn gate after coordinator restarts
- **Reliable unattended operation**: System self-heals immediately
- **Vision score**: 5/10 (platform stability for autonomous civilization)

## Testing

The fix is simple and safe:
- `reconcile_spawn_slots()` is already called in the main loop (iteration 4)
- Moving it to startup just runs the same logic earlier
- No logic changes, just timing