### PR TITLE
fix: wrap 4 remaining bare kubectl commands in coordinator.sh with timeout (issue #696)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -237,7 +237,7 @@ cleanup_stale_assignments() {
         local issue="${pair##*:}"
 
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
 
@@ -281,7 +281,7 @@ cleanup_active_agents() {
         
         # Check if Job still active (exists and no completionTime)
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
         
@@ -611,13 +611,13 @@ while true; do
     
     # Read current circuit breaker limit
     local cb_limit
-    cb_limit=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    cb_limit=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
         -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
     if ! [[ "$cb_limit" =~ ^[0-9]+$ ]]; then cb_limit=12; fi
     
     # Count active jobs (fast check, only when needed)
     local current_active
-    current_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    current_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
         2>/dev/null || echo "0")
     


### PR DESCRIPTION
## Summary

Fixes #696 - Wraps 4 remaining bare kubectl commands in coordinator.sh with kubectl_with_timeout 10 to prevent 120s hangs during cluster connectivity issues.

## Changes

Modified 4 kubectl commands in `images/runner/coordinator.sh`:
- Line 240: `kubectl get job` → `kubectl_with_timeout 10 get job` (cleanup_stale_assignments)
- Line 284: `kubectl get job` → `kubectl_with_timeout 10 get job` (cleanup_active_agents)
- Line 614: `kubectl get configmap` → `kubectl_with_timeout 10 get configmap` (adaptive reconcile)
- Line 620: `kubectl get jobs` → `kubectl_with_timeout 10 get jobs` (adaptive reconcile)

## Why This Matters

Issue #687 claimed to fix kubectl timeouts in coordinator.sh, but these 4 commands were missed. During cluster API connectivity issues (like #430), these commands hang for 120s, blocking the coordinator's control loop which runs every 30s.

**Impact:**
- Lines 240, 284: Run every 30s during cleanup (stale assignment/agent removal)
- Lines 614, 620: Run every 30s when near capacity (adaptive reconciliation frequency check)

Without timeouts, the coordinator can hang for 120s, preventing:
- Task queue management
- Spawn slot reconciliation
- Vote tallying
- Heartbeat updates

## Testing Strategy

No behavior changes - only timeout wrapper addition. Coordinator will now:
- Fail fast (10s) instead of hanging (120s) during network issues
- Return to normal operation once cluster connectivity is restored
- Gracefully handle kubectl failures with `|| echo "false"` / `|| echo "0"` fallbacks

## Related Issues

- #696: This issue (coordinator kubectl timeout gaps)
- #687: Incomplete fix (missed these 4 commands)
- #430: Root cause (kubectl cluster connectivity timeouts)
- #659: entrypoint.sh kubectl timeout fix (precedent)