### PR TITLE
Memory architecture: god-delegate owns chronicle, agents stop writing to S3

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -428,37 +428,9 @@ EOF
       ;;
   esac
 
-  # Persist thought to S3 for long-term memory (survives cluster restarts)
-  # Check if bucket exists before attempting write
-  if aws s3 ls s3://agentex-thoughts/ >/dev/null 2>&1; then
-    local timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    local s3_key="${AGENT_NAME}-${thought_name}.json"
-    
-    # Create JSON document with full thought metadata
-    local s3_output
-    if ! s3_output=$(cat <<JSON | aws s3 cp - "s3://agentex-thoughts/${s3_key}" --content-type application/json 2>&1
-{
-  "name": "${thought_name}",
-  "agentRef": "${AGENT_NAME}",
-  "displayName": "${AGENT_DISPLAY_NAME:-$AGENT_NAME}",
-  "taskRef": "${TASK_CR_NAME}",
-  "thoughtType": "${type}",
-  "confidence": ${confidence},
-  "topic": "${topic}",
-  "filePath": "${file_path}",
-  "parentRef": "${parent_ref}",
-  "timestamp": "${timestamp}",
-  "content": $(echo "$content" | jq -Rs .)
-}
-JSON
-); then
-      log "WARNING: Failed to persist thought to S3 (key=${s3_key}): ${s3_output}"
-    fi
-    
-    # Update identity stats (if identity system is active)
-    if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
-      update_identity_stats "thoughtsPosted" 1
-    fi
+  # Update identity stats (if identity system is active)
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+    update_identity_stats "thoughtsPosted" 1
   fi
 }
 
@@ -1909,52 +1881,12 @@ else
   log "WARNING: Could not read chronicle from S3"
 fi
 
-# ── 5c. S3 Historical Thoughts (long-term memory) ─────────────────────────────
-# Supplement in-cluster thoughts with recent historical thoughts from S3
-# This provides context across cluster restarts and preserves institutional memory
-if aws s3 ls s3://agentex-thoughts/ >/dev/null 2>&1; then
-  S3_THOUGHTS=""
-  
-  # Get the 20 most recent thought files from S3 (sorted by modification time)
-  # Filter to only thought files (exclude chronicle.json, identities/*.json, etc.)
-  # Thought files follow pattern: <agent>-thought-<timestamp>.json (from post_thought line 241)
-  S3_FILES=$(aws s3 ls s3://agentex-thoughts/ --recursive 2>/dev/null | \
-    grep -E '\-thought-.*\.json$' | \
-    sort -k1,2 | tail -20 | awk '{print $4}' || true)
-  
-  # Read each thought file and format for display (exclude our own thoughts)
-  for s3_key in $S3_FILES; do
-    THOUGHT_DATA=$(aws s3 cp "s3://agentex-thoughts/${s3_key}" - 2>/dev/null || echo "{}")
-    
-    # Extract fields and format like in-cluster thoughts
-    THOUGHT_AGENT=$(echo "$THOUGHT_DATA" | jq -r '.agentRef // "unknown"' 2>/dev/null || echo "unknown")
-    
-    # Skip our own thoughts
-    if [ "$THOUGHT_AGENT" != "$AGENT_NAME" ]; then
-      THOUGHT_TYPE=$(echo "$THOUGHT_DATA" | jq -r '.thoughtType // "observation"' 2>/dev/null || echo "observation")
-      THOUGHT_CONF=$(echo "$THOUGHT_DATA" | jq -r '.confidence // 7' 2>/dev/null || echo "7")
-      THOUGHT_CONTENT=$(echo "$THOUGHT_DATA" | jq -r '.content // ""' 2>/dev/null || echo "")
-      
-      if [ -n "$THOUGHT_CONTENT" ]; then
-        S3_THOUGHTS="${S3_THOUGHTS}[${THOUGHT_AGENT}/${THOUGHT_TYPE}/c=${THOUGHT_CONF}] (S3): ${THOUGHT_CONTENT}
-"
-      fi
-    fi
-  done
-  
-  # Combine in-cluster and S3 thoughts (prioritize in-cluster as they're more recent)
-  if [ -n "$S3_THOUGHTS" ]; then
-    if [ -n "$PEER_THOUGHTS" ]; then
-      PEER_THOUGHTS="${PEER_THOUGHTS}
-
-=== S3 HISTORICAL CONTEXT ===
-${S3_THOUGHTS}"
-    else
-      PEER_THOUGHTS="=== S3 HISTORICAL CONTEXT ===
-${S3_THOUGHTS}"
-    fi
-  fi
-fi
+# ── 5c. S3 Historical Thoughts — REMOVED ─────────────────────────────────────
+# Removed: agents no longer load individual thought files from S3.
+# The chronicle (5b above) is the sole source of durable historical context.
+# It is written by the god-delegate every ~20 min — curated, high-signal,
+# generation-level summaries. Individual thought files are no longer written
+# to or read from S3. See memory architecture decision 2026-03-09.
 
 # ── 6. Read Task CR ───────────────────────────────────────────────────────────
 log "Reading task CR..."
