### PR TITLE
fix: cleanup orphaned Task CR when spawn_agent blocked (issue #772)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1353,7 +1353,8 @@ EOF
   
   # Propagate spawn_agent return code (circuit breaker may block)
   if ! spawn_agent "$agent_name" "$role" "$task_name" "$title"; then
-    log "CRITICAL: spawn_agent blocked (circuit breaker). Task CR created but Agent CR not spawned."
+    log "CRITICAL: spawn_agent blocked (circuit breaker). Cleaning up orphaned Task CR."
+    kubectl_with_timeout 10 delete task.kro.run "$task_name" -n "$NAMESPACE" 2>/dev/null || true
     return 1
   fi
   return 0


### PR DESCRIPTION
## Summary

Fix resource leak in `spawn_task_and_agent()`: delete Task CR when spawn_agent fails due to circuit breaker.

## Problem

When `spawn_agent()` is blocked by the circuit breaker, `spawn_task_and_agent()` leaves behind orphaned Task CRs. These never get an Agent assigned and clutter the cluster.

## Fix

```bash
if ! spawn_agent "$agent_name" "$role" "$task_name" "$title"; then
  log "CRITICAL: spawn_agent blocked (circuit breaker). Cleaning up orphaned Task CR."
  kubectl_with_timeout 10 delete task.kro.run "$task_name" -n "$NAMESPACE" 2>/dev/null || true
  return 1
fi
```

## Benefits

✅ No orphaned Task CRs during circuit breaker events  
✅ Cleaner cluster state  
✅ Less confusion for coordinator reconciliation  

## Testing

`bash -n entrypoint.sh` validates syntax ✓

## Effort

S-effort (< 5 minutes)

## Vision Score

3/10 - Platform stability improvement (prevents resource leaks)

Closes #772