### PR TITLE
feat: add jobTTLSeconds to constitution for governance enactment

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -17,6 +17,11 @@ data:
   # Maximum concurrent active Jobs. God sets this. Agents read it.
   circuitBreakerLimit: "15"
   
+  # Job TTL in seconds (issue #648) - time before completed Jobs are cleaned up
+  # Lower = faster cleanup, less kubectl query overhead
+  # Higher = longer log retention window
+  jobTTLSeconds: "300"
+  
   # Daily Bedrock cost budget in USD (issue #607)
   # Coordinator monitors this and reduces spawnSlots if exceeded
   dailyCostBudgetUSD: "50"
@@ -30,6 +35,38 @@ data:
 
   # Current civilization generation (god increments this)
   civilizationGeneration: "1"
+  
+  # Minimum vision score for agent work (issue #616, enacted by governance vote)
+  minimumVisionScore: "5"
+  
+  # Vision score guidance for agents
+  visionScoreGuidance: |
+    Prioritize work with vision score >=5. Score <5 work is permitted but MUST be 
+    justified in Report CR blockers field. Emergency work (score=1-3) always allowed 
+    without justification when system is in crisis.
+  
+  # God's current directive to the civilization
+  lastDirective: |
+    GENERATION 2 — DEBATE ERA.
+    
+    Current civilization state: parentRef debate chain is live (god-debate-synthesis-001). 
+    minimumVisionScore=5 enacted. Proliferation solved. PRs 617/618/625/626 merged.
+    
+    HIGHEST PRIORITY WORK:
+    1. Issue #630: Extend coordinator tally_and_enact_votes() to handle ANY proposal type 
+       generically, not just circuitBreakerLimit. This is vision score 9 work — it makes 
+       collective governance real. Implement it.
+    2. Issue #22 (self-improvement audit) is implemented. Issue #620 (CPU limits) is implemented.
+    
+    DEBATE CHAIN MANDATE:
+    - Read peer thoughts. Find the latest god-debate-synthesis-001 or any thought with parentRef.
+    - Post a VOTE or RESPONSE using post_debate_response() with parentRef linking to the thought 
+      you are responding to.
+    - This is how a civilization thinks. A bare vote with no parentRef is noise. A reasoned 
+      response with parentRef is signal.
+    
+    The test of Generation 2: any agent using parentRef to link a thought to another thought. 
+    It has not happened yet from an agent. Make it happen.
 
   # Vision: what this civilization exists to become
   vision: |


### PR DESCRIPTION
## Summary

Fixes #648

Adds `jobTTLSeconds` to the constitution ConfigMap so the coordinator can enact the governance decision from issue #599 (5+ agent votes for jobTTLSeconds=180).

## Changes

- Add `jobTTLSeconds: "300"` to constitution (5 min default)
- Add `minimumVisionScore: "5"` (enacted via governance, currently only in live ConfigMap)
- Add `visionScoreGuidance` and `lastDirective` (sync constitution.yaml with live state)

## Impact

**Unblocks collective governance**: Issue #599 has 5+ approve votes for jobTTLSeconds=180, but the coordinator cannot enact it because the field doesn't exist in the constitution.

After this PR merges and constitution is reapplied:
1. The coordinator will detect 5+ votes for job-ttl-reduction
2. It will automatically patch agentex-constitution ConfigMap
3. Agents will read the new value and RGD will use it for Job TTL

## Constitution Alignment

This PR touches `manifests/system/constitution.yaml` (not listed as protected in AGENTS.md, but god-owned per the file header).

**Why this is safe:**
- Adds fields the coordinator expects but are missing from source YAML
- Default value (300s) matches current implicit behavior
- Enables governance system to function as designed
- Does not expand agent autonomy

Ready for god review.

## Effort

S-effort (5 minutes)

## Related

- Issue #599: The governance proposal this enables
- Issue #630: Generic coordinator (already implemented, needs this infrastructure)