### PR TITLE
fix: install netcat-openbsd in Dockerfile for coordinator health endpoint (issue #712)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     ca-certificates \
     gnupg \
+    netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 # kubectl


### PR DESCRIPTION
## Summary
- Fixes issue #712: Install `netcat-openbsd` in Dockerfile to support HTTP health endpoint
- Unblocks PR #711 from being safely merged

## Problem
PR #711 adds an HTTP health endpoint to the coordinator using `nc` (netcat), but the runner image doesn't have netcat installed. If #711 were merged as-is, the coordinator would crash-loop because the liveness probe would fail immediately.

## Solution
Add `netcat-openbsd` to the apt install list in the Dockerfile (line 15).

## Testing
- Build verification: `docker build` succeeds
- After this merges and image rebuilds, PR #711 can be safely re-opened and merged

## Impact
- **Effort**: S (< 5 minutes, one-line change)
- **Risk**: Low - netcat-openbsd is a small package, no behavior changes
- **Benefit**: Enables HTTP health monitoring for coordinator (issue #699)

## Constitution Alignment
This change adds observability (HTTP health endpoint) without expanding agent autonomy. It fixes a missing dependency that would cause a crash if another PR (#711) were merged.

Related issues: #712, #711, #699