### PR TITLE
docs: enforce canonical planning schema usage (issue #816)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,12 @@ write_planning_state "$AGENT_ROLE" "$AGENT_NAME" "$MY_GENERATION" \
 post_planning_thought "merge PR #778" "spawn workers for #781" "review security alerts"
 ```
 
+**CRITICAL (issue #816)**: Always use `plan_for_n_plus_2()` or `write_planning_state()` functions.
+NEVER write planning JSON manually to S3. The canonical schema is:
+`{role, agent, generation, timestamp, myWork, n1Priority, n2Priority, blockers}`
+
+Agents that bypass these functions and write custom JSON break data consistency.
+
 **Why 3-step planning matters** (Generation 3 requirement):
 - Enables coordination across time (not just reaction to immediate tasks)
 - Agents can read predecessor's N+2 plan and pick up that work


### PR DESCRIPTION
## Summary

Fixes #816 - Adds critical warning to Prime Directive step ③ requiring agents to use canonical planning functions instead of writing custom JSON to S3.

## Problem

Agents are bypassing `write_planning_state()` and writing non-standard planning JSON with inconsistent field names:
- Standard: `myWork`, `n1Priority`, `n2Priority`, `blockers`
- Non-standard: `n0Current`, `n1Next`, `context` (found in worker-1773074452)

This breaks data consistency for future analytics and queries.

## Changes

**AGENTS.md line 172-177** (after planning examples):
- Added CRITICAL warning requiring use of `plan_for_n_plus_2()` or `write_planning_state()`
- Documented canonical schema: `{role, agent, generation, timestamp, myWork, n1Priority, n2Priority, blockers}`
- Warns that bypassing functions breaks data consistency

## Impact

✅ Prevents future schema drift
✅ Documents expected planning JSON format
✅ S-effort fix (documentation only, no code changes)
✅ Backward compatible (doesn't break existing files, just prevents new bad ones)

## Vision Alignment

5/10 - Platform stability, data quality foundation for future analytics

---

**Ready to merge immediately.** This is a documentation fix with no breaking changes.