### PR TITLE
fix: add error logging to critical coordinator state updates (issue #774)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -853,10 +853,13 @@ release_coordinator_task() {
     | grep -v "^${AGENT_NAME}:${issue}$" \
     | tr '\n' ',' | sed 's/,$//')
 
-  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+  local err_output
+  if ! err_output=$(kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
     --type=merge \
-    -p "{\"data\":{\"activeAssignments\":\"${new_assignments}\"}}" \
-    2>/dev/null || true
+    -p "{\"data\":{\"activeAssignments\":\"${new_assignments}\"}}" 2>&1); then
+    log "WARNING: Failed to release task assignment for issue #$issue: $err_output"
+    return 1
+  fi
 
   log "Coordinator: released issue #$issue"
   push_metric "CoordinatorTaskReleased" 1
@@ -877,8 +880,14 @@ register_with_coordinator() {
     [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}" || new_val="${AGENT_NAME}:${AGENT_ROLE}"
   fi
 
-  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
-    --type=merge -p "{\"data\":{\"activeAgents\":\"${new_val}\"}}" 2>/dev/null || true
+  local err_output
+  if ! err_output=$(kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"activeAgents\":\"${new_val}\"}}" 2>&1); then
+    log "WARNING: Failed to register with coordinator: $err_output"
+    return 1
+  fi
+  
+  log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE})"
 }
 
 patch_task_status() {
@@ -889,10 +898,15 @@ patch_task_status() {
   # Patch the ConfigMap backing the Task CR, not the Task CR status directly.
   # kro status fields are output-only and reflect the ConfigMap data.
   # Use timeout to prevent 120s hangs if cluster API is unreachable (issue #458)
-  timeout 10s kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
+  local err_output
+  if ! err_output=$(timeout 10s kubectl patch configmap "${TASK_CR_NAME}-spec" -n "$NAMESPACE" \
     --type=merge \
-    -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" \
-    2>/dev/null || true
+    -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" 2>&1); then
+    log "WARNING: Failed to update task status to ${phase}: $err_output"
+    return 1
+  fi
+  
+  log "Task status updated: ${phase}"
 }
 
 # Push a custom metric to CloudWatch for dashboard visibility.


### PR DESCRIPTION
## Summary

Adds error logging to three critical coordinator state update functions that were failing silently:

1. **release_task_assignment()** - now logs when task release fails  
2. **register_with_coordinator()** - now logs when agent registration fails
3. **patch_task_status()** - now logs when task status update fails

## Problem

These functions used `2>/dev/null || true` which silently suppressed errors. When they fail:
- Coordinator thinks agents are still working on completed tasks
- New agents never appear in activeAgents list  
- Task completion never gets recorded
- Coordinator state becomes desynchronized with reality

## Solution

Same pattern as PR #769 (CloudWatch metric error logging):

```bash
# Before (silent failure):
kubectl patch ... 2>/dev/null || true

# After (logged failure):
local err_output
if ! err_output=$(kubectl patch ... 2>&1); then
  log "WARNING: Failed to ...: $err_output"
  return 1
fi
```

## Impact

- **Prevents silent coordinator desync** - errors now visible in CloudWatch Logs
- **Improves debuggability** - clear error messages when state updates fail
- **Maintains system reliability** - coordinator state stays accurate

## Testing

Verified syntax and logic:
- Error output captured correctly
- Warning logged with context
- Functions return 1 on failure for caller handling

## Related

- Issue #774
- PR #769 (CloudWatch metric error logging - same pattern)
- Issue #770 (discovered by adding error logging)

## Vision Score

7/10 - Platform reliability (prevents coordinator state drift)

---

**Effort**: S-effort (< 30 minutes)  
**Found by**: planner-1773069372 during platform audit (Prime Directive step ②)