@@ -2252,27 +2184,14 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   7=role escalation/dashboard/cross-agent debate (platform capabilities),
   5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
 
-⑦ APPEND TO THE CIVILIZATION CHRONICLE
+⑦ THE CIVILIZATION CHRONICLE (read-only for agents)
   The chronicle at s3://agentex-thoughts/chronicle.json is the civilization's
-  permanent memory. Future agents will read it. You must add to it if you
-  discovered something they should know.
-
-  When to append: if you discovered a recurring mistake, a root cause, a
-  milestone, a pattern, or anything that took you time to figure out that
-  the next generation should not have to figure out again.
-
-  How to append (use the helper function):
-    append_to_chronicle "Era Name" "Agent/generation range" "What happened" "What future agents should know"
-
-  Optional fields (milestone, root cause, challenge):
-    append_to_chronicle "Era Name" "Agent-123 to Agent-145" "What happened" "Lesson" "Milestone reached" "Root cause found" "Challenge posed"
-
-  The function handles errors gracefully, prevents race conditions with retries,
-  and emits CloudWatch metrics. It will not fail your agent if S3 is unavailable.
-
-  If you have nothing to add, skip this step. But if you fixed a recurring
-  bug, discovered a root cause, or reached a milestone — write it down.
-  The civilization's memory only exists if you maintain it.
+  permanent memory. You already read it at startup (it was in your context above).
+  The chronicle is written by the god-delegate every ~20 minutes — curated,
+  generation-level summaries. Agents do NOT write to the chronicle.
+  If you discovered something critical, post it as a high-confidence Thought CR
+  (thoughtType: insight) — the god-delegate will read it and decide if it belongs
+  in the chronicle.
 
 THE SYSTEM MUST NEVER IDLE. IF YOU EXIT WITHOUT SPAWNING A SUCCESSOR,
 THE ENTIRE PLATFORM STOPS. TREAT THIS AS A CRITICAL FAILURE.

--- a/manifests/bootstrap/god-delegate.yaml
+++ b/manifests/bootstrap/god-delegate.yaml
@@ -275,7 +275,49 @@ spec:
     BODY
     )"
 
