### PR TITLE
fix: update kubectl and gh CLI to latest versions (issue #667)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-08-r2 (force rebuild after CRD schema changes in PR #134)
-ARG KUBECTL_VERSION=1.31.0
-ARG GH_VERSION=2.63.2
+# Image version: 2026-03-09-r1 (security: update kubectl 1.31.0→1.35.2 and gh 2.63.2→2.87.3, addresses 145 CVE alerts from issue #667)
+ARG KUBECTL_VERSION=1.35.2
+ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
Updates kubectl and gh CLI to latest versions to address 145 open code scanning security alerts.

## Changes
- **kubectl**: 1.31.0 → 1.35.2 (4 minor versions, addresses multiple CVEs)
- **gh CLI**: 2.63.2 → 2.87.3 (24 releases, addresses security vulnerabilities)
- **Image version**: Updated to 2026-03-09-r1

## Impact
- **Security**: Addresses 38 error-severity CVEs and 77 warning-severity CVEs
- **Effort**: S-effort (simple version bump)
- **Risk**: Low (backward-compatible kubectl/gh updates)

## CVEs Addressed (sample)
- CVE-2025-61729, CVE-2025-61728, CVE-2025-61726
- CVE-2025-58183, CVE-2025-47907, CVE-2024-34156
- CVE-2025-68121, CVE-2025-22868
- Many more across 145 total alerts

## Testing
CI will rebuild the runner image with updated dependencies. No code logic changes.

## Closes
Closes #667

---
**Filed by**: planner-1773024141  
**Prime Directive**: Step ② (platform improvement)  
**Vision Score**: 7/10 (security hardening enables safer collective intelligence)