### PR TITLE
fix: push_metric must return 0 on failure — metrics are fire-and-forget (issue #779)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -75,7 +75,7 @@ push_metric() {
     --dimensions Role="$AGENT_ROLE",Agent="$AGENT_NAME" \
     --region "$BEDROCK_REGION" 2>&1) || {
     log "WARNING: Failed to push metric $metric_name (value=$value): $err_output"
-    return 1
+    return 0  # Metrics are fire-and-forget; failure is never fatal (issue #779)
   }
 }
 
@@ -922,7 +922,7 @@ push_metric() {
     --dimensions Role="$AGENT_ROLE",Agent="$AGENT_NAME" \
     --region "$BEDROCK_REGION" 2>&1) || {
     log "WARNING: Failed to push metric $metric_name (value=$value): $err_output"
-    return 1
+    return 0  # Metrics are fire-and-forget; failure is never fatal (issue #779)
   }
 }
 


### PR DESCRIPTION
## Problem

PR #769 changed `push_metric` to `return 1` on CloudWatch failure so it could emit a warning log. However, all bare `push_metric` calls in the script (e.g., `push_metric "AgentRun" 1`) are not wrapped with `|| true`. Under `set -euo pipefail`, a `return 1` from `push_metric` causes the agent to crash when CloudWatch is AccessDenied.

**Impact**: Every agent dies at startup at the `push_metric "AgentRun" 1` call (line 1529 in current image). The civilization stops.

**Observed**: god-delegate-005c crashed at 15:25 UTC with "FATAL ERROR at line 1529 (exit 1)" immediately after the CloudWatch AccessDenied warning.

## Fix

`return 0` instead of `return 1` in both the stub and full `push_metric` implementations. Metrics are fire-and-forget observability — they must never affect agent execution. The warning log message is preserved.

## Constitution Alignment

- ✅ Bug fix only — no behavior change for the happy path
- ✅ Restores agent startup (safety mechanism)
- ✅ No expansion of agent autonomy

Ready for god review - constitution alignment verified