-    ## STEP 7 — SPAWN THE NEXT GOD DELEGATE
+    ## STEP 7 — WRITE TO THE CIVILIZATION CHRONICLE
+
+    The chronicle is the civilization's permanent memory, written ONLY by the god-delegate.
+    Agents read it at startup for historical context. You write one entry per run.
+    Cap at 20 entries — oldest entries are dropped when the cap is exceeded.
+
+      CHRONICLE_ENTRY_ERA="Generation ${MY_GEN} Assessment"
+      CHRONICLE_ENTRY_PERIOD="god-delegate-$(printf "%03d" ${MY_GEN}) ($(date -u '+%Y-%m-%d'))"
+
+      # Download current chronicle (or start fresh)
+      CURRENT_CHRONICLE=$(aws s3 cp s3://agentex-thoughts/chronicle.json - 2>/dev/null || echo '{"entries":[],"civilizationAge":"unknown","totalAgentsRun":0,"totalPRsMerged":0}')
+      if [ -z "$CURRENT_CHRONICLE" ]; then
+        CURRENT_CHRONICLE='{"entries":[],"civilizationAge":"unknown","totalAgentsRun":0,"totalPRsMerged":0}'
+      fi
+
+      # Count active agents and recent PRs for the summary
+      ACTIVE_JOBS=$(kubectl get jobs -n agentex --no-headers 2>/dev/null | grep -v "Complete\|Failed" | wc -l | tr -d ' ')
+      RECENT_PRS=$(gh pr list --repo pnz1990/agentex --state merged --limit 5 --json number --jq 'length' 2>/dev/null || echo "0")
+
+      # Build and upload updated chronicle (capped at 20 entries)
+      NEW_CHRONICLE=$(echo "$CURRENT_CHRONICLE" | jq \
+        --arg era "$CHRONICLE_ENTRY_ERA" \
+        --arg period "$CHRONICLE_ENTRY_PERIOD" \
+        --arg summary "God-delegate generation ${MY_GEN} completed assessment. Active jobs: ${ACTIVE_JOBS}. Recent PRs merged: ${RECENT_PRS}. Top priority: see latest [GOD-REPORT] GitHub issue and directive Thought CR for this generation." \
+        --arg lesson "Read the god-delegate directive Thought CR for this generation to understand the civilization's current priority and what work was injected." \
+        --arg gen "${MY_GEN}" \
+        '.entries += [{
+          "era": $era,
+          "period": $period,
+          "summary": $summary,
+          "lessonLearned": $lesson,
+          "generation": ($gen | tonumber)
+        }] | .entries = (.entries | sort_by(.generation // 0) | .[-20:]) | .civilizationAge = ("Generation " + $gen)' \
+        2>/dev/null)
+
+      if [ -n "$NEW_CHRONICLE" ]; then
+        echo "$NEW_CHRONICLE" | aws s3 cp - s3://agentex-thoughts/chronicle.json \
+          --content-type application/json 2>/dev/null && \
+          echo "Chronicle updated (generation ${MY_GEN}, capped at 20 entries)" || \
+          echo "WARNING: Failed to update chronicle"
+      fi
+
+    ## STEP 8 — SPAWN THE NEXT GOD DELEGATE
 
     NEXT_GEN=$((MY_GEN + 1))
     NEXT_TS=$(date +%s)


### PR DESCRIPTION
## Summary

Redesigns the civilization's memory architecture so the chronicle is curated by the entity with the broadest view, not by every individual agent.

## Changes

### `images/runner/entrypoint.sh` (protected)
- **Remove section 5c** (S3 historical thought loading): eliminated 1 `aws s3 ls --recursive` + 20 individual `aws s3 cp` calls per agent startup — total 21 S3 API calls saved, zero useful context lost
- **Remove S3 write from `post_thought()`**: stops ~10-20 S3 PUTs per agent run; bucket was at 2,680 files and growing unboundedly
- **Update Prime Directive step ⑦**: chronicle is now read-only for agents; critical insights should be high-confidence Thought CRs, not chronicle entries

### `manifests/bootstrap/god-delegate.yaml` (protected)
- **Add STEP 7**: god-delegate writes one curated chronicle entry per ~20 min run — active job count, recent PRs merged, top priority pointer — capped at 20 entries via `jq .[-20:]`

## Why

- Chronicle had 1 real entry despite hundreds of agents running (agents rarely called `append_to_chronicle` voluntarily)
- S3 thought files were redundant: in-cluster Thought CRs already gave agents the last 10 thoughts; S3 copies added latency for marginal cross-restart benefit
- God-delegate already reads all Reports + Thoughts + GitHub every ~20 min — it has the full picture and is the right author for civilizational history

## Result

- Chronicle: curated rolling log of last 20 god-delegate assessments, always current, high signal
- S3 bucket: stops growing from thought files; `planning/` and `identities/` prefixes untouched
- Agent startup: 21 fewer S3 API calls

## Notes

- `append_to_chronicle()` function definition kept in `entrypoint.sh` — god can still call it manually if needed
- Requires `god-approved` label (touches protected files)
- S3 cleanup of existing 2,680 thought files done separately (operational, no code change)