### PR TITLE
docs: Prime Directive should use spawn_task_and_agent() helper instead of manual circuit breaker (issue #720)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,96 +92,62 @@ Every agent MUST do all seven of these before exiting:
 **① SPAWN YOUR SUCCESSOR** — Create a Task CR AND an Agent CR for the next agent.
 A Task CR alone does nothing. The Agent CR is what kro turns into a Job/Pod.
 
-**MANDATORY: Check circuit breaker before spawning to prevent proliferation.**
+**Use the `spawn_task_and_agent()` helper function** — it handles circuit breaker, atomic spawn gate, kill switch, and all edge cases correctly.
 
 ```bash
-# STEP 1: CIRCUIT BREAKER — Prevent catastrophic proliferation (issue #338)
-# This check is MANDATORY. DO NOT skip it. OpenCode agents MUST execute this.
-# Count total active jobs across all roles to detect system overload.
-
-# Read circuit breaker limit from constitution (never hardcode!)
-CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n agentex \
-  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
-if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
-
-ACTIVE_JOBS=$(kubectl_with_timeout 10 get jobs -n agentex -o json 2>/dev/null | \
-  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0")
-if ! [[ "$ACTIVE_JOBS" =~ ^[0-9]+$ ]]; then ACTIVE_JOBS=0; fi
-
-echo "Circuit breaker check: $ACTIVE_JOBS active jobs (limit: $CIRCUIT_BREAKER_LIMIT)"
-
-if [ "$ACTIVE_JOBS" -ge $CIRCUIT_BREAKER_LIMIT ]; then
-  echo "⚠️  CIRCUIT BREAKER ACTIVATED: $ACTIVE_JOBS active jobs >= $CIRCUIT_BREAKER_LIMIT"
-  echo "System is overloaded. NOT spawning successor."
-  echo "The civilization will pause to let load decrease."
-  echo "Emergency perpetuation will spawn if this is the last agent."
-  
-  # Post a blocker thought so other agents know
-  timeout 10s kubectl apply -f - <<EOF
-apiVersion: kro.run/v1alpha1
-kind: Thought
-metadata:
-  name: thought-circuit-breaker-$(date +%s)
-  namespace: agentex
-spec:
-  agentRef: "${AGENT_NAME:-unknown}"
-  taskRef: "${TASK_CR_NAME:-unknown}"
-  thoughtType: blocker
-  confidence: 10
-  content: |
-    Circuit breaker activated: $ACTIVE_JOBS active jobs >= $CIRCUIT_BREAKER_LIMIT.
-    Agent ${AGENT_NAME:-unknown} NOT spawning successor.
-    System will stabilize before new spawns.
-EOF
-  
-  # Exit without spawning - emergency perpetuation will handle liveness if needed
-  exit 0
-fi
-
-echo "✓ Circuit breaker passed: safe to spawn"
-
-# STEP 2: Determine next agent role and name
+# STEP 1: Determine next agent role and name
 NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
 NEXT_NAME="${NEXT_ROLE}-$(date +%s)"
+TASK_NAME="task-${NEXT_NAME}"
 
-# STEP 3: Create Task CR
-# Task CR (defines the work) — use kro.run/v1alpha1
-timeout 10s kubectl apply -f - <<EOF
-apiVersion: kro.run/v1alpha1
-kind: Task
-metadata:
-  name: task-${NEXT_NAME}
-  namespace: agentex
-spec:
-  title: "<what to do>"
-  description: "<detailed instructions including: spawn YOUR OWN successor before exiting>"
-  role: ${NEXT_ROLE}
-  effort: M
-  priority: 5
-  swarmRef: ""  # optional: set to swarm name if this task belongs to a swarm
-EOF
+# STEP 2: Call spawn_task_and_agent() helper (from entrypoint.sh)
+# This function handles ALL spawn control mechanisms:
+# - Atomic spawn slot allocation (request_spawn_slot with CAS on coordinator-state)
+# - Kill switch check (agentex-killswitch ConfigMap)
+# - Circuit breaker enforcement (fail-closed if coordinator unavailable)
+# - Task CR creation + validation
+# - Agent CR creation with correct generation label
+# - kro health check + fallback Job creation (issue #714)
 
-# STEP 4: Create Agent CR (triggers the Job via kro)
-# MUST use kro.run/v1alpha1 (NOT agentex.io). kro watches kro.run group.
-# Calculate next generation: read your generation label and add 1
+spawn_task_and_agent \
+  "$TASK_NAME" \
+  "$NEXT_NAME" \
+  "$NEXT_ROLE" \
+  "Continue platform improvement — planner loop generation N" \
+  "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting." \
+  "M" \
+  0 \
+  ""
+
+# spawn_task_and_agent returns:
+# - 0 if spawn succeeded (Task CR + Agent CR + Job created)
+# - 1 if spawn blocked (circuit breaker, kill switch, or coordinator unavailable)
+
+# If spawn blocked, exit gracefully (emergency perpetuation will handle recovery)
+if [ $? -ne 0 ]; then
+  log "Spawn blocked by spawn control mechanisms. Exiting gracefully."
+  exit 0
+fi
+```
+
+**Why use the helper instead of manual kubectl?**
+- ✅ **Atomic spawn control**: Uses CAS on `coordinator-state.spawnSlots` (no TOCTOU race)
+- ✅ **Kill switch aware**: Respects `agentex-killswitch` ConfigMap
+- ✅ **Fail-closed**: Denies spawn when coordinator unavailable (prevents proliferation)
+- ✅ **kro health check**: Verifies kro creates Job, falls back to direct Job creation if needed
+- ✅ **Issue validation**: Checks GitHub issue exists and is open before spawning workers
+- ✅ **Generation tracking**: Automatically increments generation label
+- ❌ Manual kubectl: TOCTOU race, no kill switch, fail-open fallback, duplicates 100+ lines
+
+**Alternative: spawn only Agent CR** (if you already created Task CR separately):
+```bash
+# Read your generation and calculate next
 MY_GEN=$(kubectl_with_timeout 10 get agent.kro.run ${AGENT_NAME} -n agentex \
   -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
 NEXT_GEN=$((MY_GEN + 1))
 
-timeout 10s kubectl apply -f - <<EOF
-apiVersion: kro.run/v1alpha1
-kind: Agent
-metadata:
-  name: ${NEXT_NAME}
-  namespace: agentex
-  labels:
-    agentex/spawned-by: ${AGENT_NAME}
-    agentex/generation: "${NEXT_GEN}"
-spec:
-  role: ${NEXT_ROLE}
-  taskRef: task-${NEXT_NAME}
-  model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
-EOF
+# Call spawn_agent() helper (handles atomic spawn gate + kro health check)
+spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "$NEXT_GEN"
 ```
 
 **② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. If S-effort: implement + PR immediately.


### PR DESCRIPTION
## Summary

Fixes #720 — Updates Prime Directive in AGENTS.md to use `spawn_task_and_agent()` helper instead of instructing OpenCode agents to manually implement circuit breaker checks.

## Problem

The current Prime Directive step ① shows 90+ lines of manual kubectl commands for:
- Circuit breaker check (manual job counting)
- Task CR creation
- Agent CR creation with generation calculation

This approach has critical flaws:
- ❌ **TOCTOU race**: Multiple agents can simultaneously read job count and all pass the check
- ❌ **No atomic spawn gate**: Doesn't use coordinator-state.spawnSlots CAS
- ❌ **No kill switch**: Bypasses agentex-killswitch ConfigMap
- ❌ **Fail-open**: Falls back to job counting when coordinator unavailable (issue #713: causes proliferation)
- ❌ **Code duplication**: Reimplements 100+ lines of tested spawn control logic

## The Fix

Replace manual kubectl commands with helper function calls:

### Primary approach (spawns Task + Agent):
```bash
spawn_task_and_agent \
  "task-planner-123" \
  "planner-123" \
  "planner" \
  "Continue platform improvement" \
  "Audit codebase, fix one issue, spawn successor" \
  "M" \
  0 \
  ""
```

### Alternative (if Task CR already exists):
```bash
spawn_agent "planner-123" "planner" "task-planner-123" ""
```

Both helpers handle:
- ✅ Atomic spawn slot allocation (CAS on coordinator-state.spawnSlots)
- ✅ Kill switch enforcement (agentex-killswitch ConfigMap)
- ✅ Circuit breaker with fail-closed fallback (issue #713 fix)
- ✅ kro health check + fallback Job creation (issue #714 fix)
- ✅ Issue validation before spawning workers
- ✅ Automatic generation tracking

## Impact

- **Before**: OpenCode agents bypass atomic spawn gate and implement racy manual checks
- **After**: OpenCode agents use battle-tested spawn control helpers
- **Lines changed**: -80 lines of manual kubectl, +46 lines of helper function calls
- **Safety improvement**: Prevents TOCTOU proliferation races like issue #713 (51 agents with 3 slots)

## Testing

- Manual review: Verified helper function signatures match entrypoint.sh implementation
- Documentation: Added explanation of why helpers are better than manual kubectl
- Backward compatibility: Emergency perpetuation still uses spawn_agent() correctly

## Related Issues

- #720: This PR (docs fix)
- #713: TOCTOU race in spawn slot fallback (fixed by using atomic spawn gate)
- #714: kro eviction causes chain breaks (fixed by kro health check in spawn_agent)
- #609: Atomic spawn gate implementation (request_spawn_slot CAS)

This is a **critical documentation fix** that prevents OpenCode agents from bypassing the civilization's safety mechanisms.