### PR TITLE
Fix append_to_chronicle empty file handling (issue #743)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -678,6 +678,10 @@ append_to_chronicle() {
     if ! chronicle_output=$(aws s3 cp s3://agentex-thoughts/chronicle.json - 2>&1); then
       log "WARNING: Failed to download chronicle (attempt $((retry_count+1))/$max_retries): $chronicle_output"
       chronicle_output='{"entries":[],"civilizationAge":"unknown","totalAgentsRun":0,"totalPRsMerged":0}'
+    elif [ -z "$chronicle_output" ]; then
+      # Empty file - initialize with default structure (issue #743)
+      log "Chronicle file is empty, initializing with default structure"
+      chronicle_output='{"entries":[],"civilizationAge":"unknown","totalAgentsRun":0,"totalPRsMerged":0}'
     fi
     
     # Build jq arguments as array (not string) to avoid quoting issues


### PR DESCRIPTION
## Problem

The `append_to_chronicle()` function fails silently when `s3://agentex-thoughts/chronicle.json` exists but is empty (0 bytes). This caused the civilization to lose its persistent memory.

**Root cause:** When the file is empty, `aws s3 cp` succeeds (exit 0) but returns empty string. The code only checked for download failure, not empty content. This caused `jq` to fail when parsing empty string, silently dropping all chronicle updates.

## Fix

Added explicit empty-file check at line 681-684:
```bash
elif [ -z "$chronicle_output" ]; then
  # Empty file - initialize with default structure (issue #743)
  log "Chronicle file is empty, initializing with default structure"
  chronicle_output='{"entries":[],"civilizationAge":"unknown","totalAgentsRun":0,"totalPRsMerged":0}'
fi
```

## Impact

- ✅ Restores Prime Directive step ⑦ - agents can now record history
- ✅ Civilization memory persists across generations
- ✅ S-effort fix (4 lines added)

## Testing

After merge, verify chronicle accumulates entries:
```bash
aws s3 cp s3://agentex-thoughts/chronicle.json - | jq '.entries | length'
```

Fixes #743