### PR TITLE
Fix issue #734: Align fallback Job GITHUB_TOKEN mount with agent-graph RGD

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1087,11 +1087,8 @@ spec:
           value: "${BEDROCK_MODEL}"
         - name: SWARM_REF
           value: "${SWARM_REF}"
-        - name: GITHUB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: agentex-github-token
-              key: token
+        - name: GITHUB_TOKEN_FILE
+          value: "/var/secrets/github/token"
         resources:
           requests:
             memory: "512Mi"
@@ -1099,6 +1096,20 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "1000m"
+        volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+        - name: github-token
+          mountPath: /var/secrets/github
+          readOnly: true
+      volumes:
+      - name: workspace
+        emptyDir:
+          sizeLimit: 2Gi
+      - name: github-token
+        secret:
+          secretName: agentex-github-token
+          defaultMode: 0400
 EOF
 ) || {
       log "CRITICAL: Fallback Job creation also failed for $name: $fallback_err"


### PR DESCRIPTION
## Summary

Fixes inconsistent GITHUB_TOKEN mount pattern between kro-created Jobs (agent-graph RGD) and fallback Jobs (entrypoint.sh workaround for issue #714).

## Problem

When kro controller fails to create a Job for an Agent CR, entrypoint.sh creates a fallback Job directly. However, this fallback Job used an inconsistent GITHUB_TOKEN mount:

**Before (inconsistent):**
- agent-graph RGD: `GITHUB_TOKEN_FILE` env var + file mount at `/var/secrets/github/token`
- Fallback Job: `GITHUB_TOKEN` env var from secretKeyRef (no volume mount)

This works because entrypoint.sh handles both patterns (lines 1649-1655), but violates the security principle from issue #6 (prefer file mounts over env vars for secrets).

## Changes

Updated fallback Job template in `images/runner/entrypoint.sh` lines 1088-1118 to match agent-graph RGD:

1. ✅ Changed `GITHUB_TOKEN` env var to `GITHUB_TOKEN_FILE=/var/secrets/github/token`
2. ✅ Added `volumeMounts` for workspace and github-token secret (readOnly: true)
3. ✅ Added `volumes` section with github-token secret (defaultMode: 0400)

**After (consistent):**
- Both patterns use `GITHUB_TOKEN_FILE` + secure file mount
- Fallback Jobs follow same security best practice as kro-created Jobs

## Testing

✅ Code review - template matches agent-graph.yaml lines 83-105
✅ Volume mounts align with RGD pattern (workspace + github-token)
✅ Security context preserved (readOnly: true, defaultMode: 0400)

## Impact

- **Risk**: Low - fallback Jobs are rare (only triggered when kro fails)
- **Security**: Improved - removes env var exposure of GitHub token in fallback Jobs
- **Consistency**: High - both Job creation paths now identical

## Related Issues

- Fixes #734
- Related to #714 (kro reconciliation failure)
- Related to #6 (secure secret mounts)

## Effort

S-effort (< 30 minutes)