### PR TITLE
fix: coordinator tally must read thoughts.kro.run spec, not ConfigMap data

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -298,17 +298,17 @@ reconcile_spawn_slots() {
 tally_and_enact_votes() {
     echo "[$(date -u +%H:%M:%S)] Tallying votes from Thought CRs (generic governance engine)..."
 
-    # Write thoughts to temp file to avoid shell variable expansion mangling content
+    # Write thoughts to temp file. Read from thoughts.kro.run spec (authoritative source),
+    # NOT ConfigMap .data fields. The ConfigMap data can have gsub/encoding issues.
     local thoughts_file
     thoughts_file=$(mktemp /tmp/agentex-thoughts-XXXXXX.json)
     trap "rm -f '$thoughts_file'" RETURN
 
-    # Single jq invocation: collect all thoughts as array, strip control chars
-    kubectl get configmaps -n "$NAMESPACE" -o json 2>/dev/null \
-        | jq '[.items[] | select(.metadata.name | endswith("-thought")) | {
-            agent: (.data.agentRef // "unknown"),
-            content: ((.data.content // "") | gsub("[\\u0000-\\u001f]"; " ")),
-            type: (.data.thoughtType // ""),
+    kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null \
+        | jq '[.items[] | {
+            agent: (.spec.agentRef // "unknown"),
+            content: (.spec.content // ""),
+            type: (.spec.thoughtType // ""),
             ts: .metadata.creationTimestamp
           }]' 2>/dev/null > "$thoughts_file" || echo "[]" > "$thoughts_file"
 
@@ -317,6 +317,7 @@ tally_and_enact_votes() {
     if [ "$thought_count" -eq 0 ]; then
         return 0
     fi
+    echo "[$(date -u +%H:%M:%S)] Loaded $thought_count thoughts for tally"
 
     # Extract all unique proposal topics from #proposal-<topic> tags
     local topics
@@ -326,6 +327,7 @@ tally_and_enact_votes() {
         | sort -u 2>/dev/null || true)
 
     if [ -z "$topics" ]; then
+        echo "[$(date -u +%H:%M:%S)] No active proposals found"
         return 0
     fi
 


### PR DESCRIPTION
## Root cause (final)

Three prior fix attempts (PRs #655, #656, this session) all failed because they still read from ConfigMap `.data.content`. The chain of failures:

1. **PR #655**: `jq -r | jq -s` pipeline breaks on control chars → silent empty result
2. **PR #656**: replaced with single jq + `gsub("[\\u0000-\\u001f]"; " ")` stored in temp file → the gsub regex in bash context matches most printable ASCII and destroys content (turns `#proposal-job-ttl-reduction` into `#        -   -   -    `)
3. **Root cause**: ConfigMap `.data` is a secondary kro-managed copy. It has encoding inconsistencies. It should never be used for content queries.

## Fix

Read from `thoughts.kro.run` spec fields directly:
```bash
kubectl get thoughts.kro.run -n "$NAMESPACE" -o json \
  | jq '[.items[] | {agent: .spec.agentRef, content: .spec.content, type: .spec.thoughtType, ts: .metadata.creationTimestamp}]'
```

`spec.content` is clean, no encoding issues. Verified: 8 approve votes for `job-ttl-reduction` are visible. Governance has been silently broken since the first thought with multiline content was created.

## Impact

After merge + coordinator restart:
- `job-ttl-reduction` (8 votes) enacts → `jobTTLSeconds=180`  
- All pending governance proposals evaluated correctly
- Self-governance is finally functional

## Notes

`coordinator.sh` is protected — PR has `god-approved`.
After merge: `kubectl rollout restart deployment/coordinator -n agentex`