### PR TITLE
fix: add timeout protection to identity.sh kubectl calls (issue #732)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -54,7 +54,7 @@ claim_identity() {
     # Get available names for this role from the flat-key ConfigMap format
     # ConfigMap format: ada: worker:available, turing: worker:available, etc.
     local available_names
-    available_names=$(kubectl get configmap agentex-name-registry -n agentex -o json 2>/dev/null | \
+    available_names=$(timeout 10s kubectl get configmap agentex-name-registry -n agentex -o json 2>/dev/null | \
       jq -r --arg role "$AGENT_ROLE" '
         .data | to_entries | 
         map(select(.value == ($role + ":available"))) |
@@ -80,7 +80,7 @@ claim_identity() {
     
     # Use JSON patch with test+replace for atomic claim
     local patch_result
-    if patch_result=$(kubectl patch configmap agentex-name-registry -n agentex \
+    if patch_result=$(timeout 10s kubectl patch configmap agentex-name-registry -n agentex \
       --type=json \
       -p "[{\"op\":\"test\",\"path\":\"/data/$claimed_name\",\"value\":\"$AGENT_ROLE:available\"},{\"op\":\"replace\",\"path\":\"/data/$claimed_name\",\"value\":\"$AGENT_ROLE:claimed:$AGENT_NAME\"}]" \
       2>&1); then
@@ -112,11 +112,11 @@ generate_identity() {
   local adjectives nouns
   
   # Get adjectives and nouns from registry or use defaults
-  adjectives=$(kubectl get configmap agentex-name-registry -n agentex \
+  adjectives=$(timeout 10s kubectl get configmap agentex-name-registry -n agentex \
     -o jsonpath='{.data.adjectives}' 2>/dev/null || \
     echo "swift,bold,wise,keen,bright,calm,quick,deep,sharp,clear")
   
-  nouns=$(kubectl get configmap agentex-name-registry -n agentex \
+  nouns=$(timeout 10s kubectl get configmap agentex-name-registry -n agentex \
     -o jsonpath='{.data.nouns}' 2>/dev/null || \
     echo "lambda,binary,cipher,kernel,daemon,parser,vector,matrix,tensor,graph")
   
@@ -142,7 +142,7 @@ generate_identity() {
 #######################################
 save_identity() {
   local generation
-  generation=$(kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
+  generation=$(timeout 10s kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
   
   local identity_json
@@ -254,7 +254,7 @@ init_identity() {
   echo "[identity] Initializing agent identity system..."
   
   # Ensure name registry exists
-  if ! kubectl get configmap agentex-name-registry -n agentex >/dev/null 2>&1; then
+  if ! timeout 10s kubectl get configmap agentex-name-registry -n agentex >/dev/null 2>&1; then
     echo "[identity] WARNING: agentex-name-registry ConfigMap not found"
     echo "[identity] Please apply manifests/bootstrap/name-registry.yaml"
     echo "[identity] Falling back to generated name"


### PR DESCRIPTION
## Summary

Adds `timeout 10s` wrapper to all 6 kubectl calls in identity.sh to prevent 120s hangs during cluster connectivity issues (like #430).

## Changes

**Modified: images/runner/identity.sh**

Added timeout protection to all kubectl calls:
1. Line 57: Get available names from registry
2. Line 83: Atomic name claim via kubectl patch
3. Line 115: Get adjectives from registry
4. Line 119: Get nouns from registry
5. Line 145: Get agent generation
6. Line 257: Check if registry ConfigMap exists

**Before:**
```bash
available_names=$(kubectl get configmap agentex-name-registry -n agentex -o json 2>/dev/null | ...
```

**After:**
```bash
available_names=$(timeout 10s kubectl get configmap agentex-name-registry -n agentex -o json 2>/dev/null | ...
```

## Benefits

- ✅ **Fast failure**: 10s timeout instead of 120s default kubectl timeout
- ✅ **Consistency**: Matches `kubectl_with_timeout` pattern in entrypoint.sh (line 30)
- ✅ **Resilience**: Agent startup doesn't hang on cluster issues
- ✅ **Observability**: Failures detected in 10s, not 2+ minutes
- ✅ **Graceful degradation**: All calls have fallback defaults

## Testing

Verified changes:
```bash
# All kubectl calls now wrapped with timeout
grep -n 'timeout 10s kubectl' images/runner/identity.sh
# Output: 6 matches (lines 57, 83, 115, 119, 145, 257)

# No raw kubectl calls remain
grep -n '^\s*kubectl' images/runner/identity.sh
# Output: 0 matches
```

## Impact

**When cluster unreachable:**
- **Before**: Identity claiming could take 6+ minutes (6 calls × 120s each)
- **After**: Identity claiming fails fast in 60s max (6 calls × 10s each)

**Normal operation:**
- No behavior change - all calls complete in milliseconds as before
- Fallback defaults ensure identity claiming always succeeds

## Effort

S-effort (< 30 minutes) - Simple timeout wrapper addition

## Related

- Fixes #732
- Related to #430: kubectl cluster connectivity timeout
- Related to #441: kubectl_with_timeout wrapper in entrypoint.sh