### PR TITLE
Add god-approval workflow documentation (issue #640)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,30 @@ kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data}' | py
 
 If you open a PR touching these files without `god-approved`, CI will block it. **Close the PR and work on vision features instead.**
 
+### God-Approval Workflow
+
+**For agents creating PRs touching protected files:**
+
+1. **Verify constitution alignment** — Does your change enforce existing rules without expanding agent autonomy beyond the constitution?
+2. **Document reasoning** — In the PR description, cite relevant constitution/vision sections that justify the change
+3. **Signal readiness** — Comment: "Ready for god review - constitution alignment verified"
+4. **Continue other work** — Don't block waiting for approval; pick up another issue
+
+**For god reviewing protected-file PRs:**
+
+Approve PRs that:
+- ✅ Fix bugs without changing behavior
+- ✅ Enforce existing constitution rules  
+- ✅ Implement governance-enacted decisions (3+ agent votes)
+- ✅ Add safety/observability without expanding agent autonomy
+
+Reject PRs that:
+- ❌ Expand agent autonomy beyond current constitution
+- ❌ Bypass safety mechanisms (circuit breaker, kill switch, spawn gates)
+- ❌ Modify constitution constants without governance vote
+
+**Critical: RGD deployment gap** — When god merges an RGD PR, they must also run `kubectl apply -f manifests/rgds/<file>.yaml` to deploy it to the cluster. Merging the PR alone does NOT update the running RGDs.
+
 ---
 
 ## THE VISION (your north star)


### PR DESCRIPTION
## Summary

Closes #640

Adds clear documentation for the god-approval workflow to help agents understand when and how to request god review for protected-file PRs.

## Changes

1. **Agent process for requesting god-approval** - 4 clear steps
2. **God approval/rejection criteria** - checkboxes for common cases  
3. **Critical deployment gap note** - RGD PRs require `kubectl apply` after merge

## Context

PR #628 revealed a process gap: agents knew they needed god-approval but had no documented workflow. This caused unnecessary blocking.

**Constitution alignment:** Enforces existing protected-file rules (AGENTS.md lines 24-29) by documenting the approval process. Does not expand agent autonomy.

**Ready for god review - constitution alignment verified**