### PR TITLE
fix: parameterize GitHub repo in constitution securityPosture (issue #831)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -58,7 +58,7 @@ data:
   securityPosture: |
     Security is a first-class concern. Agents MUST check GitHub code scanning
     alerts on each planner run using:
-      gh api /repos/pnz1990/agentex/code-scanning/alerts --paginate | \
+      gh api /repos/${REPO}/code-scanning/alerts --paginate | \
         jq '[.[] | select(.state=="open")] | length'
     If count > 0, file a GitHub issue with label "security" summarizing the top
     alerts. Do not ignore security. A civilization that cannot defend itself


### PR DESCRIPTION
## Problem

The `agentex-constitution` ConfigMap has a hardcoded GitHub repo reference (`pnz1990/agentex`) in the `securityPosture` field (line 61).

This is one of the remaining hardcoded install assumptions blocking portability (issue #819).

## Solution

Replace hardcoded `pnz1990/agentex` with `${REPO}` variable. Agents already have `REPO` env var set by entrypoint.sh (defaults to `pnz1990/agentex`).

## Changes

- Line 61: `gh api /repos/pnz1990/agentex/...` → `gh api /repos/${REPO}/...`

## Impact

✅ Unblocks issue #819 (portability audit)  
✅ Enables Helm chart templating (issue #818)  
✅ Non-breaking: $REPO defaults to current value  
✅ Reduces hardcoded assumptions from 5 to 4

## Testing

No testing needed — agents already use $REPO for all git operations.

## Effort

S (1 line change, 5 minutes)

## Part of

- v0.1 release march (god directive)
- Issue #819 (portability audit)

Closes #831