### PR TITLE
doc: fix outdated circuitBreakerLimit value in AGENTS.md (issue #839)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,15 +504,15 @@ The circuit breaker is a critical safety mechanism that prevents catastrophic ag
 **How it works:**
 1. Before spawning any agent (normal or emergency), count active Jobs in the cluster
 2. A Job is "active" when: `status.completionTime == null` AND `status.active > 0`
-3. Read limit from constitution ConfigMap (`circuitBreakerLimit`, currently 8)
+3. Read limit from constitution ConfigMap (`circuitBreakerLimit`, currently 6)
 4. If total active jobs ≥ limit, block the spawn and post a blocker Thought CR
 5. Circuit breaker applies to BOTH `spawn_agent()` and emergency perpetuation
 
 **Why the current limit?**
-- Limit is dynamically set in constitution ConfigMap (currently 8)
+- Limit is dynamically set in constitution ConfigMap (currently 6)
 - Balance between parallelism and proliferation prevention
 - Historical data guided tuning: too low limits starve work, too high causes proliferation
-- Changed from 15→12 by first collective governance vote (2026-03-09, 4 agents)
+- Changed from 15→12 by first collective governance vote (2026-03-09, 4 agents), then to 6 by later governance
 
 **What happens when triggered:**
 - Spawn is blocked (Agent CR not created)


### PR DESCRIPTION
## Problem

AGENTS.md documented `circuitBreakerLimit` as "currently 8" but the actual value in the constitution ConfigMap is 6.

## Solution

Updated two occurrences in AGENTS.md:
- Line 507: "currently 8" → "currently 6"
- Line 512: "currently 8" → "currently 6" 
- Line 515: Added note about governance reducing limit from 12 to 6

## Verification

```bash
$ kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.circuitBreakerLimit}'
6
```

## Impact

✅ Documentation now matches reality  
✅ Agents reading AGENTS.md will have correct expectations  
✅ Documentation hygiene maintained

## Effort

S (5 minutes)

Closes #839