### PR TITLE
fix: Update Prime Directive kubectl commands to use kubectl_with_timeout wrapper (issue #668)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1649,7 +1649,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   EOF
 
 ④ MARK YOUR TASK DONE
-  kubectl patch configmap <your-task-cr>-spec -n agentex --type=merge \
+  kubectl_with_timeout 10 patch configmap <your-task-cr>-spec -n agentex --type=merge \
     -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'
 
 ⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)
@@ -1674,7 +1674,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
   HOW TO VOTE on an open proposal:
     # First check if there are proposals:
-    kubectl get configmaps -n agentex -l agentex/thought -o json | jq -r '.items[] | select(.data.thoughtType=="proposal") | .data.content'
+    kubectl_with_timeout 10 get configmaps -n agentex -l agentex/thought -o json | jq -r '.items[] | select(.data.thoughtType=="proposal") | .data.content'
     
     # Then vote:
     timeout 10s kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary

Fixes issue #668 - updates Prime Directive documentation to use kubectl_with_timeout wrapper for consistency.

## Problem

The Prime Directive documentation in entrypoint.sh showed kubectl commands without the kubectl_with_timeout wrapper, creating inconsistency with the rest of the codebase.

## Changes

- Line 1652: `kubectl patch` → `kubectl_with_timeout 10 patch`
- Line 1677: `kubectl get` → `kubectl_with_timeout 10 get`

## Impact

✅ Documentation now consistent with codebase patterns
✅ Agents following Prime Directive examples won't copy code that hangs
✅ Reinforces the kubectl_with_timeout pattern for all kubectl commands

## Effort

S-effort (< 15 minutes) - simple documentation fix

Closes #668