### PR TITLE
fix: change spawn slot fallback from fail-open to fail-closed (issue #713)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -833,19 +833,19 @@ request_spawn_slot() {
     slots=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
       -o jsonpath='{.data.spawnSlots}' 2>/dev/null || echo "")
 
-    # If coordinator-state missing or spawnSlots not set, fall back to job count (fail-open)
+    # If coordinator-state missing or spawnSlots not set, FAIL CLOSED (deny spawn)
+    # Issue #713: The previous fail-open fallback allowed TOCTOU race conditions.
+    # Multiple agents could simultaneously read job count, all pass the check, and all spawn.
+    # This caused 51 agents to spawn with only 3 slots available.
+    # FIX: coordinator-state is the source of truth. If unavailable, deny spawn.
+    # The coordinator will self-heal and reconcile slots when it recovers.
     if [ -z "$slots" ] || ! [[ "$slots" =~ ^[0-9]+$ ]]; then
-      log "WARNING: coordinator spawnSlots unavailable, falling back to job count circuit breaker"
-      local total_active
-      total_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
-        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
-      if [ "$total_active" -ge "$CIRCUIT_BREAKER_LIMIT" ]; then
-        log "FALLBACK CIRCUIT BREAKER: $total_active active jobs >= $CIRCUIT_BREAKER_LIMIT. Spawn denied."
-        push_metric "CircuitBreakerTriggered" 1
-        return 1
-      fi
-      log "FALLBACK CIRCUIT BREAKER passed: $total_active < $CIRCUIT_BREAKER_LIMIT"
-      return 0
+      log "CRITICAL: coordinator spawnSlots unavailable. FAILING CLOSED to prevent proliferation race."
+      log "Coordinator must reconcile slots before spawning can resume."
+      post_thought "Spawn denied: coordinator-state unavailable (fail-closed for safety). Issue #713 fix." "blocker" 9
+      push_metric "CircuitBreakerTriggered" 1
+      push_metric "CoordinatorUnavailable" 1
+      return 1
     fi
 
     if [ "$slots" -le 0 ]; then


### PR DESCRIPTION
## Root Cause

Issue #713 reported 51 agents spawning in <5 minutes despite only 3 spawn slots being available. The root cause is a **TOCTOU race condition in the fallback circuit breaker**.

### The Race Condition

When `coordinator-state` is unavailable or `spawnSlots` is not set, `request_spawn_slot()` falls back to counting jobs directly (lines 836-848):

```bash
# Multiple agents SIMULTANEOUSLY:
1. Read coordinator-state → unavailable
2. Fall back to counting jobs → read 9 active jobs
3. Check 9 < 12 limit → PASS
4. All spawn concurrently → 51 agents created
```

This is a classic TOCTOU (time-of-check to time-of-use) race. The job count read is stale by the time each agent spawns.

### Why Fail-Open Was Wrong

The original fallback mode was **fail-open** (allow spawn when coordinator unavailable). This prioritized availability over correctness, which is wrong for proliferation control.

## The Fix

Change fallback mode to **FAIL CLOSED**: deny all spawns when `coordinator-state` is unavailable.

```bash
if [ -z "$slots" ] || ! [[ "$slots" =~ ^[0-9]+$ ]]; then
  log "CRITICAL: coordinator spawnSlots unavailable. FAILING CLOSED to prevent proliferation race."
  push_metric "CoordinatorUnavailable" 1
  return 1  # DENY SPAWN
fi
```

### Why This Works

1. **Eliminates TOCTOU race**: No fallback path that reads stale job counts
2. **coordinator-state is source of truth**: Single atomic counter, no race conditions
3. **Self-healing**: Coordinator reconciles slots every 30-120s, system recovers quickly
4. **Trade-off**: Brief spawn pause (< 2 min) vs catastrophic proliferation (5.17x limit violation)

## Testing

- **With coordinator running**: Spawn slot CAS works as before (no change)
- **With coordinator unavailable**: All spawns blocked until coordinator reconciles slots
- **Recovery time**: 30-120s (coordinator reconciliation interval)

## Impact

- ✅ Prevents proliferation bursts like #713 (9→60 jobs in 5 min)
- ✅ Preserves atomic spawn gate correctness
- ⚠️ Temporary spawn blockage if coordinator crashes (self-heals within 2 min)

## Related Issues

- #713: Massive proliferation burst despite atomic spawn gate
- #609: Atomic spawn gate implementation
- #502, #519, #251, #348: Previous proliferation events

This is the **definitive fix** for TOCTOU-based proliferation races.