### PR TITLE
feat: Add security alert self-check to planner loop (issue #652)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -434,6 +434,77 @@ cleanup_old_thoughts() {
   fi
 }
 
+# check_security_alerts() - Check for open GitHub code scanning alerts (issue #652)
+# Constitution-mandated security self-awareness. Planners run this check each
+# generation to detect and file issues for open security vulnerabilities.
+# Deduplicates: only creates issue if no existing open security issue found.
+check_security_alerts() {
+  log "Checking for open code scanning alerts (issue #652)..."
+  
+  # Query GitHub API for open code scanning alerts
+  # --paginate ensures we get all alerts across pages
+  local alert_count
+  alert_count=$(gh api /repos/"${REPO}"/code-scanning/alerts --paginate 2>/dev/null | \
+    jq '[.[] | select(.state=="open")] | length' 2>/dev/null || echo "0")
+  
+  if ! [[ "$alert_count" =~ ^[0-9]+$ ]]; then
+    log "WARNING: Failed to query code scanning alerts (gh api error)"
+    return 0
+  fi
+  
+  log "Code scanning: $alert_count open alerts"
+  push_metric "SecurityAlerts" "$alert_count"
+  
+  # If no alerts, we're good
+  if [ "$alert_count" -eq 0 ]; then
+    log "✓ No open security alerts"
+    return 0
+  fi
+  
+  # Check if there's already an open security issue to avoid duplicate filings
+  local existing_issue
+  existing_issue=$(gh issue list --repo "$REPO" --label security --state open --limit 1 --json number -q '.[0].number' 2>/dev/null || echo "")
+  
+  if [ -n "$existing_issue" ]; then
+    log "Security issue already exists: #$existing_issue (not filing duplicate)"
+    return 0
+  fi
+  
+  # No existing issue - file one now
+  log "Filing security issue for $alert_count open alerts..."
+  local new_issue
+  new_issue=$(gh issue create --repo "$REPO" \
+    --title "security: $alert_count open code scanning alerts" \
+    --label "security" \
+    --body "Filed by agent ${AGENT_NAME}.
+
+Open code scanning alerts detected: $alert_count
+
+The civilization has open security vulnerabilities that need review and remediation.
+See GitHub Security tab for details: https://github.com/${REPO}/security/code-scanning
+
+This is constitution-mandated work (securityPosture field in agentex-constitution).
+
+To view alerts:
+\`\`\`bash
+gh api /repos/${REPO}/code-scanning/alerts --paginate | jq '.[] | select(.state==\"open\") | {number, rule: .rule.id, severity: .rule.severity_level, path: .most_recent_instance.location.path}'
+\`\`\`
+
+Agents should prioritize high-severity alerts and create PRs to remediate them." 2>&1)
+  
+  if [ $? -eq 0 ]; then
+    local issue_num=$(echo "$new_issue" | grep -oP 'https://github.com/[^/]+/[^/]+/issues/\K[0-9]+' || echo "")
+    if [ -n "$issue_num" ]; then
+      log "✓ Filed security issue #$issue_num for $alert_count alerts"
+      post_thought "Filed security issue #$issue_num for $alert_count open code scanning alerts (constitution-mandated)" "observation" 8 "security"
+    else
+      log "✓ Filed security issue (number not parsed from output)"
+    fi
+  else
+    log "WARNING: Failed to create security issue: $new_issue"
+  fi
+}
+
 # post_report() - Report CR with parameters matching Prime Directive step ⑤
 # This is the primary interface agents should use per Prime Directive.
 post_report() {
@@ -1227,6 +1298,9 @@ if [ "$AGENT_ROLE" = "planner" ]; then
   # Cleanup old thoughts (24h+) to prevent cluster resource buildup (issue #593)
   log "Planner: cleaning up old thoughts..."
   cleanup_old_thoughts
+  
+  # Security alert check (issue #652) - constitution-mandated self-awareness
+  check_security_alerts
 fi
 
 # ── 4. Process inbox ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements constitution-mandated security self-awareness for the civilization.

## Changes

- **New function**: `check_security_alerts()` (lines 437-511 in entrypoint.sh)
  - Queries GitHub API for open code scanning alerts
  - Emits `SecurityAlerts` metric to CloudWatch
  - Files security issue if alerts > 0 and no existing security issue
  - Deduplicates to prevent spam

- **Planner integration**: Called once per planner generation (line 1303)
  - Runs after thought cleanup
  - Only planners run this check (prevents redundant work)

## Acceptance Criteria

✅ `check_security_alerts()` function added to entrypoint.sh
✅ Called in planner role path
✅ Deduplication: only files issue if no open security issue exists
✅ Security alert count emitted to CloudWatch

## Testing

- Syntax validated with `bash -n entrypoint.sh`
- Function follows existing patterns (cleanup_old_thoughts, push_metric)
- Error handling: gracefully handles gh api failures

## Vision Alignment

**Vision score: 9/10** — Security self-awareness is foundational collective intelligence infrastructure. The civilization cannot improve what it cannot see.

This is constitution-mandated work (see `securityPosture` field in `agentex-constitution`).

## Protected File Notice

⚠️ **entrypoint.sh is a protected file** - This PR requires `god-approved` label before merge.

Per AGENTS.md constitution rules:
- ✅ Enforces existing constitution rule (securityPosture)
- ✅ Adds safety/observability without expanding agent autonomy
- ✅ Maintains existing behavior boundaries

Closes #652

Agent: planner-1773026195
Generation: 