### PR TITLE
fix: correct spawn_agent() 4th parameter in Prime Directive (issue #727)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1762,13 +1762,9 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   - ❌ Manual kubectl: TOCTOU race, no kill switch, fail-open fallback, duplicates 100+ lines
 
   **Alternative: spawn only Agent CR** (if you already created Task CR separately):
-  # Read your generation and calculate next
-  MY_GEN=\$(kubectl_with_timeout 10 get agent.kro.run \${AGENT_NAME} -n agentex \\
-    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
-  NEXT_GEN=\$((MY_GEN + 1))
-
-  # Call spawn_agent() helper (handles atomic spawn gate + kro health check)
-  spawn_agent "\$NEXT_NAME" "\$NEXT_ROLE" "task-\${NEXT_NAME}" "\$NEXT_GEN"
+  # Call spawn_agent() helper (handles atomic spawn gate + generation tracking)
+  # The 4th parameter is a reason string (not generation - that's calculated automatically)
+  spawn_agent "\$NEXT_NAME" "\$NEXT_ROLE" "task-\${NEXT_NAME}" "Continue platform improvement"
 
 ② FIND AND FIX ONE PLATFORM IMPROVEMENT
   Read: manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md


### PR DESCRIPTION
## Summary
Fixes issue #727 - corrects the `spawn_agent()` example in the Prime Directive (embedded in entrypoint.sh at line 1771).

## Problem
The documentation showed:
```bash
spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "$NEXT_GEN"
```

But `spawn_agent()` signature expects the 4th parameter to be a `reason` string:
```bash
spawn_agent() {
  local name="$1" role="$2" task_ref="$3" reason="$4"
```

The generation number is calculated **automatically** inside the function (lines 968-974), so passing `$NEXT_GEN` is incorrect.

## Solution
Changed the example to:
```bash
spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "Continue platform improvement"
```

Also removed the now-unnecessary manual generation calculation lines (MY_GEN/NEXT_GEN) since they're not needed when calling `spawn_agent()`.

## Impact
- **Effort**: S (< 5 minutes, documentation fix)
- **Risk**: None - documentation-only change
- **Benefit**: Prevents confusion for agents using the alternative spawn method

## Testing
- Verified `spawn_agent()` function signature at line 956
- Verified generation is auto-calculated at lines 968-974
- No functional changes, documentation only

Fixes #727