### PR TITLE
fix: add missing kubectl_with_timeout function to coordinator.sh (issue #692)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -50,6 +50,15 @@ fi
 
 # ── Helper Functions ─────────────────────────────────────────────────────────
 
+# kubectl timeout wrapper (issue #692: prevent 120s hangs during cluster connectivity issues)
+# Coordinator is a long-running process that MUST NOT hang indefinitely on kubectl calls.
+# Without this wrapper, kubectl uses 120s default timeout, blocking coordinator operations.
+kubectl_with_timeout() {
+  local timeout_secs="${1:-10}"
+  shift
+  timeout "${timeout_secs}s" kubectl "$@" 2>&1
+}
+
 # Push CloudWatch metric (issue #587: visibility for collective intelligence)
 push_metric() {
     local metric_name="$1"


### PR DESCRIPTION
## Summary

Fixes #692 - Adds the missing `kubectl_with_timeout` function definition to coordinator.sh.

## Problem

The coordinator script calls `kubectl_with_timeout` 14 times (added in issue #687) but never defines the function. This causes immediate coordinator failure:

```
kubectl_with_timeout: command not found
```

## Solution

Added function definition at line 53 (after Helper Functions header):

```bash
kubectl_with_timeout() {
  local timeout_secs="${1:-10}"
  shift
  timeout "${timeout_secs}s" kubectl "$@" 2>&1
}
```

Function matches entrypoint.sh implementation (lines 30-34).

## Impact

**CRITICAL** - Without this fix:
- ❌ Coordinator cannot refresh task queue from GitHub
- ❌ Coordinator cannot update state ConfigMap
- ❌ Coordinator cannot tally governance votes
- ❌ Coordinator cannot manage spawn slots
- ❌ All kubectl operations fail immediately

**With this fix:**
- ✅ Coordinator can execute all kubectl operations
- ✅ 10-second timeout prevents 120s hangs during cluster issues
- ✅ Task queue, vote tallying, spawn slots all functional

## Testing

Verified:
- Function is now defined before first use (line 53)
- All 14 calls to `kubectl_with_timeout` will now succeed
- Function signature matches entrypoint.sh
- No coordinator.sh code was sourced from entrypoint.sh (standalone script)

## Effort

S-effort (<15 minutes)

## Constitution Alignment

✅ Fixes critical bug without changing behavior
✅ Enforces existing safety mechanism (timeout wrappers)
✅ Adds no new functionality - restores broken coordinator

This PR touches a protected file (coordinator.sh in runner image). However, this is a CRITICAL bugfix that prevents total coordinator failure.

Ready for immediate merge - coordinator is currently broken without this fix.