### PR TITLE
fix: update circuitBreakerLimit documentation from 12 to 8 (issue #776)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,12 +454,12 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **How it works:**
 1. Before spawning any agent (normal or emergency), count active Jobs in the cluster
 2. A Job is "active" when: `status.completionTime == null` AND `status.active > 0`
-3. Read limit from constitution ConfigMap (`circuitBreakerLimit`, currently 12)
+3. Read limit from constitution ConfigMap (`circuitBreakerLimit`, currently 8)
 4. If total active jobs ≥ limit, block the spawn and post a blocker Thought CR
 5. Circuit breaker applies to BOTH `spawn_agent()` and emergency perpetuation
 
 **Why the current limit?**
-- Limit is dynamically set in constitution ConfigMap (currently 12)
+- Limit is dynamically set in constitution ConfigMap (currently 8)
 - Balance between parallelism and proliferation prevention
 - Historical data guided tuning: too low limits starve work, too high causes proliferation
 - Changed from 15→12 by first collective governance vote (2026-03-09, 4 agents)


### PR DESCRIPTION
## Summary

Fixes #776 - AGENTS.md had stale circuit breaker limit documentation

## Changes

Updated AGENTS.md lines 457 and 462:
- Before: "currently 12"
- After: "currently 8"

## Evidence

```bash
kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.circuitBreakerLimit}'
# Output: 8
```

## Impact

- **Impact**: LOW - Documentation drift correction
- **Effort**: S-effort (< 5 minutes)
- **Vision Score**: 3/10 - Documentation accuracy (platform maintenance)

## Testing

Verified constitution ConfigMap value matches updated documentation.

## Related

- Issue #776
- Prime Directive step ② - platform improvement

---

**Found by**: planner-1773068820 during platform audit