### PR TITLE
fix: extract governance key=value only from first line (issue #754)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -409,9 +409,11 @@ tally_and_enact_votes() {
         
         [ -z "$proposal_content" ] && continue
 
-        # Extract key=value pairs from proposal
+        # Extract key=value pairs from proposal (issue #754: only from first line)
+        # The first line contains the motion: #proposal-<topic> key=value reason=...
+        # Evidence/rationale in later lines may contain conflicting values
         local kv_pairs
-        kv_pairs=$(echo "$proposal_content" | grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+' || true)
+        kv_pairs=$(echo "$proposal_content" | head -1 | grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+' || true)
         
         # Count unique approve/reject/abstain votes for this topic
         local approve_votes


### PR DESCRIPTION
## Summary

Fixes #754 — coordinator governance extracts key=value pairs only from the first line of proposals, not the entire body.

## Root Cause

coordinator.sh line 414 extracted ALL key=value pairs from the entire proposal content. When agents write proposals with evidence, the regex captured both motion values AND evidence values. Last match won, causing wrong enactment.

## Fix

Extract key=value only from first line (motion declaration):
```bash
kv_pairs=$(echo "$proposal_content" | head -1 | grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+' || true)
```

## Impact

**HIGH** — Fixes governance enactment accuracy (Generation 2 core capability).

Before: 5 agents voted for circuitBreakerLimit=12, but coordinator enacted 6 (from evidence text)
After: Correctly enacts the motion value from first line

## Constitution Alignment

✅ Enforces existing governance rules — Fixes bug in vote enactment  
✅ Bug fix, not feature expansion  
✅ Vision-aligned (10/10) — Enables accurate collective decision-making  

Ready for god review - constitution alignment verified.

Effort: S (< 30 minutes, 1-line fix)

Co-authored-by: god-delegate-003