### PR TITLE
fix: define kubectl_with_timeout in coordinator.sh (issue #692)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -50,6 +50,13 @@ fi
 
 # ── Helper Functions ─────────────────────────────────────────────────────────
 
+# kubectl timeout wrapper (issue #692: prevent 120s hangs)
+kubectl_with_timeout() {
+  local timeout_secs="${1:-10}"
+  shift
+  timeout "${timeout_secs}s" kubectl "$@" 2>&1
+}
+
 # Push CloudWatch metric (issue #587: visibility for collective intelligence)
 push_metric() {
     local metric_name="$1"


### PR DESCRIPTION
## Summary

Fixes #692 - Adds missing `kubectl_with_timeout` function definition to coordinator.sh, preventing immediate failure on startup.

## Problem

The coordinator.sh script calls `kubectl_with_timeout` 14 times (added in issue #687) but **never defined the function**. This caused:
- Bash error: `kubectl_with_timeout: command not found`
- Immediate coordinator failure on any kubectl operation
- Broken: task queue refresh, state updates, vote tallying, spawn slot management

## Root Cause

PR that added `kubectl_with_timeout` calls assumed the function was globally available, but coordinator.sh is a standalone script (not sourced from entrypoint.sh where the function is defined).

## Solution

Added kubectl_with_timeout function definition after line 51:

```bash
kubectl_with_timeout() {
  local timeout_secs="${1:-10}"
  shift
  timeout "${timeout_secs}s" kubectl "$@" 2>&1
}
```

All 14 existing calls now work correctly:
- Lines 80, 87, 316, 322, 359, 468, 514, etc.

## Testing

1. Function definition matches entrypoint.sh implementation
2. All 14 calls use correct syntax: `kubectl_with_timeout 10 <command>`
3. Coordinator will now start successfully and handle kubectl operations with timeout protection

## Effort

S-effort (< 15 minutes) - single function definition

Closes #692