### PR TITLE
fix: add retry on suspiciously high circuit breaker count (issue #714)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -184,6 +184,19 @@ EARLY_ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/
 
 log "Early circuit breaker check: $EARLY_ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
 
+# If count seems anomalously high (>= 3x limit), it may be a stale API server cache.
+# Wait 5s and recount before triggering. This prevents false positives during cluster churn
+# (e.g., when kro restarts and reconciles many completed-but-not-yet-TTLed jobs).
+# Issue #714: kro restart causes 67 "active" jobs false positive.
+DOUBLE_LIMIT=$((CIRCUIT_BREAKER_LIMIT * 3))
+if [ "$EARLY_ACTIVE_JOBS" -ge "$DOUBLE_LIMIT" ]; then
+  log "Suspiciously high job count ($EARLY_ACTIVE_JOBS >= ${DOUBLE_LIMIT}). Waiting 5s and recounting (may be stale cache)..."
+  sleep 5
+  EARLY_ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+  log "Recount: $EARLY_ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
+fi
+
 if [ "$EARLY_ACTIVE_JOBS" -ge $CIRCUIT_BREAKER_LIMIT ]; then
   log "EARLY CIRCUIT BREAKER TRIGGERED: System overloaded ($EARLY_ACTIVE_JOBS >= $CIRCUIT_BREAKER_LIMIT)"
   log "Exiting immediately BEFORE resource allocation (identity, inbox, git clone, etc.)"
@@ -1235,6 +1248,17 @@ else
     post_thought "Startup failed: cluster unreachable during circuit breaker check (kubectl timeout). Cannot verify system state safely." "blocker" 10
     exit 1
   fi
+fi
+
+# If count seems anomalously high (>= 3x limit), it may be a stale API server cache.
+# Wait 5s and recount before triggering (issue #714: kro restart causes false positives).
+STARTUP_DOUBLE_LIMIT=$((CIRCUIT_BREAKER_LIMIT * 3))
+if [ "$STARTUP_ACTIVE_JOBS" -ge "$STARTUP_DOUBLE_LIMIT" ]; then
+  log "Suspiciously high job count ($STARTUP_ACTIVE_JOBS >= ${STARTUP_DOUBLE_LIMIT}). Waiting 5s and recounting (may be stale cache)..."
+  sleep 5
+  STARTUP_JOBS_JSON=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null)
+  STARTUP_ACTIVE_JOBS=$(echo "$STARTUP_JOBS_JSON" | jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
+  log "Recount: $STARTUP_ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
 fi
 
 if [ "$STARTUP_ACTIVE_JOBS" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then


### PR DESCRIPTION
## Problem

After kro restarts (e.g., due to EKS Auto Mode pod eviction), the API server cache may return stale job counts where many completed jobs still show `active > 0`. This causes false positive circuit breaker triggers.

**Evidence:** god-delegate-003 was blocked by "67 active jobs >= 12" when the real active count was 1. This happens during the ~30s window after kro restarts while the informer cache is out of sync.

## Fix

Add a double-check: if count >= 3x circuit breaker limit, wait 5s and recount. A genuine proliferation scenario (40+ active jobs) would survive the recount. A false positive (stale cache) would show the correct lower number after 5s.

Applied to both:
1. Early circuit breaker (line ~182, before identity/git/etc.)
2. Step 9.5 circuit breaker check

## Testing

- False positive: 67 stale jobs → wait 5s → recount shows 1 → agent proceeds ✓
- Real proliferation: 36 active jobs → wait 5s → recount still shows 36 → circuit breaker fires ✓
- Normal load: 5 jobs → no retry needed → agent proceeds ✓