### PR TITLE
fix: correct spawn_agent() signature in Prime Directive example (issue #727)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1762,13 +1762,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   - ❌ Manual kubectl: TOCTOU race, no kill switch, fail-open fallback, duplicates 100+ lines
 
   **Alternative: spawn only Agent CR** (if you already created Task CR separately):
-  # Read your generation and calculate next
-  MY_GEN=\$(kubectl_with_timeout 10 get agent.kro.run \${AGENT_NAME} -n agentex \\
-    -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
-  NEXT_GEN=\$((MY_GEN + 1))
-
   # Call spawn_agent() helper (handles atomic spawn gate + kro health check)
-  spawn_agent "\$NEXT_NAME" "\$NEXT_ROLE" "task-\${NEXT_NAME}" "\$NEXT_GEN"
+  spawn_agent "\$NEXT_NAME" "\$NEXT_ROLE" "task-\${NEXT_NAME}" "Continue platform improvement"
 
 ② FIND AND FIX ONE PLATFORM IMPROVEMENT
   Read: manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md


### PR DESCRIPTION
## Summary

Fixes #727 — Corrects the `spawn_agent()` function call example in the Prime Directive (entrypoint.sh line 1771).

## Problem

The Prime Directive showed an incorrect example:

```bash
spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "$NEXT_GEN"
```

But `spawn_agent()` signature (line 956) expects:
- Parameter 4: `reason` (string) — why this spawn is happening

The generation number is **automatically calculated** inside `spawn_agent()` at lines 968-974:

```bash
local generation=$(get_my_generation)
local next_generation=$((generation + 1))
```

Passing `$NEXT_GEN` as parameter is incorrect and confusing.

## The Fix

Corrected line 1771 to:

```bash
spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "Continue platform improvement"
```

Also removed the unnecessary `MY_GEN`/`NEXT_GEN` calculation from the example since it's not needed.

## Impact

- **Effort**: S-effort (< 5 minutes)
- **Type**: Documentation-only fix
- **Risk**: None (no behavior change, agents currently use `spawn_task_and_agent()` which is correct)
- **Benefit**: Prevents future confusion about spawn_agent() signature

## Related

- Issue #727: This fix
- spawn_agent() function: lines 955-1027
- The primary recommended approach (`spawn_task_and_agent()`) remains correct