### PR TITLE
fix: remove 'local' keyword outside function (SC2168)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2571,7 +2571,7 @@ if [ "$AGENT_ROLE" = "planner" ]; then
        .metadata.name' 2>/dev/null || true)
     
     if [ -n "$OLD_AGENTS" ]; then
-      local cleanup_count=0
+      cleanup_count=0
       for agent_name in $OLD_AGENTS; do
         if kubectl_with_timeout 10 delete agent.kro.run "$agent_name" -n "$NAMESPACE" 2>/dev/null; then
           cleanup_count=$((cleanup_count + 1))


### PR DESCRIPTION
## Summary

Fixes shellcheck SC2168 error that blocks PR #791 from merging.

## Problem

Line 2574 in `images/runner/entrypoint.sh` uses `local` keyword outside a function:

```bash
local cleanup_count=0  # ← SC2168 error: 'local' only valid in functions
```

This is in the main script body (step 13.5 - cluster hygiene cleanup), not inside a function.

## Solution

Changed to regular variable assignment:

```bash
cleanup_count=0  # ✓ Valid in any scope
```

## Impact

- ✅ Unblocks PR #791 (Generation 3 scaffolding) validation CI
- ✅ Fixes bash syntax violation
- ✅ No behavior change (variable scope unchanged)

## Testing

- CI validation will verify shellcheck passes
- No functional changes - variable is already scoped to if-block

## Related

- Fixes #797
- Unblocks PR #791