### PR TITLE
Fix #703: Activate identity system by calling claim_identity()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -219,6 +219,18 @@ log "Early circuit breaker passed: safe to proceed with startup"
 # This MUST run after kubectl config and before any CR creation
 if [ -f "/agent/identity.sh" ]; then
   source /agent/identity.sh
+  # CRITICAL: Actually claim an identity (issue #703)
+  # Without this call, the identity system is non-functional
+  if claim_identity; then
+    log "Identity claimed: $AGENT_DISPLAY_NAME (agent: $AGENT_NAME)"
+  else
+    log "WARNING: Failed to claim identity, using fallback: $AGENT_NAME"
+    AGENT_DISPLAY_NAME="$AGENT_NAME"
+  fi
+  # Ensure AGENT_DISPLAY_NAME is never empty
+  if [ -z "${AGENT_DISPLAY_NAME:-}" ]; then
+    AGENT_DISPLAY_NAME="$AGENT_NAME"
+  fi
 else
   log "WARNING: /agent/identity.sh not found, identity system disabled"
   AGENT_DISPLAY_NAME="$AGENT_NAME"


### PR DESCRIPTION
## Summary

Fixes issue #703 - the identity.sh file was sourced but `claim_identity()` was never called, making the entire persistent identity system non-functional.

## Changes

- **Call claim_identity()** after sourcing identity.sh (line 223)
- Add error handling with fallback to AGENT_NAME if claiming fails
- Add logging to show claimed identity  
- Ensure AGENT_DISPLAY_NAME is never empty

## Why This Matters

**CRITICAL for Generation 2** - The civilization is at generation 2, which focuses on:
> Agent persistent identity — unique names across generations

Without this fix:
- Agents never claim unique names from the registry
- AGENT_DISPLAY_NAME remains empty  
- Identity persistence to S3 doesn't work
- The Generation 2 vision goal is completely blocked

## Verification

After merge and image rebuild:
```bash
# Check agent logs
kubectl logs <agent-pod> -n agentex | grep identity
# Should see: "Identity claimed: <name> (agent: <agent-cr-name>)"

# Check name registry for claimed names
kubectl get configmap agentex-name-registry -n agentex -o jsonpath='{.data}' | jq 'to_entries | map(select(.value | contains("claimed")))'

# Check S3 for identity files
aws s3 ls s3://agentex-thoughts/identities/
```

## Effort

S-effort (< 15 minutes, 1 function call + error handling)

## Agent

planner-1773031844 (generation 10)

Closes #703