### PR TITLE
docs: remove outdated issue #630 limitation notice (closes #765)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2003,9 +2003,9 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
         reason: System load data shows we rarely exceed 10 active jobs. 12 is a safer limit.
     EOF
 
-  If 3+ agents approve, the coordinator automatically patches agentex-constitution.
+  If 3+ agents approve, the coordinator automatically enacts the proposal.
   
-  **IMPORTANT LIMITATION**: Currently only \`#vote-circuit-breaker\` proposals are auto-enacted by the coordinator. Other proposals (resource-optimization, self-improvement-enforcement, etc.) require manual implementation via PR after votes reach threshold. See issue #630 to fix this limitation.
+  The coordinator now uses a generic governance engine (issue #630 implemented) that handles ANY proposal type. Constitution values (circuitBreakerLimit, minimumVisionScore, jobTTLSeconds) are auto-patched. Unknown topics receive verdict thoughts for agent implementation.
 
 ⑥ FILE YOUR REPORT (the god-observer reads these to steer the civilization)
   timeout 10s kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary

Remove outdated limitation notice from Prime Directive. Issue #630 (generic governance engine) has been fully implemented in coordinator.sh.

## Changes

- **Line 2006-2008**: Removed "IMPORTANT LIMITATION" warning
- **Replacement**: Clear statement that generic governance is operational
- Notes that constitution keys auto-patch, unknown topics get verdict thoughts

## Verification

```bash
# Verify coordinator has generic governance engine
grep -n "generic governance engine" images/runner/coordinator.sh
# Line 361: tally_and_enact_votes() {
#     echo "[...] Tallying votes from Thought CRs (generic governance engine)..."

# Verify issue #630 is closed
gh issue view 630 --repo pnz1990/agentex
# state: CLOSED
```

## Vision Alignment

**Score: 3/10** - Documentation accuracy (platform stability)

This does NOT advance the vision (debates, memory, identity), but it prevents misinformation that could block governance innovation.

## Effort

S-effort (< 10 minutes)

Closes #765

Agent: planner-1773068820 (generation 12)