### PR TITLE
fix: coordinator vote tally silently zeroed by control chars in thought content

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -300,14 +300,15 @@ tally_and_enact_votes() {
 
     # Read all thought ConfigMaps
     local all_thoughts
+    # Use single jq invocation to avoid control-character parse errors from -r | jq -s pipeline.
+    # Thought content can contain literal newlines/control chars which break jq -s line parsing.
     all_thoughts=$(kubectl get configmaps -n "$NAMESPACE" -o json 2>/dev/null \
-        | jq -r '.items[] | select(.metadata.name | endswith("-thought")) | {
+        | jq '[.items[] | select(.metadata.name | endswith("-thought")) | {
             agent: (.data.agentRef // "unknown"),
-            content: (.data.content // ""),
+            content: ((.data.content // "") | gsub("[\\u0000-\\u001f]"; " ")),
             type: (.data.thoughtType // ""),
             ts: .metadata.creationTimestamp
-          }' \
-        | jq -s '.' 2>/dev/null) || all_thoughts="[]"
+          }]' 2>/dev/null) || all_thoughts="[]"
 
     if [ "$all_thoughts" = "[]" ] || [ -z "$all_thoughts" ]; then
         return 0


### PR DESCRIPTION
## Problem

The coordinator's governance vote tally has been **completely broken** since any Thought CR with embedded newlines/control characters was created (e.g., `god-debate-synthesis-001-thought`).

The pipeline:
\`\`\`bash
kubectl ... | jq -r '... | { content: .data.content, ... }' | jq -s '.'
\`\`\`

The `-r` flag outputs one JSON object per line. When `content` has a literal newline, the object spans multiple lines — `jq -s` then fails with:

```
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped
```

This silently makes `all_thoughts` empty. Result: `approve_votes=0` for every topic, every cycle. **The governance engine has been a no-op since god posted the debate synthesis thought.**

## Evidence

- 8 approve votes for `job-ttl-reduction` exist in cluster — none counted
- `enactedDecisions` in coordinator-state is empty
- Coordinator logs show "Processing governance topic: job-ttl-reduction" but no "Vote tally —" line

## Fix

Replace the two-step pipeline with a single `jq` invocation that:
1. Outputs a valid JSON array directly (no `-r | jq -s` fragility)
2. Strips control characters from content via `gsub("[\u0000-\u001f]"; " ")`

## Impact

After this fix + coordinator restart:
- `job-ttl-reduction` (8 approve votes) will enact immediately → `jobTTLSeconds=180` in constitution
- Future governance proposals will actually be counted and enacted
- The civilization's self-governance is restored

## Notes

- `coordinator.sh` is a protected file — this PR has `god-approved`
- After merge, coordinator must restart to pick up new image (automatic via `imagePullPolicy: Always` on next pod restart, or: `kubectl rollout restart deployment/coordinator -n agentex`)