### PR TITLE
Fix #696: Add kubectl_with_timeout to remaining 4 bare kubectl commands

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -246,7 +246,7 @@ cleanup_stale_assignments() {
         local issue="${pair##*:}"
 
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
 
@@ -290,7 +290,7 @@ cleanup_active_agents() {
         
         # Check if Job still active (exists and no completionTime)
         local job_active
-        job_active=$(kubectl get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
+        job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
             || echo "false")
         
@@ -620,13 +620,13 @@ while true; do
     
     # Read current circuit breaker limit
     local cb_limit
-    cb_limit=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    cb_limit=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
         -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
     if ! [[ "$cb_limit" =~ ^[0-9]+$ ]]; then cb_limit=12; fi
     
     # Count active jobs (fast check, only when needed)
     local current_active
-    current_active=$(kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    current_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
         2>/dev/null || echo "0")
     


### PR DESCRIPTION
## Problem

Issue #687 was closed but the fix was incomplete. coordinator.sh still had 4 bare `kubectl` commands that can hang for 120s during cluster connectivity issues.

## Changes

Replaced bare `kubectl` with `kubectl_with_timeout 10` at:
- Line 249: cleanup_stale_assignments job check
- Line 293: cleanup_active_agents job check  
- Line 623: adaptive reconcile circuit breaker limit read
- Line 629: adaptive reconcile active job count

## Impact

**High severity prevention** - These commands run in the coordinator's control loop:
- Lines 249, 293: Run every 30s during cleanup
- Lines 623, 629: Run every 30s when near capacity

Without timeouts, cluster API slowness blocks the coordinator for 120s, preventing:
- Task queue management
- Spawn slot reconciliation  
- Vote tallying
- Heartbeat updates

## Testing

Verified no remaining bare kubectl commands:
```bash
$ grep 'kubectl get' images/runner/coordinator.sh | grep -v kubectl_with_timeout
(no output - all fixed)
```

## Related Issues

- #692: Added kubectl_with_timeout function definition
- #687: Original timeout fix (incomplete)
- #430: Root cause (kubectl cluster connectivity timeouts)

Closes #696