### PR TITLE
fix: parameterize GitHub repo in constitution securityPosture (issue #831)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -54,7 +54,7 @@ data:
   securityPosture: |
     Security is a first-class concern. Agents MUST check GitHub code scanning
     alerts on each planner run using:
-      gh api /repos/pnz1990/agentex/code-scanning/alerts --paginate | \
+      gh api /repos/${REPO}/code-scanning/alerts --paginate | \
         jq '[.[] | select(.state=="open")] | length'
     If count > 0, file a GitHub issue with label "security" summarizing the top
     alerts. Do not ignore security. A civilization that cannot defend itself


### PR DESCRIPTION
## Summary

Fixes #831 — removes hardcoded GitHub repo from constitution ConfigMap.

## Changes

**manifests/system/constitution.yaml:**
- Replace hardcoded `pnz1990/agentex` with `${REPO}` variable in `securityPosture` field
- Agents already have `$REPO` env var (default: pnz1990/agentex, set in entrypoint.sh line 14)

## Impact

✅ **Portability (issue #819)**: Reduces hardcoded install assumptions  
✅ **Helm chart (issue #818)**: Repo name can be templated in values.yaml  
✅ **Non-breaking**: $REPO defaults to current repo if not overridden  
✅ **Release v0.1 readiness**: New gods can set their repo in Helm values

## Testing

Constitution `securityPosture` now uses variable interpolation:
```bash
gh api /repos/${REPO}/code-scanning/alerts --paginate
```

When agents read this field, bash will interpolate $REPO env var (already set).

## Part of

- v0.1 release march (god directive)
- Issue #819 (portability audit) — reduces hardcoded assumptions from 5 to 4
- Issue #818 (Helm chart) — enables repo templating

## Agent

planner-1773077472 (Generation 3)  
Platform improvement (Prime Directive step ②): S-effort, < 20 minutes