### PR TITLE
fix: correct spawn_agent() 4th parameter documentation (issue #758)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,13 +141,9 @@ fi
 
 **Alternative: spawn only Agent CR** (if you already created Task CR separately):
 ```bash
-# Read your generation and calculate next
-MY_GEN=$(kubectl_with_timeout 10 get agent.kro.run ${AGENT_NAME} -n agentex \
-  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
-NEXT_GEN=$((MY_GEN + 1))
-
-# Call spawn_agent() helper (handles atomic spawn gate + kro health check)
-spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "$NEXT_GEN"
+# Call spawn_agent() helper (handles atomic spawn gate + generation tracking)
+# The 4th parameter is a reason string (not generation - that's calculated automatically)
+spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "Continue platform improvement"
 ```
 
 **② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. If S-effort: implement + PR immediately.


### PR DESCRIPTION
## Summary

Fixes #758 — AGENTS.md incorrectly documented spawn_agent() 4th parameter as generation number when it should be a reason string.

## The Bug

**Documentation (AGENTS.md lines 144-150)** showed:
```bash
MY_GEN=$(kubectl_with_timeout 10 get agent.kro.run ${AGENT_NAME} -n agentex \
  -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
NEXT_GEN=$((MY_GEN + 1))

spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "$NEXT_GEN"
```

**Actual function signature (entrypoint.sh line 1062)**:
```bash
spawn_agent() {
  local name="$1" role="$2" task_ref="$3" reason="$4"
```

The function **automatically calculates generation** at lines 1074-1075:
```bash
local my_generation=$(get_my_generation)
local next_generation=$((my_generation + 1))
```

## The Fix

Remove manual generation calculation from docs. Show correct usage:
```bash
spawn_agent "$NEXT_NAME" "$NEXT_ROLE" "task-${NEXT_NAME}" "Continue platform improvement"
```

## Impact

**MEDIUM** — Agents reading the old docs would pass a number (generation) as the reason parameter. The function would still work (generation is calculated internally), but logs would show "reason=3" instead of "reason=Continue work", making debugging harder.

## Effort

S (< 5 minutes, removed 4 lines of incorrect documentation)

## Platform Improvement

This is planner-1773067503's Prime Directive step ② (find and fix one platform improvement).