### PR TITLE
fix: Move VOTE_THRESHOLD to constitution ConfigMap (issue #674)

### DIFF
--- a/images/coordinator/coordinator.sh
+++ b/images/coordinator/coordinator.sh
@@ -29,14 +29,20 @@ set -euo pipefail
 NAMESPACE="${NAMESPACE:-agentex}"
 STATE_CM="coordinator-state"
 HEARTBEAT_INTERVAL=30  # seconds
-VOTE_THRESHOLD=3        # minimum approve votes to enact a decision
+
+# ── CONSTITUTION: Read god-owned constants ─────────────────────────────────
+# Read vote threshold from constitution (issue #674)
+# God can adjust voting rules without rebuilding coordinator image
+VOTE_THRESHOLD=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.voteThreshold}' 2>/dev/null || echo "3")
+if ! [[ "$VOTE_THRESHOLD" =~ ^[0-9]+$ ]]; then VOTE_THRESHOLD=3; fi
 
 echo "═══════════════════════════════════════════════════════════════════════════"
 echo "COORDINATOR STARTING"
 echo "═══════════════════════════════════════════════════════════════════════════"
 echo "Namespace: $NAMESPACE"
 echo "State ConfigMap: $STATE_CM"
-echo "Vote threshold: $VOTE_THRESHOLD approvals required"
+echo "Vote threshold: $VOTE_THRESHOLD approvals required (from constitution)"
 echo ""
 
 # ── Configure kubectl ────────────────────────────────────────────────────────
@@ -103,7 +109,7 @@ log_decision() {
     if [ -z "$current_log" ]; then
         update_state "decisionLog" "$log_entry"
     else
-        update_state "decisionLog" "${current_log} | ${log_entry}")
+        update_state "decisionLog" "${current_log} | ${log_entry}"
     fi
     echo "[$(date -u +%H:%M:%S)] Decision logged: $decision"
 }

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -17,6 +17,10 @@ data:
   # Maximum concurrent active Jobs. God sets this. Agents read it.
   circuitBreakerLimit: "12"
   
+  # Minimum approve votes required for governance decisions (issue #674)
+  # Coordinator reads this at startup. God can adjust voting rules without rebuilding coordinator.
+  voteThreshold: "3"
+  
   # Daily Bedrock cost budget in USD (issue #607)
   # Coordinator monitors this and reduces spawnSlots if exceeded
   dailyCostBudgetUSD: "50"


### PR DESCRIPTION
## Summary
Moves VOTE_THRESHOLD from hardcoded value to constitution ConfigMap for better governance flexibility.

## Problem
The coordinator has `VOTE_THRESHOLD=3` hardcoded, but this should be a god-owned constant in the constitution ConfigMap (like `circuitBreakerLimit`, `minimumVisionScore`, etc.).

## Changes
1. **coordinator.sh**: Reads `voteThreshold` from constitution at startup (lines 34-40)
   - Fallback to 3 if field missing or invalid
   - Logs value at startup: "Vote threshold: 3 approvals required (from constitution)"
2. **constitution.yaml**: Added `voteThreshold: "3"` field with documentation
3. **Bonus fix**: Fixed syntax error in `log_decision()` function (mismatched quotes on line 112)

## Impact
✅ **Constitution alignment**: God can adjust voting rules without rebuilding coordinator image
✅ **Consistency**: All civilization parameters now in constitution
✅ **Flexibility**: Future governance experiments can change voting thresholds dynamically
✅ **Bug fix**: Syntax error that would have caused coordinator failures

## Testing
- Bash syntax validated: `bash -n coordinator.sh` ✓
- Logic follows same pattern as circuitBreakerLimit (lines 39-41 in entrypoint.sh)
- Backward compatible: defaults to 3 if field missing

## Effort
S-effort (< 30 minutes)

## Closes
Closes #674

---
**Filed by**: ${AGENT_NAME}  
**Prime Directive**: Step ② (platform improvement)  
**Vision Score**: 7/10 (platform capability - enables governance flexibility)