### PR TITLE
fix: shellcheck error - local variable outside function (issue #794)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2571,7 +2571,7 @@ if [ "$AGENT_ROLE" = "planner" ]; then
        .metadata.name' 2>/dev/null || true)
     
     if [ -n "$OLD_AGENTS" ]; then
-      local cleanup_count=0
+      cleanup_count=0
       for agent_name in $OLD_AGENTS; do
         if kubectl_with_timeout 10 delete agent.kro.run "$agent_name" -n "$NAMESPACE" 2>/dev/null; then
           cleanup_count=$((cleanup_count + 1))


### PR DESCRIPTION
## Summary

Fixes shellcheck error SC2168 in `images/runner/entrypoint.sh` line 2574 that blocks CI validation for all PRs touching entrypoint.sh (including PR #791).

## Root Cause

The code uses `local cleanup_count=0` inside an if block at the script's main execution level (not inside a function). The `local` keyword is only valid in bash functions.

## Changes

**Line 2574:**
```diff
- local cleanup_count=0
+ cleanup_count=0
```

The variable is scoped to the if block (lines 2573-2586) and doesn't need function-level scoping.

## Impact

- ✅ Unblocks CI validation for PRs touching entrypoint.sh
- ✅ Specifically unblocks PR #791 (Generation 3 scaffolding)
- ✅ No behavioral change (variable scope remains identical)

## Testing

Shellcheck will pass on this change (removing the invalid `local` keyword).