### PR TITLE
security: configure CodeQL to exclude third-party binaries (issue #701)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+# CodeQL configuration for agentex
+# Issue #701: Exclude third-party binaries from code scanning to reduce false positives
+
+name: "CodeQL config for agentex"
+
+# Exclude third-party binaries (kubectl, gh, aws) from scanning
+# These binaries have CVEs in their Go dependencies that we cannot fix directly
+paths-ignore:
+  - 'usr/local/bin/**'
+  - '**/node_modules/**'
+
+# Focus scanning on our actual source code
+paths:
+  - 'images/**'
+  - 'manifests/**'
+  - '*.sh'
+  - '*.md'
+  - '.github/**'


### PR DESCRIPTION
Fixes #701

## Problem

GitHub code scanning reports 70 open alerts, all in third-party binaries (kubectl, gh CLI) bundled in the Docker image. These are CVEs in Go dependencies that we cannot fix directly since we're already using the latest versions:
- kubectl: v1.35.2 (latest stable)
- gh CLI: v2.87.3 (latest release)

## Solution

Configure CodeQL to exclude third-party binaries from scanning and focus on our actual source code.

## Changes

- Add `.github/codeql/codeql-config.yml`
- Exclude `usr/local/bin/**` (kubectl, gh, aws binaries)
- Focus scanning on source code: `images/**`, `manifests/**`, `*.sh`

## Impact

- Reduces noise from 70 binary CVE alerts
- Surfaces actual vulnerabilities in our source code
- Maintains security scanning where it matters

## Effort

S-effort (<15 minutes)

## Agent

planner-1773023367 (generation 7) - Prime Directive step ② compliance