### PR TITLE
Add HTTP health endpoint to coordinator for monitoring

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -590,6 +590,52 @@ touch /tmp/coordinator-alive
 touch /tmp/coordinator-ready
 echo "[$(date -u +%H:%M:%S)] Health check files initialized"
 
+# Start HTTP health endpoint in background (issue #699)
+# Serves on port 8080 for liveness/readiness probes with heartbeat staleness check
+start_health_server() {
+    while true; do
+        # Build health response
+        local last_heartbeat
+        last_heartbeat=$(get_state "lastHeartbeat" 2>/dev/null || echo "")
+        local now_epoch
+        now_epoch=$(date +%s)
+        local heartbeat_epoch=0
+        
+        if [ -n "$last_heartbeat" ]; then
+            heartbeat_epoch=$(date -d "$last_heartbeat" +%s 2>/dev/null || echo "0")
+        fi
+        
+        local age=$(( now_epoch - heartbeat_epoch ))
+        local status="healthy"
+        local http_status="200 OK"
+        
+        # If heartbeat is older than 90s (3x heartbeat interval), coordinator loop is stuck
+        if [ "$age" -gt 90 ]; then
+            status="unhealthy"
+            http_status="503 Service Unavailable"
+        fi
+        
+        # Get current phase
+        local phase
+        phase=$(get_state "phase" 2>/dev/null || echo "unknown")
+        
+        # Build JSON response
+        local response="{\"status\":\"$status\",\"lastHeartbeat\":\"$last_heartbeat\",\"heartbeatAge\":$age,\"phase\":\"$phase\"}"
+        
+        # Serve HTTP response with netcat
+        { printf "HTTP/1.1 %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s" \
+            "$http_status" "${#response}" "$response"; } | nc -l -p 8080 -q 1 2>/dev/null || true
+        
+        # Small delay to prevent CPU spinning if nc fails repeatedly
+        sleep 0.1
+    done
+}
+
+# Launch health server in background
+start_health_server &
+HEALTH_SERVER_PID=$!
+echo "[$(date -u +%H:%M:%S)] HTTP health server started on port 8080 (pid: $HEALTH_SERVER_PID)"
+
 iteration=0
 while true; do
     iteration=$((iteration + 1))

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -109,18 +109,24 @@ spec:
                     limits:
                       memory: "512Mi"
                       cpu: "500m"
+                  ports:
+                    - name: health
+                      containerPort: 8080
+                      protocol: TCP
                   livenessProbe:
-                    exec:
-                      command: ["/bin/sh", "-c", "test -f /tmp/coordinator-alive"]
-                    initialDelaySeconds: 30
-                    periodSeconds: 60
+                    httpGet:
+                      path: /health
+                      port: 8080
+                    initialDelaySeconds: 60
+                    periodSeconds: 30
                     timeoutSeconds: 5
                     failureThreshold: 3
                   readinessProbe:
-                    exec:
-                      command: ["/bin/sh", "-c", "test -f /tmp/coordinator-ready"]
-                    initialDelaySeconds: 10
-                    periodSeconds: 30
+                    httpGet:
+                      path: /health
+                      port: 8080
+                    initialDelaySeconds: 15
+                    periodSeconds: 15
                     timeoutSeconds: 5
                     failureThreshold: 2
                   volumeMounts:


### PR DESCRIPTION
## Summary

Implements issue #699: Add HTTP health endpoint to coordinator for better Kubernetes monitoring.

## Changes

1. **HTTP Health Server** (`coordinator.sh`):
   - Background netcat server on port 8080
   - Returns JSON with: `{status, lastHeartbeat, heartbeatAge, phase}`
   - 200 OK if heartbeat updated in last 90s (3x heartbeat interval)
   - 503 Service Unavailable if heartbeat stale → coordinator loop stuck

2. **Deployment Probes** (`coordinator-graph.yaml`):
   - Changed from exec (file checks) to httpGet (port 8080)
   - Liveness: every 30s, initial delay 60s
   - Readiness: every 15s, initial delay 15s
   - Exposes port 8080 for health checks

## Benefits

- ✅ Kubernetes detects stuck coordinator and restarts it automatically
- ✅ Monitoring systems can alert on coordinator health
- ✅ Better visibility into coordinator loop status
- ✅ Automatic recovery from kubectl timeout hangs (issues #430, #692, #696)

## Testing

Local validation of script syntax complete. Ready for deployment testing.

## Effort

M-effort (2 hours implementation + testing)

Agent: planner-1773030777 (generation 2)