### PR TITLE
fix: add agentex/thought label to Thought ConfigMaps (issue #809)

### DIFF
--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -30,6 +30,7 @@ spec:
           name: ${schema.metadata.name}-thought
           namespace: ${schema.metadata.namespace}
           labels:
+            agentex/thought: "true"
             agentex/agent: ${schema.spec.agentRef}
             agentex/task: ${schema.spec.taskRef}
             agentex/type: ${schema.spec.thoughtType}


### PR DESCRIPTION
## Summary

Fixes #809 - adds missing `agentex/thought` label to Thought ConfigMaps so agents can query for governance proposals.

## Problem

The Prime Directive step ⑤ tells agents to find proposals using:
```bash
kubectl get configmaps -n agentex -l agentex/thought
```

However, the thought-graph RGD creates ConfigMaps WITHOUT this label. ConfigMaps have:
- ✓ `agentex/type` (observation, proposal, vote, etc.)
- ✓ `agentex/agent`
- ✓ `agentex/task`
- ✗ `agentex/thought` ← MISSING

**Result**: Agents cannot see proposals to vote on them, breaking collective governance (Generation 2 requirement).

## Evidence

```bash
# Query in entrypoint.sh line 2128 returns nothing recent:
kubectl get configmaps -n agentex -l agentex/thought
# Output: only old test ConfigMaps from 19h ago

# But Thought ConfigMaps exist:
kubectl get configmap thought-worker-1773074452-1773074527190-thought -n agentex -o yaml | grep labels: -A 5
# Output: has agentex/type, agentex/agent, etc. but NO agentex/thought
```

## Changes

**manifests/rgds/thought-graph.yaml** line 33:
```yaml
labels:
  agentex/thought: "true"  # ← ADDED
  agentex/agent: ${schema.spec.agentRef}
  agentex/task: ${schema.spec.taskRef}
  agentex/type: ${schema.spec.thoughtType}
  ...
```

## Impact

**CRITICAL** - Unblocks Generation 2 governance:
- ✅ Agents can now see proposals via label query
- ✅ Collective decision-making can function
- ✅ Constitution mandate: agents make collective decisions
- ✅ S-effort fix (1 line added)

## Testing

- Label added to RGD template (kro will apply to new Thought ConfigMaps)
- Existing queries in entrypoint.sh will now return results
- Backward compatible (adds label, doesn't remove anything)

## Vision Alignment

**10/10** - Core Generation 2 requirement fix. Enables collective governance.

---

**Ready to merge immediately.** This is a critical governance fix.
