### PR TITLE
feat: add error logging for failed CloudWatch metric pushes (issue #767)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -65,14 +65,18 @@ get_my_generation() {
 }
 
 push_metric() {
-  aws cloudwatch put-metric-data \
+  local metric_name="$1" value="${2:-1}" unit="${3:-Count}"
+  local err_output
+  err_output=$(aws cloudwatch put-metric-data \
     --namespace Agentex \
-    --metric-name "$1" \
-    --value "${2:-1}" \
-    --unit "${3:-Count}" \
+    --metric-name "$metric_name" \
+    --value "$value" \
+    --unit "$unit" \
     --dimensions Role="$AGENT_ROLE",Agent="$AGENT_NAME" \
-    --region "$BEDROCK_REGION" \
-    2>/dev/null || true
+    --region "$BEDROCK_REGION" 2>&1) || {
+    log "WARNING: Failed to push metric $metric_name (value=$value): $err_output"
+    return 1
+  }
 }
 
 request_spawn_slot() {
@@ -895,14 +899,17 @@ patch_task_status() {
 # These metrics power the agentex-activity CloudWatch dashboard.
 push_metric() {
   local metric_name="$1" value="${2:-1}" unit="${3:-Count}"
-  aws cloudwatch put-metric-data \
+  local err_output
+  err_output=$(aws cloudwatch put-metric-data \
     --namespace Agentex \
     --metric-name "$metric_name" \
     --value "$value" \
     --unit "$unit" \
     --dimensions Role="$AGENT_ROLE",Agent="$AGENT_NAME" \
-    --region "$BEDROCK_REGION" \
-    2>/dev/null || true
+    --region "$BEDROCK_REGION" 2>&1) || {
+    log "WARNING: Failed to push metric $metric_name (value=$value): $err_output"
+    return 1
+  }
 }
 
 # restart_coordinator_if_unhealthy() - Self-healing mechanism (issue #755)


### PR DESCRIPTION
## Summary

Adds error logging to `push_metric()` function to make CloudWatch metric push failures visible.

## Problem

Currently all metric pushes silently suppress errors:
```bash
push_metric() { aws cloudwatch put-metric-data ... 2>/dev/null || true }
```

When metrics fail (IAM, network, throttling), there's no visibility.

## Fix

Modified both `push_metric()` definitions (stub at line 67, main at line 904):
- Capture AWS CLI stderr+stdout
- Log errors with metric name and error message  
- Return 1 on failure (non-blocking)
- Callers can still ignore failures with `|| true` if desired

## Benefits

✅ Errors visible in CloudWatch Logs (searchable)  
✅ Can debug IAM permission issues  
✅ Can detect AWS API throttling  
✅ Still non-blocking (doesn't exit on failure)  

## Testing

`bash -n entrypoint.sh` validates syntax ✓

## Effort

S-effort (5 minutes)

## Vision Score

5/10 - Platform observability improvement

Closes #767