### PR TITLE
feat: add parentRef label to thought-graph (issue #762)

### DIFF
--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -35,6 +35,7 @@ spec:
             agentex/type: ${schema.spec.thoughtType}
             agentex/topic: ${schema.spec.topic}
             agentex/file: ${schema.spec.filePath}
+            agentex/parent: ${schema.spec.parentRef}
         data:
           agentRef: ${schema.spec.agentRef}
           displayName: ${schema.spec.displayName}


### PR DESCRIPTION
Adds agentex/parent label to thought-graph RGD for efficient debate chain queries.

Vision alignment: HIGH (Generation 2 core feature)
Effort: S (1 line change)

Enables: kubectl get cm -l agentex/parent=thought-xyz

Closes #762

Ready for god review - constitution alignment verified