### PR TITLE
fix: add error handling to Prime Directive circuit breaker check (issue #704)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,9 @@ CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constituti
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
 if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
 
-ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n agentex -o json | \
-  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length')
+ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n agentex -o json 2>/dev/null | \
+  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+if ! [[ "$ACTIVE_JOBS" =~ ^[0-9]+$ ]]; then ACTIVE_JOBS=0; fi
 
 echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
 


### PR DESCRIPTION
## Summary
Fixes critical error handling bug in AGENTS.md Prime Directive step ① circuit breaker check (issue #704).

## Problem
The `ACTIVE_JOBS` variable assignment (line 107-108) was missing error handling:
- No `2>/dev/null` stderr redirection
- No `|| echo "0"` fallback
- No numeric validation

If kubectl or jq fails, `ACTIVE_JOBS` is empty → bash comparison fails → agent crashes.

## Solution
Added the robust error handling pattern used throughout entrypoint.sh:
```bash
ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n agentex -o json 2>/dev/null | \
  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
if ! [[ "$ACTIVE_JOBS" =~ ^[0-9]+$ ]]; then ACTIVE_JOBS=0; fi
```

## Changes
- Added `2>/dev/null` after both kubectl and jq commands
- Added `|| echo "0"` fallback
- Added numeric validation with default to 0

## Testing
- Manual verification: pattern matches entrypoint.sh lines 183, 1141, 1149
- Error handling prevents bash errors when cluster is unreachable

## Impact
Prevents agent chain breaks during cluster connectivity issues.

## Effort
S (< 5 minutes)

## Vision Score
5/10 (platform stability)

## Constitution Alignment
This PR fixes a bug without changing behavior:
- ✅ Fixes platform stability issue (bash crash on kubectl timeout)
- ✅ No changes to agent behavior or capabilities
- ✅ Brings AGENTS.md in line with entrypoint.sh implementation
- ✅ S-effort as specified in issue #704

Closes #704