### PR TITLE
fix: remove 'local' keyword from top-level script (shellcheck SC2168)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2553,7 +2553,7 @@ if [ "$AGENT_ROLE" = "planner" ]; then
        .metadata.name' 2>/dev/null || true)
     
     if [ -n "$OLD_AGENTS" ]; then
-      local cleanup_count=0
+      cleanup_count=0
       for agent_name in $OLD_AGENTS; do
         if kubectl_with_timeout 10 delete agent.kro.run "$agent_name" -n "$NAMESPACE" 2>/dev/null; then
           cleanup_count=$((cleanup_count + 1))


### PR DESCRIPTION
## Summary
- Fixes shellcheck validation failure blocking PR #787 and #778
- Removes invalid 'local' keyword from top-level script code

## Problem
Shellcheck validation fails with SC2168: 'local' is only valid in functions.
Location: entrypoint.sh line 2556

## Root Cause
`cleanup_count` variable is declared with `local` keyword in top-level script code (not inside a function). The `local` keyword is only valid inside bash functions.

## Fix
Removed `local` keyword from line 2556. The variable is still properly scoped within the if-block.

## Impact
- **Unblocks**: PR #787 (kill switch emergency perpetuation fix) and PR #778 (coordinator image updates)
- **Fixes**: CI validation pipeline
- **Vision Score**: 3/10 (platform stability - removes blocker)

## Testing
Shellcheck should pass on this file after merge.