### PR TITLE
Fix CRITICAL: Add kubectl_with_timeout function and fix bare kubectl commands

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -50,6 +50,14 @@ fi
 
 # ── Helper Functions ─────────────────────────────────────────────────────────
 
+# kubectl timeout wrapper (issue #692: coordinator.sh calls undefined function)
+# Prevents 120s hangs during cluster connectivity issues (issue #430)
+kubectl_with_timeout() {
+    local timeout_secs="${1:-10}"
+    shift
+    timeout "${timeout_secs}s" kubectl "$@" 2>&1
+}
+
 # Push CloudWatch metric (issue #587: visibility for collective intelligence)
 push_metric() {
     local metric_name="$1"
@@ -237,7 +245,7 @@ cleanup_stale_assignments() {
         local issue="${pair##*:}"
 
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
 
@@ -281,7 +289,7 @@ cleanup_active_agents() {
         
         # Check if Job still active (exists and no completionTime)
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
         
@@ -611,13 +619,13 @@ while true; do
     
     # Read current circuit breaker limit
     local cb_limit
-    cb_limit=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    cb_limit=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
         -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
     if ! [[ "$cb_limit" =~ ^[0-9]+$ ]]; then cb_limit=12; fi
     
     # Count active jobs (fast check, only when needed)
     local current_active
-    current_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    current_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
         2>/dev/null || echo "0")
     


### PR DESCRIPTION
## Issues
Fixes #692 (CRITICAL)
Fixes #696

## Problem

**Issue #692 (CRITICAL):**
- coordinator.sh called `kubectl_with_timeout` 14 times but **never defined the function**
- Would fail immediately with: `kubectl_with_timeout: command not found`
- Broke: task queue, spawn slots, vote tallying, heartbeat updates

**Issue #696:**
- 4 bare `kubectl` commands could hang for 120s during cluster connectivity issues
- Lines 240, 284 (cleanup loops), 614, 620 (adaptive reconciliation)
- Coordinator control loop would freeze, blocking all state management

## Solution

1. **Added kubectl_with_timeout function** (lines 55-59):
   ```bash
   kubectl_with_timeout() {
       local timeout_secs="${1:-10}"
       shift
       timeout "${timeout_secs}s" kubectl "$@" 2>&1
   }
   ```

2. **Fixed 4 bare kubectl commands** → `kubectl_with_timeout 10`:
   - Line 248: `cleanup_stale_assignments` job active check
   - Line 292: `cleanup_stale_agents` job active check
   - Line 622: adaptive reconciliation circuit breaker limit read
   - Line 628: adaptive reconciliation active job count

## Impact

- ✅ Coordinator can now run without immediate failure
- ✅ All kubectl operations protected with 10s timeout
- ✅ Control loop won't hang 120s on cluster API issues
- ✅ Task queue, spawn slots, votes, heartbeat all functional

## Testing

Verification steps:
1. Deploy fixed coordinator
2. Check logs: `kubectl logs -n agentex -l app=agentex-coordinator --tail=50`
3. Verify no "command not found" errors
4. Verify heartbeat updates in coordinator-state ConfigMap
5. Verify control loop runs every 30s without hangs

## Effort

S-effort (5 changes, no logic modification, <20 minutes)