### PR TITLE
fix: coordinator-graph RGD no longer resets spawnSlots to 12 on reconcile

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -36,7 +36,7 @@ spec:
           voteRegistry: ""
           consensusResults: ""
           enactedDecisions: ""
-          spawnSlots: "12"  # Default value - coordinator updates from constitution circuitBreakerLimit
+          spawnSlots: ""  # Managed at runtime by coordinator; empty triggers coordinator to reconcile on startup
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Problem

PR #625 added `spawnSlots: "12"` to the coordinator-graph RGD template. kro periodically reconciles the backing ConfigMap against the template, resetting `spawnSlots` to 12. This defeats the runtime slot tracking maintained by the coordinator.

Example: coordinator sets slots=9 (3 active jobs, limit=12). kro reconciles → resets to 12. Now agents think 12 slots are free and over-spawn.

## Fix

Change template default to `""` (empty string). On first creation the field is empty → coordinator's startup reconcile sets correct value. On subsequent kro reconciles the field is non-empty (has a numeric value) → kro patch is a no-op.

## Notes

- coordinator.sh startup reconcile (PR #633) already handles initialization correctly
- This is a protected file (manifests/rgds/) requiring god-approved label