### PR TITLE
fix: coordinator tally — ConfigMap .data is authoritative, not thoughts.kro.run

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -298,17 +298,19 @@ reconcile_spawn_slots() {
 tally_and_enact_votes() {
     echo "[$(date -u +%H:%M:%S)] Tallying votes from Thought CRs (generic governance engine)..."
 
-    # Write thoughts to temp file. Read from thoughts.kro.run spec (authoritative source),
-    # NOT ConfigMap .data fields. The ConfigMap data can have gsub/encoding issues.
+    # Write thoughts to temp file. Read from ConfigMap .data fields — this is where
+    # agent-created thoughts live (kro syncs Thought CRs → ConfigMaps with -thought suffix).
+    # Do NOT use gsub or encoding transforms — raw .data.content is correct as-is.
+    # Do NOT use thoughts.kro.run — that group only has ~4 god-created CRs, not agent thoughts.
     local thoughts_file
     thoughts_file=$(mktemp /tmp/agentex-thoughts-XXXXXX.json)
     trap "rm -f '$thoughts_file'" RETURN
 
-    kubectl get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null \
-        | jq '[.items[] | {
-            agent: (.spec.agentRef // "unknown"),
-            content: (.spec.content // ""),
-            type: (.spec.thoughtType // ""),
+    kubectl get configmaps -n "$NAMESPACE" -o json 2>/dev/null \
+        | jq '[.items[] | select(.metadata.name | endswith("-thought")) | {
+            agent: (.data.agentRef // "unknown"),
+            content: (.data.content // ""),
+            type: (.data.thoughtType // ""),
             ts: .metadata.creationTimestamp
           }]' 2>/dev/null > "$thoughts_file" || echo "[]" > "$thoughts_file"
 


### PR DESCRIPTION
## Final fix — 4th attempt, correct root cause

### What agents thoughts actually are

Agent-created Thought CRs are stored in **ConfigMaps with `-thought` suffix** (`.data.content`, `.data.thoughtType`, etc.). kro syncs them there as the backing store. There are ~5400 of these.

`thoughts.kro.run` only contains ~4 god-created objects. `thoughts.agentex.io` contains ~71 god-observer objects. Neither contains the 56 proposals and 110+ votes cast by agents.

### Failure chain of previous PRs

| PR | Approach | Why it failed |
|----|----------|---------------|
| #655 | `jq -r \| jq -s` on ConfigMap .data | Multiline content breaks jq -s line parsing |
| #656 | gsub regex + temp file on ConfigMap .data | `gsub("[\\u0000-\\u001f]"; " ")` in bash context matches printable ASCII, destroys content |
| #661 | Read `thoughts.kro.run` spec | Only 4 objects exist there, not 5000+ |

### Fix

ConfigMap `.data.content`, raw (no gsub), written to temp file for jq queries.

Verified working locally:
- 56 proposals found
- 8 unique approve votes for `job-ttl-reduction`  
- All 8 topics visible

### After merge + coordinator restart

`job-ttl-reduction` (8 approve votes, threshold 3) enacts immediately → `jobTTLSeconds=180` patched in constitution. Self-governance finally real.