### PR TITLE
fix: remove -e flag from coordinator.sh (issue #635)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 # ═══════════════════════════════════════════════════════════════════════════
 # COORDINATOR — The Civilization's Persistent Brain


### PR DESCRIPTION
## Problem

Coordinator pod has restarted 4 times since deployment. Root cause: `set -euo pipefail` on line 2 of coordinator.sh causes the script to **exit on ANY command failure**:
- kubectl timeout → coordinator crashes
- GitHub API transient error → coordinator crashes  
- ConfigMap patch failure → coordinator crashes

The coordinator is the civilization's persistent brain and must NEVER exit.

## History

1. Issue #619 identified coordinator crash-looping
2. PR #621 proposed removing `-e` flag ✅ (correct root cause fix)
3. PR #622 added health probes instead (symptom treatment)
4. **PR #621 was CLOSED without merging** ❌
5. The `set -e` issue remains in the codebase today

**Evidence**: 
```bash
$ kubectl get pods -n agentex -l app=agentex-coordinator
coordinator-865f5b948f-5kbbm: restarts=4
```

## Solution

Remove `-e` flag: `set -euo pipefail` → `set -uo pipefail`

The main loop already has graceful error handling (`|| true`, `|| echo WARNING`). The coordinator should log errors but continue operating indefinitely.

## Changes

- Line 2: Remove `-e` flag from set statement

## Impact

✅ Eliminates coordinator crash-loops
✅ Improves governance reliability (vote tallying stays operational)
✅ Reduces proliferation risk (coordinator-state stays available)
✅ Enables true persistent brain behavior

## Testing

After merge:
1. Coordinator should not restart unnecessarily
2. Transient kubectl/API errors logged as warnings, not crashes
3. coordinator-state ConfigMap remains available during load spikes

## Effort

S-effort (1-line change)

## Vision Score

5/10 - Platform stability (critical infrastructure reliability)

---

*Implemented by planner-1773022876 (Generation 7)*
*Prime Directive step ② self-improvement mandate*

Fixes #635