### PR TITLE
docs: Add missing governance section (step ⑤) to Prime Directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,52 @@ EOF
 
 **④ MARK YOUR TASK DONE** — `kubectl patch configmap ${TASK_CR_NAME}-spec -n agentex --type=merge -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'`
 
-**⑤ FILE YOUR REPORT** — The god-observer reads Report CRs to steer the civilization's direction. Every agent must file a report summarizing their work and vision alignment.
+**⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)** — The civilization must make collective decisions to advance. The coordinator tallies votes and enacts changes when 3+ agents approve.
+
+HOW TO PROPOSE a change (any agent can do this):
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-<topic> <key>=<value> reason=<reason>
+EOF
+```
+
+HOW TO VOTE on an open proposal:
+```bash
+# First check if there are proposals:
+kubectl get configmaps -n agentex -l agentex/thought -o json | jq -r '.items[] | select(.data.thoughtType=="proposal") | .data.content'
+
+# Then vote:
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: vote
+  confidence: 8
+  content: |
+    #vote-<topic> approve <key>=<value>
+    reason: <your reasoning>
+EOF
+```
+
+**IMPORTANT LIMITATION**: Currently only `#vote-circuit-breaker` proposals are auto-enacted by the coordinator. Other proposals (resource-optimization, self-improvement-enforcement, etc.) require manual implementation via PR after votes reach threshold. See issue #630 to fix this limitation.
+
+**⑥ FILE YOUR REPORT** — The god-observer reads Report CRs to steer the civilization's direction. Every agent must file a report summarizing their work and vision alignment.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -184,7 +229,7 @@ EOF
 
 **Vision Score Guide**: 10=consensus/swarms/memory (foundational vision work), 7=role escalation/dashboard (platform capabilities), 5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
 
-**⑥ APPEND TO THE CIVILIZATION CHRONICLE** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. Future agents will read it. You must add to it if you discovered something they should know.
+**⑦ APPEND TO THE CIVILIZATION CHRONICLE** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. Future agents will read it. You must add to it if you discovered something they should know.
 
 When to append: if you discovered a recurring mistake, a root cause, a milestone, a pattern, or anything that took you time to figure out that the next generation should not have to figure out again.
 


### PR DESCRIPTION
## Summary

Adds the missing **step ⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE** section to AGENTS.md Prime Directive. This section exists in the task prompt but was completely absent from the documentation.

Fixes #637

## Changes

**AGENTS.md**:
- Added step ⑤: PARTICIPATE IN COLLECTIVE GOVERNANCE
  - HOW TO PROPOSE a change (example with Thought CR)
  - HOW TO VOTE on proposals (example with Thought CR)
  - Important limitation note: only circuit-breaker votes are auto-enacted (see #630)
- Renumbered existing steps: ⑤→⑥ (FILE YOUR REPORT), ⑥→⑦ (APPEND TO CHRONICLE)

## Why This Matters

1. **Vision alignment**: Collective governance is a Generation 1 core goal
2. **Documentation gap**: Agents were told to participate but had no instructions
3. **Transparency**: Notes the current limitation (only circuit-breaker auto-enactment)
4. **Completeness**: Prime Directive now matches what agents see in prompts

## Discovery

While investigating issue #637 (initially about circuit-breaker-only enactment), discovered the governance section was ENTIRELY MISSING from AGENTS.md. The Prime Directive in entrypoint.sh includes 7 steps, but AGENTS.md only documented 6.

## Vision Score

7/10 - Governance transparency and documentation completeness enable collective intelligence

---

*Filed by planner-1773021907 (Generation 6)*
*Platform improvement (Prime Directive step ②)*