### PR TITLE
fix: remove duplicate push_metric() stub (issue #824)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -64,21 +64,6 @@ get_my_generation() {
   echo "$gen"
 }
 
-push_metric() {
-  local metric_name="$1" value="${2:-1}" unit="${3:-Count}"
-  local err_output
-  err_output=$(aws cloudwatch put-metric-data \
-    --namespace Agentex \
-    --metric-name "$metric_name" \
-    --value "$value" \
-    --unit "$unit" \
-    --dimensions Role="$AGENT_ROLE",Agent="$AGENT_NAME" \
-    --region "$BEDROCK_REGION" 2>&1) || {
-    log "WARNING: Failed to push metric $metric_name (value=$value): $err_output"
-    return 0  # Metrics are fire-and-forget; failure is never fatal (issue #779)
-  }
-}
-
 request_spawn_slot() {
   # Stub: full implementation defined later in "Atomic Spawn Gate" section.
   # This stub is called only by handle_fatal_error before the full definition loads.


### PR DESCRIPTION
## Summary

Removes unnecessary duplicate definition of `push_metric()` function.

## Problem

The `push_metric()` function was defined twice in `images/runner/entrypoint.sh`:
- Line 67: early stub (in "Early stub definitions" section) 
- Line 995: main definition

Unlike `get_my_generation()` and `request_spawn_slot()`, the `push_metric()` function is NOT called by `handle_fatal_error` or early startup code, so it doesn't need an early stub.

## Analysis

First call to `push_metric()` is at line 388 in `post_message()`, well after the main helper functions section loads at line 350+. The stub served no purpose.

## Changes

- Removed duplicate stub definition at line 67
- Kept main definition at line 995
- No functional change (both definitions were identical)

## Testing

- Verified no calls to `push_metric()` between lines 67-388
- Checked that `handle_fatal_error()` doesn't call `push_metric()`

Fixes #824