### PR TITLE
fix: auto-update coordinator with SHA-tagged images after builds (issue #768)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -61,3 +61,17 @@ jobs:
         run: |
           docker push $ECR_REGISTRY/$ECR_REPO:${{ github.sha }}
           docker push $ECR_REGISTRY/$ECR_REPO:latest
+
+      - name: Update coordinator image to SHA tag
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Configure kubectl to access EKS cluster
+          aws eks update-kubeconfig --name agentex --region ${{ env.AWS_REGION }}
+          
+          # Update Coordinator CR spec to use new SHA tag (kro will propagate to deployment)
+          kubectl patch coordinator coordinator -n agentex \
+            --type=merge \
+            -p '{"spec":{"imageTag":"'"${{ github.sha }}"'"}}'
+          
+          echo "Coordinator CR updated to use imageTag: ${{ github.sha }}"
+          echo "kro will automatically update the deployment with new image: $ECR_REGISTRY/$ECR_REPO:${{ github.sha }}"

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       enabled: boolean | default=true
       model: string | default="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      imageTag: string | default="latest"
     status:
       configMapName: ${coordinatorState.metadata.name}
       phase: ${coordinatorState.data.phase}
@@ -76,7 +77,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}
                   imagePullPolicy: Always
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
                   securityContext:


### PR DESCRIPTION
## Summary
- Fixes coordinator not updating after PR merges (issue #768)
- Adds automatic SHA-tag image updates via GitHub Actions workflow
- Adds `imageTag` field to Coordinator CR spec

## Problem
PR #756 merged with critical governance fix (issue #754), GitHub Actions built new image successfully, but coordinator pods still running old code. Root cause: EKS caching `:latest` tag images.

## Solution
1. **Added `imageTag` field to Coordinator CR spec** (default: `latest`)
2. **Updated coordinator-graph.yaml** to use `${schema.spec.imageTag}` in image reference
3. **Added workflow step** to patch Coordinator CR with SHA tag after image push
4. **kro automatically updates deployment** when CR spec changes

## How It Works
After each merge to main:
1. GitHub Actions builds image with commit SHA tag
2. Pushes to ECR with both SHA and `:latest` tags
3. **NEW**: Patches `coordinator` CR `spec.imageTag` to commit SHA
4. kro detects CR change and updates deployment with new image
5. New coordinator pod runs latest code

## Testing Plan
1. Merge this PR
2. Wait for GitHub Actions build to complete
3. Check coordinator pod has new SHA-tagged image
4. Verify coordinator code includes PR #756 fix (line 417 has `head -1`)

## Impact
- **Fixes**: Issue #754 governance bug now actually deployed
- **Prevents**: Future stale coordinator image issues
- **Vision Score**: 7/10 (platform deployment reliability)

## Changes
- `.github/workflows/build-runner.yml`: added step to patch Coordinator CR after image push
- `manifests/rgds/coordinator-graph.yaml`: added `imageTag` spec field, updated image reference to use it