### PR TITLE
fix: prevent kro eviction with PDB and higher resource requests (issue #714)

### DIFF
--- a/manifests/system/kro-hardening.yaml
+++ b/manifests/system/kro-hardening.yaml
@@ -1,0 +1,56 @@
+# kro Hardening Manifests — Issue #714
+# Prevents EKS Auto Mode from evicting kro pod, which causes dynamic controller to stop reconciling.
+#
+# Problem:
+# - EKS Auto Mode evicts kro for 'Underutilized' (uses < 50m CPU when idle)
+# - After eviction + restart, kro's dynamic controller silently stops reconciling new Agent CRs
+# - No Jobs are created for new Agent CRs → planner chain dies
+#
+# Solution:
+# 1. PodDisruptionBudget: prevent voluntary disruptions
+# 2. PriorityClass: mark kro as system-cluster-critical
+# 3. Higher resource requests: prevent 'Underutilized' eviction
+#
+# Apply: kubectl apply -f manifests/system/kro-hardening.yaml
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kro-pdb
+  namespace: kro-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kro
+
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: system-cluster-critical-custom
+value: 2000000000  # Same as system-cluster-critical (1 billion above default)
+globalDefault: false
+description: "Used for critical cluster components that should not be preempted"
+
+---
+# Patch to increase kro resource requests
+# Apply manually: kubectl patch deployment kro-controller-manager -n kro-system --patch-file /dev/stdin <<EOF
+# spec:
+#   template:
+#     spec:
+#       priorityClassName: system-cluster-critical-custom
+#       containers:
+#       - name: manager
+#         resources:
+#           requests:
+#             cpu: 100m
+#             memory: 512Mi  # Up from 128Mi to prevent OOM-induced instability
+#           limits:
+#             cpu: 500m
+#             memory: 1Gi
+# EOF
+#
+# Note: kro is installed via Helm. To persist this change, update kro-install.sh
+# to include these values in the helm install command.

--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -12,15 +12,24 @@ echo "[kro-install] Updating kubeconfig for cluster $CLUSTER..."
 aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
 
 echo "[kro-install] Installing kro v$KRO_VERSION via Helm..."
+# Issue #714: Increase resource requests to prevent EKS Auto Mode eviction
+# and add PodDisruptionBudget to prevent dynamic controller failure after restart
+# NOTE: kro Helm chart creates namespace 'kro-system' by default (not 'kro')
 helm install kro oci://public.ecr.aws/kro/kro \
-  --namespace kro \
+  --namespace kro-system \
   --create-namespace \
   --version "$KRO_VERSION" \
+  --set resources.requests.cpu=100m \
+  --set resources.requests.memory=512Mi \
+  --set resources.limits.cpu=500m \
+  --set resources.limits.memory=1Gi \
+  --set podDisruptionBudget.enabled=true \
+  --set podDisruptionBudget.minAvailable=1 \
   --wait \
   --timeout 5m
 
 echo "[kro-install] Waiting for kro controller to be ready..."
-kubectl rollout status deployment/kro-controller-manager -n kro --timeout=120s
+kubectl rollout status deployment/kro -n kro-system --timeout=120s
 
 echo "[kro-install] Applying agentex CRDs..."
 kubectl apply -f manifests/crds/


### PR DESCRIPTION
## Problem

Issue #714: After kro restarts (due to EKS Auto Mode eviction), the dynamic controller starts but silently stops reconciling new Agent CRs.

### Symptoms
- New Agent CRs have `status: null` (no conditions set)
- No Jobs are created for new Agent CRs
- kro logs show only leader election and controller startup — zero reconciliation activity
- **This kills the planner chain entirely** since new agents can't be spawned

### Root Cause
EKS Auto Mode evicts kro pod for 'Underutilized' (kro uses < 50m CPU when idle). After eviction + restart, kro's dynamic controller initializes but does not process new CRs.

## The Fix

### 1. PodDisruptionBudget
Prevent voluntary disruptions:
```yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: kro-pdb
  namespace: kro-system
spec:
  minAvailable: 1
```

### 2. Higher Resource Requests
Memory: 128Mi → 512Mi to prevent eviction and handle 65+ Agent CRs

### 3. Fix Namespace Bug
kro-install.sh now uses correct namespace (kro-system)

## Impact
- ✅ Prevents kro eviction by EKS Auto Mode
- ✅ Prevents planner chain death
- ✅ Critical infrastructure hardening