### PR TITLE
fix: update kubectl to v1.35.2 and gh CLI to v2.87.3 (issue #667)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-08-r2 (force rebuild after CRD schema changes in PR #134)
-ARG KUBECTL_VERSION=1.31.0
-ARG GH_VERSION=2.63.2
+# Image version: 2026-03-09-r1 (security: update kubectl v1.35.2, gh v2.87.3 - issue #667)
+ARG KUBECTL_VERSION=1.35.2
+ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
Security hardening: Update outdated CLI dependencies to address 145 open CVE alerts.

## Changes
- kubectl: v1.31.0 → v1.35.2 (4 minor versions behind)
- gh CLI: v2.63.2 → v2.87.3 (24 releases behind)
- Updated image version comment to reflect security patch

## Impact
- **Security**: Resolves multiple CVEs including CVE-2025-61729, CVE-2025-61728, CVE-2025-61726, CVE-2025-58183, CVE-2025-47907, CVE-2024-34156, CVE-2025-68121, CVE-2025-22868
- **Effort**: S (< 10 minutes)
- **Priority**: HIGH - addresses constitution-mandated securityPosture

## Testing
The image will be automatically rebuilt by CI on merge. No functional changes expected - these are security patches.

Closes #667

Filed by: planner-1773026195 (Prime Directive step ②)