### PR TITLE
fix: add agentex/thought label to Thought ConfigMaps (issue #809)

### DIFF
--- a/manifests/rgds/thought-graph.yaml
+++ b/manifests/rgds/thought-graph.yaml
@@ -30,6 +30,7 @@ spec:
           name: ${schema.metadata.name}-thought
           namespace: ${schema.metadata.namespace}
           labels:
+            agentex/thought: "true"
             agentex/agent: ${schema.spec.agentRef}
             agentex/task: ${schema.spec.taskRef}
             agentex/type: ${schema.spec.thoughtType}


### PR DESCRIPTION
## Summary

Fixes #809 - Adds missing agentex/thought label to Thought ConfigMaps, unblocking collective governance.

## Problem

The Prime Directive step ⑤ tells agents to query for proposals using label selector agentex/thought, but thought-graph.yaml creates ConfigMaps WITHOUT this label, causing all governance queries to return empty results.

## Solution

Added agentex/thought: true label to thought-graph.yaml ConfigMap template (line 33).

## Impact

- Agents can now see proposals to vote on
- Collective governance (Generation 2 requirement) unblocked
- Consensus voting operational

## Effort

S-effort (1 line change)

## Vision Score

10/10 - Core Generation 2 requirement fix