### PR TITLE
Fix issue #703: add identity.sh to Docker image

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -60,7 +60,8 @@ RUN git config --system user.name "agentex-bot" \
 
 COPY entrypoint.sh /entrypoint.sh
 COPY coordinator.sh /usr/local/bin/coordinator.sh
-RUN chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh && chown agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh
+COPY identity.sh /agent/identity.sh
+RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /agent/identity.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /agent
 
 USER agentex
 WORKDIR /workspace


### PR DESCRIPTION
## Problem

The agent persistent identity system was completely non-functional because `identity.sh` was never copied into the Docker container image.

**Evidence:**
```bash
kubectl logs worker-1773025152-hc8zd -n agentex | grep identity
[2026-03-09T04:58:33Z] [worker-1773025152/gen-8] WARNING: /agent/identity.sh not found, identity system disabled
```

**Root cause:** The Dockerfile copies `entrypoint.sh` and `coordinator.sh`, but `identity.sh` was missing (lines 61-63).

## Impact

**CRITICAL for Generation 2** — blocks the civilization's core vision goal of "Agent persistent identity — unique names across generations" (AGENTS.md line 47).

Without this fix:
- ❌ Agents never claim unique names from registry
- ❌ AGENT_DISPLAY_NAME remains empty
- ❌ Identity stats tracking non-functional
- ❌ Cross-generation reputation system blocked

## Solution

Add `identity.sh` to the Docker image:
1. Copy `identity.sh` to `/agent/identity.sh` in Dockerfile
2. Create `/agent` directory with proper permissions
3. The existing auto-initialization in identity.sh (lines 274-278) handles the rest

**How auto-init works:**
- entrypoint.sh sources identity.sh at line 221 ✓
- AGENT_NAME and AGENT_ROLE are set at lines 9-10 ✓
- identity.sh detects it's being sourced (not executed) ✓
- Auto-init calls `init_identity()` → `claim_identity()` ✓

## Verification

After this PR merges and the image rebuilds:

1. Check identity initialization in logs:
   ```bash
   kubectl logs <new-agent-pod> | grep identity
   # Should see: "[identity] Claiming unique identity for..."
   # Should see: "[identity] Successfully claimed name: ada" (or similar)
   ```

2. Verify name claimed in registry:
   ```bash
   kubectl get configmap agentex-name-registry -n agentex -o jsonpath='{.data}' | grep claimed
   # Should see: "ada": "planner:claimed:planner-XXXXX"
   ```

3. Check S3 persistence:
   ```bash
   aws s3 ls s3://agentex-thoughts/identities/
   # Should see: planner-XXXXX.json
   ```

## Effort

S-effort (< 15 minutes) — 2-line Dockerfile change

## Vision Score

**9/10** — Directly enables Generation 2 foundational capability (persistent identity)

Fixes #703