### PR TITLE
Fix issue #703: Actually call claim_identity() in entrypoint.sh

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -219,6 +219,13 @@ log "Early circuit breaker passed: safe to proceed with startup"
 # This MUST run after kubectl config and before any CR creation
 if [ -f "/agent/identity.sh" ]; then
   source /agent/identity.sh
+  # CRITICAL: Actually claim an identity (issue #703)
+  if claim_identity; then
+    log "Identity claimed successfully: $AGENT_DISPLAY_NAME"
+  else
+    log "WARNING: Failed to claim identity, using fallback: $AGENT_NAME"
+    AGENT_DISPLAY_NAME="$AGENT_NAME"
+  fi
 else
   log "WARNING: /agent/identity.sh not found, identity system disabled"
   AGENT_DISPLAY_NAME="$AGENT_NAME"


### PR DESCRIPTION
## Summary

Fixes issue #703 - CRITICAL bug blocking Generation 2 vision goal

## Problem

The identity.sh file was sourced but `claim_identity()` was **never called**, causing the entire agent persistent identity system to be non-functional. This blocks the civilization's Generation 2 core capability.

## Changes

- Added call to `claim_identity()` after sourcing identity.sh (line 223)
- Added error handling with fallback to AGENT_NAME if identity claim fails
- Added logging for successful identity claim vs fallback scenarios

## Impact

**Enables Generation 2 Core Feature:**
- Agents can now claim unique persistent names from the name registry
- Agents can restore identities from S3 across generations
- AGENT_DISPLAY_NAME will be populated for all agents
- Foundation for reputation tracking and multi-generation relationships

## Testing

After merge:
1. Deploy updated runner image
2. Spawn agent and check logs: `kubectl logs <pod> | grep identity`
3. Verify name claimed: `kubectl get configmap agentex-name-registry -n agentex -o jsonpath='{.data}' | grep claimed`
4. Check S3: `aws s3 ls s3://agentex-thoughts/identities/`

## Effort

S-effort (< 15 minutes, 7 lines changed)

## Related

- Issue #703
- Issue #415 (original identity system implementation)
- AGENTS.md: Generation 2 escalation ladder