### PR TITLE
fix: Use EXIT trap to ensure Agent CR cleanup on all exit paths (issue #750)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -194,6 +194,42 @@ EOF
   fi
 }
 
+# ── Cleanup function for EXIT trap (issue #750) ──────────────────────────────
+# This function MUST run on ALL exit paths (normal, error, early return) to
+# prevent kro re-spawn loops. Without this, agents that exit early (circuit
+# breaker, rolling restart, etc.) leave orphaned Agent CRs that kro re-spawns.
+cleanup_agent_cr_on_exit() {
+  local exit_code=$?
+  
+  # Skip cleanup if AGENT_NAME not set (very early failure before env validation)
+  if [ -z "$AGENT_NAME" ]; then
+    return 0
+  fi
+  
+  log "EXIT trap: cleaning up Agent CR $AGENT_NAME (exit_code=$exit_code)"
+  
+  # Step 1: Remove kro finalizer so deletion is not blocked
+  # kro adds kro.run/finalizer to Agent CRs. If kro is busy/restarting,
+  # deletion hangs forever. Removing finalizer ensures CR is deleted
+  # even if kro is not responsive (issue #736, #750)
+  kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
+    --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
+    && log "Finalizer removed from Agent CR $AGENT_NAME" \
+    || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
+  
+  # Step 2: Delete the CR (now unblocked)
+  kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
+    && log "Agent CR $AGENT_NAME deleted successfully" \
+    || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted)"
+  
+  log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE ExitCode=$exit_code"
+}
+
+# Register EXIT trap to ensure Agent CR cleanup on ALL exit paths
+# This fires on: normal exit, error exit, early return, SIGTERM
+# Does NOT fire on: SIGKILL (but that's rare and non-graceful anyway)
+trap cleanup_agent_cr_on_exit EXIT
+
 # Register trap for ERR (but NOT EXIT - that would trigger on normal completion too)
 # Only trigger on errors, not on successful exits
 trap 'handle_fatal_error $? $LINENO' ERR
@@ -2467,23 +2503,17 @@ if [ "$AGENT_ROLE" = "planner" ]; then
   fi
 fi
 
-# ── 14. Self-cleanup: delete our own Agent CR (issue #597) ───────────────────
-# CRITICAL: Agent CRs must be deleted after job completion to prevent kro
-# from re-creating Jobs when it restarts. Without this, every kro restart
-# causes mass proliferation regardless of the circuit breaker or spawn gate.
+# ── 14. Self-cleanup: handled by EXIT trap (issue #750) ──────────────────────
+# Agent CR cleanup is now handled by cleanup_agent_cr_on_exit() EXIT trap
+# (registered at line ~197). This ensures cleanup happens on ALL exit paths,
+# not just normal script completion. See issue #750 for details.
 #
-# kro adds a finalizer (kro.run/finalizer) to Agent CRs. If kro is busy or
-# restarting, deletion hangs forever. Fix: remove the finalizer first, then delete.
-# This ensures the CR is gone even if kro is not responsive.
-log "Self-cleanup: deleting Agent CR $AGENT_NAME to prevent kro re-proliferation (issue #597, #736)"
-# Step 1: Remove kro finalizer so deletion is not blocked
-kubectl_with_timeout 10 patch agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" \
-  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null \
-  && log "Finalizer removed from Agent CR $AGENT_NAME" \
-  || log "WARNING: Could not remove finalizer from $AGENT_NAME (may not have one)"
-# Step 2: Delete the CR (now unblocked)
-kubectl_with_timeout 10 delete agent.kro.run "$AGENT_NAME" -n "$NAMESPACE" --ignore-not-found 2>/dev/null \
-  && log "Agent CR $AGENT_NAME deleted successfully" \
-  || log "WARNING: Could not delete Agent CR $AGENT_NAME (may already be deleted or kro finalizer pending)"
-
-log "Agent exiting. Task=$TASK_CR_NAME Role=$AGENT_ROLE"
+# The EXIT trap was necessary because there are 5 early exit points that
+# bypassed the cleanup code that was here:
+#   - Line 284: Circuit breaker check
+#   - Line 1444: Rolling restart detection
+#   - Line 1500: Circuit breaker at startup
+#   - Line 1828: Unknown exit
+#   - Line 2083: Circuit breaker pre-execution
+#
+# With the EXIT trap, all of these paths now properly clean up the Agent CR.


### PR DESCRIPTION
## Problem

Issue #736 identified that Agent CRs must be deleted when agents exit to prevent kro re-spawn loops. PR #737 merged a fix that removes the finalizer before deletion.

**However, the fix is INCOMPLETE.** The cleanup code only ran if the script reached the end naturally. There are 5 early exit points that bypassed cleanup:

1. Line 284: Circuit breaker check (exits before identity init)
2. Line 1444: Rolling restart detection
3. Line 1500: Circuit breaker at startup (after identity init)
4. Line 1828: Unknown exit
5. Line 2083: Circuit breaker pre-execution check

## Evidence

Cluster currently has 20+ Agent CRs from 9+ hours ago that should have been deleted. Active jobs: 15 (limit: 12). System is overloaded due to kro re-spawning old agents.

## Solution

Use an EXIT trap to ensure cleanup happens on ALL exit paths (normal, error, early return). The trap fires on any exit except SIGKILL.

## Changes

1. Added `cleanup_agent_cr_on_exit()` function (lines ~197-230)
2. Registered EXIT trap: `trap cleanup_agent_cr_on_exit EXIT`
3. Removed duplicate cleanup code from section 14 (now handled by trap)

## Testing

After deployment:
- Old Agent CRs should disappear within seconds of Job completion
- Agent CR count should stabilize at ~5-15 (active agents only)
- kro should not re-spawn old agents when Jobs TTL out

## Related

- Issue #736 (original bug identification)
- PR #737 (partial fix - finalizer removal, but no EXIT trap)
- Issue #750 (this PR completes the fix)

Fixes #750