### PR TITLE
Upgrade agents from claude-sonnet-4-5 to claude-sonnet-4-6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,7 +730,7 @@ REPO            — pnz1990/agentex
 CLUSTER         — agentex
 NAMESPACE       — agentex
 BEDROCK_REGION  — us-west-2
-BEDROCK_MODEL   — us.anthropic.claude-sonnet-4-5-20250929-v1:0
+BEDROCK_MODEL   — us.anthropic.claude-sonnet-4-6
 ```
 
 Entrypoint (`images/runner/entrypoint.sh`) does:

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -14,7 +14,7 @@ NAMESPACE="${NAMESPACE:-agentex}"
 REPO="${REPO:-pnz1990/agentex}"
 CLUSTER="${CLUSTER:-agentex}"
 BEDROCK_REGION="${BEDROCK_REGION:-us-west-2}"
-BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}"
 WORKSPACE="/workspace"
 MY_GENERATION=""  # Set after kubectl config (issue #566)
 

--- a/manifests/bootstrap/coordinator.yaml
+++ b/manifests/bootstrap/coordinator.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: agentex
 spec:
   enabled: true
-  model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  model: us.anthropic.claude-sonnet-4-6

--- a/manifests/bootstrap/god-delegate.yaml
+++ b/manifests/bootstrap/god-delegate.yaml
@@ -183,7 +183,7 @@ spec:
       spec:
         role: worker
         taskRef: task-worker-delegate-${TS}
-        model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+        model: us.anthropic.claude-sonnet-4-6
       EOF
 
     ## STEP 5 — POST YOUR ASSESSMENT AS A DIRECTIVE THOUGHT CR
@@ -321,7 +321,7 @@ spec:
     spec:
       role: planner
       taskRef: task-god-delegate-$(printf "%03d" ${NEXT_GEN})
-      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+      model: us.anthropic.claude-sonnet-4-6
     EOF
 
     # Record run timestamp so next delegate can gate on it
@@ -353,4 +353,4 @@ metadata:
 spec:
   role: planner
   taskRef: task-god-delegate-001
-  model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  model: us.anthropic.claude-sonnet-4-6

--- a/manifests/bootstrap/god-observer.yaml
+++ b/manifests/bootstrap/god-observer.yaml
@@ -161,7 +161,7 @@ spec:
       spec:
         role: planner
         taskRef: task-god-observer-${TS}
-        model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+        model: us.anthropic.claude-sonnet-4-6
       EOF
 
     ### 5b — Next god-delegate (steering chain), if not already running
@@ -207,7 +207,7 @@ spec:
       spec:
         role: planner
         taskRef: task-god-delegate-${NEXT_PADDED}
-        model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+        model: us.anthropic.claude-sonnet-4-6
       EOF
 
     ## STEP 6 — MARK DONE
@@ -232,4 +232,4 @@ metadata:
 spec:
   role: planner
   taskRef: task-god-observer
-  model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+  model: "us.anthropic.claude-sonnet-4-6"

--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -55,7 +55,7 @@ spec:
             - name: TASK_CR_NAME
               value: "bootstrap"
             - name: BEDROCK_MODEL
-              value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+              value: "us.anthropic.claude-sonnet-4-6"
             - name: BEDROCK_REGION
               value: "us-west-2"
             - name: REPO
@@ -76,7 +76,7 @@ spec:
               git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1 &&
               cd /workspace/repo &&
               mkdir -p "${HOME}/.config/opencode" &&
-              printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0","permission":"allow"}' \
+              printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-6","permission":"allow"}' \
               > "${HOME}/.config/opencode/config.json" &&
               bash /prompt/seed-prompt.sh | opencode run --print-logs &&
               echo "Bootstrap complete. The loop is now self-sustaining."
@@ -148,7 +148,7 @@ data:
       Example Agent CR (fill in your values):
         apiVersion: kro.run/v1alpha1 / kind: Agent / namespace: agentex
         spec.role: worker / spec.taskRef: task-issue-N
-        spec.model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+        spec.model: us.anthropic.claude-sonnet-4-6
         metadata.labels: agentex/spawned-by=bootstrap-seed
       NOTE: Agent CRs MUST use apiVersion: kro.run/v1alpha1 (NOT agentex.io/v1alpha1)
       kro watches kro.run group to trigger Jobs. Using agentex.io will NOT work.

--- a/manifests/bootstrap/seed-prompt.sh
+++ b/manifests/bootstrap/seed-prompt.sh
@@ -40,7 +40,7 @@ Task CR example:
 Agent CR example:
   kubectl apply -f - (paste yaml with apiVersion agentex.io/v1alpha1, kind Agent,
     metadata.labels agentex/spawned-by=bootstrap-seed,
-    spec.role=worker, spec.taskRef=task-issue-N, spec.model=us.anthropic.claude-sonnet-4-5-20250929-v1:0)
+    spec.role=worker, spec.taskRef=task-issue-N, spec.model=us.anthropic.claude-sonnet-4-6)
 
 Wait for kro CRDs if not ready: sleep 30 && kubectl get crd agents.agentex.io
 

--- a/manifests/crds/agent-crd.yaml
+++ b/manifests/crds/agent-crd.yaml
@@ -24,7 +24,7 @@ spec:
                   description: Name of the Task CR assigned to this agent
                 model:
                   type: string
-                  default: "anthropic.claude-sonnet-4-5"
+                  default: "us.anthropic.claude-sonnet-4-6"
                 swarmRef:
                   type: string
                   description: Optional Swarm CR this agent belongs to

--- a/manifests/crds/swarm-crd.yaml
+++ b/manifests/crds/swarm-crd.yaml
@@ -46,7 +46,7 @@ spec:
                       default: 0
                 model:
                   type: string
-                  default: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                  default: "us.anthropic.claude-sonnet-4-6"
                   description: Bedrock model ID for agents in this swarm
                 consensusThreshold:
                   type: integer

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       role: string | default="worker"
       taskRef: string | required=true
-      model: string | default="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      model: string | default="us.anthropic.claude-sonnet-4-6"
       swarmRef: string | default=""
       priority: integer | default=5
     status:

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -8,7 +8,7 @@ spec:
     kind: Coordinator
     spec:
       enabled: boolean | default=true
-      model: string | default="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      model: string | default="us.anthropic.claude-sonnet-4-6"
       imageTag: string | default="latest"
     status:
       configMapName: ${coordinatorState.metadata.name}

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -16,7 +16,7 @@ spec:
       reviewers: integer | default=1
       consensusThreshold: integer | default=51
       githubRepo: string | default="pnz1990/agentex"
-      model: string | default="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      model: string | default="us.anthropic.claude-sonnet-4-6"
     status:
       configMapName: ${swarmState.metadata.name}
       phase: ${swarmState.data.phase}

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -26,7 +26,7 @@ data:
   dailyCostBudgetUSD: "50"
 
   # Model to use for all agents (cross-region inference prefix required)
-  agentModel: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+  agentModel: "us.anthropic.claude-sonnet-4-6"
 
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)


### PR DESCRIPTION
## Summary

- Replaces `us.anthropic.claude-sonnet-4-5-20250929-v1:0` with `us.anthropic.claude-sonnet-4-6` everywhere
- Affects: `entrypoint.sh`, all RGDs (`agent-graph`, `coordinator-graph`, `swarm-graph`), all bootstrap manifests (`god-delegate`, `god-observer`, `seed-agent`, `coordinator`), CRDs, `constitution.yaml`, `AGENTS.md`
- Model confirmed available on Bedrock via `aws bedrock list-inference-profiles` in both `us-west-2` and `us-east-1`

## Why

Agents were running Claude Sonnet 4.5 while the god supervisor runs Sonnet 4.6. This aligns all agents to the latest available model.

## Files changed

13 files, 19 substitutions (all mechanical find-replace of the model ID string).

## Notes

- `AGENTS.md` and `manifests/rgds/*.yaml` are protected files — requires `god-approved` label
- No behavioral changes, purely model ID update