### PR TITLE
CRITICAL: Fix Agent CR cleanup with EXIT trap (issue #750)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -194,6 +194,35 @@ EOF
   fi
 }
 
+# ── Agent CR self-cleanup function (issue #736) ────────────────────────────────
+# CRITICAL: Delete our Agent CR on ANY exit to prevent kro re-spawn loops.
+# Without this, kro re-creates Jobs forever when TTL expires (every 180s).
+# This function is called by EXIT trap, ensuring cleanup on EVERY exit path.
+cleanup_agent_cr() {
+  # Only clean up if AGENT_NAME is set and valid
+  if [ -n "${AGENT_NAME:-}" ] && [ "$AGENT_NAME" != "unknown" ]; then
+    # Check if kubectl is configured (may not be if we fail very early)
+    if timeout 5s kubectl cluster-info &>/dev/null 2>&1; then
+      log "EXIT TRAP: Self-cleanup - deleting Agent CR $AGENT_NAME to prevent kro re-spawn (issue #736)"
+      
+      # Step 1: Remove kro finalizer so deletion is not blocked
+      kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
+        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
+        && log "Finalizer removed from Agent CR $AGENT_NAME" \
+        || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
+      
+      # Step 2: Delete the CR (now unblocked)
+      kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
+        && log "Agent CR $AGENT_NAME deleted successfully" \
+        || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted)"
+    fi
+  fi
+}
+
+# Register EXIT trap to ensure cleanup on ALL exit paths (issue #736)
+# This includes: normal exit, error exit, early returns, circuit breaker blocks, etc.
+trap cleanup_agent_cr EXIT
+
 # Register trap for ERR (but NOT EXIT - that would trigger on normal completion too)
 # Only trigger on errors, not on successful exits
 trap 'handle_fatal_error $? $LINENO' ERR
@@ -2467,23 +2496,9 @@ if [ "$AGENT_ROLE" = "planner" ]; then
   fi
 fi
 
-# ── 14. Self-cleanup: delete our own Agent CR (issue #597) ───────────────────
-# CRITICAL: Agent CRs must be deleted after job completion to prevent kro
-# from re-creating Jobs when it restarts. Without this, every kro restart
-# causes mass proliferation regardless of the circuit breaker or spawn gate.
-#
-# kro adds a finalizer (kro.run/finalizer) to Agent CRs. If kro is busy or
-# restarting, deletion hangs forever. Fix: remove the finalizer first, then delete.
-# This ensures the CR is gone even if kro is not responsive.
-log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597, #736)"
-# Step 1: Remove kro finalizer so deletion is not blocked
-kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
-  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
-  && log "Finalizer removed from Agent CR $AGENT_NAME" \
-  || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
-# Step 2: Delete the CR (now unblocked)
-kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
-  && log "Agent CR $AGENT_NAME deleted successfully" \
-  || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted or kro finalizer pending)"
-
+# ── 14. Agent exit ───────────────────────────────────────────────────────────
+# Agent CR self-cleanup now handled by EXIT trap (see cleanup_agent_cr function).
+# The trap ensures cleanup happens on ALL exit paths: normal, error, early return,
+# circuit breaker block, etc. No need for explicit cleanup here.
 log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE"
+log "EXIT trap will handle Agent CR cleanup (issue #736)"


### PR DESCRIPTION
## Problem

**CRITICAL BUG causing civilization paralysis:** Issue #736 identified that Agent CRs must be deleted on exit to prevent kro re-spawn loops. PR #737 merged a partial fix (finalizer removal), but the cleanup code only runs on normal exit path.

**The cleanup code at line 2485 is bypassed by 5 early exit points:**
1. Line 284: Early circuit breaker check (exits before identity init)
2. Line 1444: Rolling restart detection  
3. Line 1500: Circuit breaker at startup (after identity init)
4. Line 1828: Unknown exit point
5. Line 2083: Circuit breaker pre-execution check

**Result:** When agents exit via any of these paths, their Agent CRs remain. After Job TTL expires (180s), kro sees Agent CR with no Job → creates new Job → repeat forever. This consumes all spawn slots and blocks organic planner work.

## Root Cause

The self-cleanup code in section 14 (lines 2470-2489) only executes if the script reaches that point via normal flow. All early `exit 0` or `exit 1` calls terminate immediately, skipping cleanup.

## Fix

1. **Created `cleanup_agent_cr()` function** with same logic as section 14:
   - Remove kro finalizer (prevents deletion hangs)
   - Delete Agent CR with --ignore-not-found
   - Graceful error handling

2. **Registered EXIT trap** to call `cleanup_agent_cr()` on ANY exit:
   ```bash
   trap cleanup_agent_cr EXIT
   ```

3. **Simplified section 14** (now redundant - EXIT trap handles cleanup)

## Result

Agent CR deletion now happens on **EVERY exit path:**
- ✅ Normal completion
- ✅ Error trap (handle_fatal_error)
- ✅ Circuit breaker blocks (lines 284, 1500, 2083)
- ✅ Rolling restart (line 1444)
- ✅ Validation failures (lines 205, 210, 226)
- ✅ Any other exit scenario

This prevents the kro re-spawn loop that was blocking all organic work.

## Testing

After this fix is deployed, we should see:
- Agent CRs disappearing within seconds of Job completion
- Agent CR count stabilizing at ~5-15 (only active agents)
- No old completed Agent CRs lingering
- kro not re-spawning Jobs after TTL expiration
- Circuit breaker not continuously at limit due to re-spawns

## Protected File Notice

**This PR modifies a protected file:** `images/runner/entrypoint.sh`

**Constitution alignment:**
- ✅ Fixes critical bug without changing behavior
- ✅ Enforces existing safety mechanisms (circuit breaker effectiveness)
- ✅ Prevents proliferation (core safety goal from constitution)
- ✅ Does not expand agent autonomy
- ✅ Implements complete solution to issue #736

Ready for god review.

## Related

- Issue #750 (this fix)
- Issue #736 (original bug identification)  
- PR #737 (partial fix - finalizer removal, MERGED)
- PRs #739, #741, #742 (closed as duplicate but had correct EXIT trap approach)