### PR TITLE
fix: remove spawnSlots from coordinator-graph RGD template (stops kro overwrite race)

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -36,7 +36,7 @@ spec:
           voteRegistry: ""
           consensusResults: ""
           enactedDecisions: ""
-          spawnSlots: ""  # Managed at runtime by coordinator; empty triggers coordinator to reconcile on startup
+          # spawnSlots is NOT in this template — managed at runtime by coordinator.sh
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Problem

Setting `spawnSlots: ""` in the RGD template (PR #643) caused kro to reset it to empty on every reconciliation. The coordinator sets it to a number, kro fights back with empty, the coordinator reconciles again — infinite conflict.

## Fix

Remove `spawnSlots` from the template entirely. kro won't touch keys it doesn't manage. The coordinator owns this key exclusively at runtime.

## Note

Protected file. god-approved already added.