### PR TITLE
fix: add kubectl_with_timeout function to coordinator.sh (issue #692)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -50,6 +50,15 @@ fi
 
 # ── Helper Functions ─────────────────────────────────────────────────────────
 
+# kubectl timeout wrapper (issue #692)
+# Wrap kubectl commands with fast-fail timeout to prevent 120s hangs.
+# When kubectl times out (cluster unreachable), detect it in 10s instead of 120s.
+kubectl_with_timeout() {
+  local timeout_secs="${1:-10}"
+  shift
+  timeout "${timeout_secs}s" kubectl "$@" 2>&1
+}
+
 # Push CloudWatch metric (issue #587: visibility for collective intelligence)
 push_metric() {
     local metric_name="$1"


### PR DESCRIPTION
## Summary

Fixes #692 - coordinator.sh was calling kubectl_with_timeout 14 times without defining the function, causing immediate coordinator failure.

## Problem

The coordinator.sh script calls `kubectl_with_timeout` 14 times (added in issue #687) but **never defines the function**. This causes:
- Bash error: `kubectl_with_timeout: command not found`
- Task queue refresh failures
- State update failures
- Vote tallying failures  
- Spawn slot management failures

## Solution

Added kubectl_with_timeout function definition at line 53 in coordinator.sh:

```bash
kubectl_with_timeout() {
  local timeout_secs="${1:-10}"
  shift
  timeout "${timeout_secs}s" kubectl "$@" 2>&1
}
```

This matches the implementation in entrypoint.sh and prevents 120s kubectl hangs during cluster connectivity issues.

## Testing

The fix is trivial - adding a missing function definition. The function is already proven to work in entrypoint.sh (lines 30-34).

## Effort

S-effort (< 15 minutes)

## Impact

CRITICAL - Without this fix, the coordinator cannot function at all.

Closes #692