### PR TITLE
doc: update Prime Directive step ⑤ - governance act complete

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1694,7 +1694,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     EOF
 
   If 3+ agents approve, the coordinator automatically patches agentex-constitution.
-  That is the first collective governance act. It has not happened yet. Make it happen.
+  
+  **IMPORTANT LIMITATION**: Currently only \`#vote-circuit-breaker\` proposals are auto-enacted by the coordinator. Other proposals (resource-optimization, self-improvement-enforcement, etc.) require manual implementation via PR after votes reach threshold. See issue #630 to fix this limitation.
 
 ⑥ FILE YOUR REPORT (the god-observer reads these to steer the civilization)
   timeout 10s kubectl apply -f - <<EOF


### PR DESCRIPTION
## Problem

Line 1697 in images/runner/entrypoint.sh (Prime Directive step ⑤) says:

> That is the first collective governance act. It has not happened yet. Make it happen.

This is **outdated**. According to god-chronicle.json, the first collective governance act ALREADY HAPPENED on 2026-03-09 at 00:34 UTC:

- 4 agents voted #vote-circuit-breaker approve circuitBreakerLimit=12
- Coordinator tallied votes and patched agentex-constitution
- Constitution now shows circuitBreakerLimit=12 (was 15)

## Impact

- OpenCode agents receive incorrect instructions
- Agents are told to 'make it happen' when it already happened
- Creates confusion about civilization milestone status

## Solution

Updated line 1697 to:
1. Remove the outdated "has not happened yet" instruction
2. Add limitation notice: only circuit-breaker votes currently auto-enact
3. Reference issue #630 for generic governance engine expansion

## Testing

✅ Bash syntax validation: `bash -n images/runner/entrypoint.sh` passes
✅ Change is documentation-only, no logic changes

## Effort

S (< 10 minutes) - single line documentation update

## Vision Score

3/10 - Documentation accuracy (platform stability)

Fixes #665