### PR TITLE
Fix issue #736: Add EXIT trap to ensure Agent CR cleanup on all exit paths

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -194,6 +194,40 @@ EOF
   fi
 }
 
+# ── EXIT trap: Agent CR self-cleanup (issue #736) ────────────────────────────
+# CRITICAL: Agent CRs must be deleted on ALL exits (success or failure) to prevent
+# kro from re-creating Jobs when they are cleaned up by TTL.
+#
+# Without this cleanup on every exit path, old Agent CRs accumulate and kro
+# continuously re-spawns them, consuming all spawn slots and preventing new work.
+#
+# This trap runs on ALL exits (exit 0, exit 1, script end), ensuring cleanup
+# happens regardless of how the script terminates.
+cleanup_agent_cr_on_exit() {
+  # Only run if we have a valid AGENT_NAME and kubectl is configured
+  # Use simple checks to avoid recursion/errors during cleanup
+  if [ -n "${AGENT_NAME:-}" ] && [ "$AGENT_NAME" != "unknown" ]; then
+    # Test if kubectl is available and cluster is reachable (fast timeout)
+    if timeout 5s kubectl cluster-info &>/dev/null 2>&1; then
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] EXIT trap: cleaning up Agent CR to prevent kro re-spawn (issue #736)" >&2
+      
+      # Step 1: Remove kro finalizer so deletion is not blocked
+      timeout 10s kubectl patch agent.kro.run "$AGENT_NAME" -n "${NAMESPACE:-agentex}" \
+        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
+        && echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Finalizer removed from Agent CR" >&2 \
+        || true  # May not have finalizer, or CR may already be deleted
+      
+      # Step 2: Delete the CR (now unblocked)
+      timeout 10s kubectl delete agent.kro.run "$AGENT_NAME" -n "${NAMESPACE:-agentex}" --ignore-not-found 2>/dev/null \
+        && echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Agent CR deleted successfully" >&2 \
+        || echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] WARNING: Could not delete Agent CR (may already be deleted)" >&2
+    fi
+  fi
+}
+
+# Register EXIT trap to cleanup Agent CR on all exit paths
+trap cleanup_agent_cr_on_exit EXIT
+
 # Register trap for ERR (but NOT EXIT - that would trigger on normal completion too)
 # Only trigger on errors, not on successful exits
 trap 'handle_fatal_error $? $LINENO' ERR
@@ -2463,23 +2497,16 @@ if [ "$AGENT_ROLE" = "planner" ]; then
   fi
 fi
 
-# ── 14. Self-cleanup: delete our own Agent CR (issue #597) ───────────────────
+# ── 14. Self-cleanup: Agent CR deletion (issue #597, #736) ───────────────────
 # CRITICAL: Agent CRs must be deleted after job completion to prevent kro
-# from re-creating Jobs when it restarts. Without this, every kro restart
-# causes mass proliferation regardless of the circuit breaker or spawn gate.
+# from re-creating Jobs when they are cleaned up by TTL.
 #
-# kro adds a finalizer (kro.run/finalizer) to Agent CRs. If kro is busy or
-# restarting, deletion hangs forever. Fix: remove the finalizer first, then delete.
-# This ensures the CR is gone even if kro is not responsive.
-log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597, #736)"
-# Step 1: Remove kro finalizer so deletion is not blocked
-kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
-  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
-  && log "Finalizer removed from Agent CR $AGENT_NAME" \
-  || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
-# Step 2: Delete the CR (now unblocked)
-kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
-  && log "Agent CR $AGENT_NAME deleted successfully" \
-  || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted or kro finalizer pending)"
+# This is now handled by the EXIT trap (cleanup_agent_cr_on_exit) registered
+# at the top of the script. The trap ensures cleanup happens on ALL exit paths
+# (exit 0, exit 1, early exits, errors, normal completion) - not just here.
+#
+# Before issue #736 fix, cleanup only happened if the script reached this line,
+# which meant early exits (circuit breaker, errors, etc.) left Agent CRs behind.
+# kro would then continuously re-spawn those old CRs, consuming all spawn slots.
 
-log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE"
+log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE (cleanup handled by EXIT trap)"


### PR DESCRIPTION
## Problem

Issue #736 identified that Agent CRs were not being deleted when agents exited early (circuit breaker, errors, validation failures). This caused kro to continuously re-spawn old Agent CRs after their Jobs were TTL-cleaned (180s), consuming all spawn slots and preventing new work.

**Overnight evidence (2026-03-09):**
- 59 old Agent CRs from before 05:00 UTC were still present at 14:30 UTC
- kro continuously re-spawned them → consumed all 12 circuit breaker slots
- No organic planner work could happen → civilization stuck in re-spawn loop

## Root Cause

The old self-cleanup code (step 14, line 2466) only ran if the script reached that point. Many exit paths bypassed it:
- Early circuit breaker exits (line 284): `exit 0`
- Validation failures (lines 205, 210): `exit 1`
- Cluster connectivity errors (line 226): `exit 1`
- Error trap exits (line 135): `exit $exit_code`

When agents exited via these paths, their Agent CRs remained. After 180s, the Job was TTL-cleaned but the Agent CR remained. kro saw an Agent CR with no Job → created a new Job → repeat forever.

## Solution

Added `cleanup_agent_cr_on_exit()` function registered with an EXIT trap. The EXIT trap catches ALL exits regardless of how/where the script terminates:
- Normal completion: `exit 0` at end of script
- Early exits: circuit breaker, validation failures, connectivity errors
- Error exits: ERR trap calling `exit 1`
- Abnormal termination: SIGTERM, SIGKILL (best effort)

The cleanup function:
1. Checks if AGENT_NAME is set and cluster is reachable (5s timeout)
2. Removes kro finalizer (prevents deletion hang if kro is busy)
3. Deletes the Agent CR
4. Uses fast timeouts and `|| true` to prevent trap recursion

## Testing

Syntax validation passed:
```bash
bash -n images/runner/entrypoint.sh
```

## Constitution Alignment

This change:
- ✅ Fixes critical bug without changing behavior (agents already should delete their CRs)
- ✅ Enforces existing constitution rules (circuit breaker, spawn control)
- ✅ Addresses root cause identified in god directive (lastDirective: "CRITICAL STRUCTURAL BUG")
- ✅ No expansion of agent autonomy - just fixes cleanup gap

## Files Modified

- `images/runner/entrypoint.sh` (PROTECTED FILE - requires `god-approved` label)

## Ready for God Review

This PR touches a protected file. Per the constitution's God-Approved Workflow:

1. ✅ Constitution alignment verified: Fixes critical bug, enforces circuit breaker
2. ✅ Reasoning documented: EXIT trap ensures cleanup on all exit paths
3. ✅ Links to issue: #736 (filed before 05:00 UTC)

**Ready for god review - constitution alignment verified**

Fixes #736