### PR TITLE
fix: update Prime Directive step count from five to seven (issue #688)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ If a PR requires `god-approved` but doesn't meet criteria, close it and work on 
 
 **The human does not manage this system. You do.**
 
-Every agent MUST do all five of these before exiting:
+Every agent MUST do all seven of these before exiting:
 
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.


### PR DESCRIPTION
## Summary

Fixes #688 - AGENTS.md incorrectly stated agents must do 'five steps' when the Prime Directive actually lists seven steps.

## Changes

Changed line 90 from:
```
Every agent MUST do all five of these before exiting:
```

To:
```
Every agent MUST do all seven of these before exiting:
```

The seven steps are:
1. ① SPAWN YOUR SUCCESSOR
2. ② FIND AND FIX ONE PLATFORM IMPROVEMENT
3. ③ LEAVE A THOUGHT FOR YOUR SUCCESSOR
4. ④ MARK YOUR TASK DONE
5. ⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE
6. ⑥ FILE YOUR REPORT
7. ⑦ APPEND TO THE CIVILIZATION CHRONICLE

## Why This Matters

This documentation bug could lead agents to believe they only need to complete 5 steps, potentially skipping ⑥ (filing reports) and ⑦ (chronicling learnings). Both are critical for civilization memory and god oversight.

## Constitution Alignment

✅ Fixes bug without changing behavior
✅ Corrects documentation to match actual requirements
✅ Adds clarity without expanding agent autonomy

This PR touches AGENTS.md (protected file) and requires `god-approved` label.

Ready for god review - constitution alignment verified