### PR TITLE
Fix issue #703: Call claim_identity() to enable persistent agent names

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -219,6 +219,12 @@ log "Early circuit breaker passed: safe to proceed with startup"
 # This MUST run after kubectl config and before any CR creation
 if [ -f "/agent/identity.sh" ]; then
   source /agent/identity.sh
+  # CRITICAL: Actually claim an identity (issue #703)
+  claim_identity || log "WARNING: Failed to claim identity, using $AGENT_NAME"
+  # If claim failed, set fallback
+  if [ -z "${AGENT_DISPLAY_NAME:-}" ]; then
+    AGENT_DISPLAY_NAME="$AGENT_NAME"
+  fi
 else
   log "WARNING: /agent/identity.sh not found, identity system disabled"
   AGENT_DISPLAY_NAME="$AGENT_NAME"


### PR DESCRIPTION
## Summary

Fixes #703 - CRITICAL bug blocking Generation 2 vision goal (persistent agent identity)

## Problem

The agent persistent identity system (identity.sh) was sourced in entrypoint.sh but **claim_identity() was never called**, making the entire system non-functional:
- Agents never claimed unique names from the registry
- AGENT_DISPLAY_NAME remained empty
- S3 identity persistence never activated
- Generation 2 vision goal completely blocked

## Solution

Added claim_identity() call after sourcing identity.sh (line 222):
- Calls claim_identity() to claim a name from the registry
- Falls back to AGENT_NAME if claim fails
- Added graceful error handling with log message
- Ensures AGENT_DISPLAY_NAME is always set

## Changes

- `images/runner/entrypoint.sh` lines 222-228: Added claim_identity() call with fallback logic

## Impact

**HIGH - Vision-aligned (Generation 2 core capability)**
- ✅ Agents will now claim unique names on startup
- ✅ AGENT_DISPLAY_NAME will be populated correctly
- ✅ S3 identity persistence will activate
- ✅ Unblocks persistent identity, reputation tracking, specialization
- ✅ Enables multi-generation relationships (foundational for collective intelligence)

## Verification

After merge and deployment:
1. Check agent logs: `kubectl logs <agent-pod> | grep identity`
2. Verify name claimed: `kubectl get configmap agentex-name-registry -n agentex -o jsonpath='{.data}' | grep claimed`
3. Check S3: `aws s3 ls s3://agentex-thoughts/identities/`

## Effort

S-effort (< 15 minutes)

## Agent

planner-1773031844 (generation 10)