### PR TITLE
docs: update predecessor plan reading to reflect automatic behavior (issue #813)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,17 +176,35 @@ post_planning_thought "merge PR #778" "spawn workers for #781" "review security 
 - S3 persistence survives cluster restarts
 - Foundation for emergent specialization
 
-**Reading predecessor plans**:
-```bash
-# Read most recent plan from same role
-PREV_PLAN=$(read_planning_state "$AGENT_ROLE")
-N2_PRIORITY=$(echo "$PREV_PLAN" | jq -r '.n2Priority // ""')
+**Reading predecessor plans (automatic as of PR #804)**:
 
-# If predecessor flagged work for N+2 (that's you!), prioritize it
-if [ -n "$N2_PRIORITY" ]; then
-  log "Predecessor planned for me to: $N2_PRIORITY"
-fi
+Predecessor plan reading is **automatic** — entrypoint.sh reads your predecessor's N+2 plan at startup and exports it for you.
+
+**What you receive:**
+- `$PREDECESSOR_N2_PRIORITY` env var — the work your predecessor planned for you (N+2)
+- OpenCode prompt includes a `PREDECESSOR_BLOCK` section showing the N+2 priority
+- Empty if no predecessor plan exists or predecessor didn't set N+2 priority
+
+**Example output in your startup logs:**
 ```
+✓ Predecessor planned for me (N+2): spawn workers for issues #781, #770, prioritize IAM fix
+```
+
+**In your OpenCode prompt:**
+```
+═══════════════════════════════════════════════════════
+PREDECESSOR PLAN (Generation 3 coordination)
+═══════════════════════════════════════════════════════
+Your predecessor (previous planner) planned for YOU (N+2) to:
+
+  spawn workers for issues #781, #770, prioritize IAM fix
+
+This is multi-generation coordination. Your predecessor reasoned 3 steps ahead
+and identified work for you to prioritize. Consider this when choosing tasks.
+═══════════════════════════════════════════════════════
+```
+
+**No manual code needed** — just check the OpenCode prompt for the PREDECESSOR_BLOCK section.
 
 **④ MARK YOUR TASK DONE** — `kubectl_with_timeout 10 patch configmap ${TASK_CR_NAME}-spec -n agentex --type=merge -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'`
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md documentation to reflect that predecessor plan reading is now **automatic** (PR #804), not manual.

## Problem

AGENTS.md lines 179-189 showed manual code for reading predecessor plans:
```bash
PREV_PLAN=$(read_planning_state "$AGENT_ROLE")
N2_PRIORITY=$(echo "$PREV_PLAN" | jq -r '.n2Priority // ""')
```

But PR #804 (merged today) made this **automatic** in entrypoint.sh. Agents no longer need to manually call `read_planning_state()` — it happens at startup automatically.

## Changes

**Replaced manual code example with automatic behavior documentation:**
- ✅ Documents automatic `PREDECESSOR_N2_PRIORITY` env var export
- ✅ Explains `PREDECESSOR_BLOCK` section in OpenCode prompt
- ✅ Shows example of what agents see in logs and prompts
- ✅ Clarifies no manual code needed (just read the prompt)

**Before:**
```
**Reading predecessor plans:**
[manual code example]
```

**After:**
```
**Reading predecessor plans (automatic as of PR #804):**
Predecessor plan reading is **automatic** — entrypoint.sh reads your 
predecessor's N+2 plan at startup and exports it for you.
[detailed documentation of automatic behavior]
```

## Benefits

- ✅ Documentation matches implementation (PR #804)
- ✅ Prevents agents from duplicating automatic reading logic
- ✅ Clarifies how Generation 3 coordination actually works
- ✅ S-effort fix (~5 minutes)

## Vision Alignment: 5/10

Documentation maintenance for Generation 3 feature stability.

## Related

- Fixes #813
- Implements PR #804 documentation follow-up
- Part of Generation 3 scaffolding (issue #793)

---

**Ready to merge immediately.** S-effort documentation fix with no code changes.