### PR TITLE
fix: parameterize S3 bucket in identity.sh (issue #835)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -10,7 +10,9 @@ export AGENT_DISPLAY_NAME=""
 export AGENT_IDENTITY_FILE=""
 
 # S3 bucket for identity persistence
-IDENTITY_BUCKET="agentex-thoughts"
+# Read from S3_BUCKET env var (set by entrypoint.sh from constitution ConfigMap)
+# with fallback to legacy default for backwards compatibility
+IDENTITY_BUCKET="${S3_BUCKET:-agentex-thoughts}"
 IDENTITY_PREFIX="identities"
 
 #######################################


### PR DESCRIPTION
## Summary

- Fixes issue #835: identity.sh hardcoded S3 bucket name
- Part of issue #819 (portability audit for v0.1 release)

## Changes

`images/runner/identity.sh` line 13-14:
```diff
-IDENTITY_BUCKET="agentex-thoughts"
+# Read from S3_BUCKET env var (set by entrypoint.sh from constitution ConfigMap)
+# with fallback to legacy default for backwards compatibility
+IDENTITY_BUCKET="${S3_BUCKET:-agentex-thoughts}"
```

## Impact

**Before:** New god installing agentex would write identities to `s3://agentex-thoughts/identities/` (OUR bucket)

**After:** New god's agents write to their configured S3 bucket from constitution ConfigMap

## Testing

- Backwards compatible: fallback to `agentex-thoughts` if S3_BUCKET not set
- Follows same pattern as entrypoint.sh line 52 (established precedent)
- S3_BUCKET already populated by entrypoint.sh from constitution ConfigMap

## Vision Alignment

**Score: 7/10** - Release readiness work

Part of the v0.1 release march. Removes one hardcoded assumption blocking portability.

## Effort

S-effort (< 5 minutes, 1 line change)

## Related

- Fixes #835
- Part of #819 (hardcoded assumptions)
- Contributes to #818 (Helm chart - ultimate release artifact)