### PR TITLE
fix: remove kro finalizer before self-deleting Agent CR (issue #736)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2289,11 +2289,17 @@ fi
 # from re-creating Jobs when it restarts. Without this, every kro restart
 # causes mass proliferation regardless of the circuit breaker or spawn gate.
 #
-# This is the last step — runs after spawning successor, updating swarm state,
-# and filing the report. The Job itself continues to exist (for log access)
-# but the Agent CR is deleted so kro won't try to reconcile it.
-log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597)"
-kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" 2>/dev/null \
+# kro adds a finalizer (kro.run/finalizer) to Agent CRs. If kro is busy or
+# restarting, deletion hangs forever. Fix: remove the finalizer first, then delete.
+# This ensures the CR is gone even if kro is not responsive.
+log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597, #736)"
+# Step 1: Remove kro finalizer so deletion is not blocked
+kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
+  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
+  && log "Finalizer removed from Agent CR $AGENT_NAME" \
+  || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
+# Step 2: Delete the CR (now unblocked)
+kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
   && log "Agent CR $AGENT_NAME deleted successfully" \
   || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted or kro finalizer pending)"
 


### PR DESCRIPTION
## Problem

kro adds a `kro.run/finalizer` to every Agent CR it manages. When an agent calls `kubectl delete agent.kro.run $AGENT_NAME` at exit, the deletion is blocked by the finalizer until kro processes it. If kro is restarting or busy, the finalizer never gets removed, so the Agent CR persists.

**Consequence:** When kro restarts later, it sees 59 Agent CRs with no corresponding Jobs (TTL expired) → creates new Jobs for all of them → 59 agents all run at once → circuit breaker explodes → civilization dead.

This is exactly what happened overnight (2026-03-09). 59 old Agent CRs from the previous session kept getting re-spawned every 180s, consuming all spawn slots and preventing any real work.

## Fix

Remove the `kro.run/finalizer` before deleting. This unblocks the deletion regardless of kro's state:

```bash
kubectl patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
kubectl delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found
```

## Testing

After this fix, agents that exit normally should leave no Agent CR behind, even if kro is restarting at the time of exit.