### PR TITLE
feat: log active job names when early circuit breaker triggers (issue #842)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -294,7 +294,14 @@ if [ "$EARLY_ACTIVE_JOBS" -ge "$DOUBLE_LIMIT" ]; then
 fi
 
 if [ "$EARLY_ACTIVE_JOBS" -ge $CIRCUIT_BREAKER_LIMIT ]; then
+  # Log which jobs are active for debugging (issue #842)
+  ACTIVE_JOB_NAMES=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq -r '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0) | 
+      {name: .metadata.name, role: (.metadata.labels."agentex/role" // "unknown"), gen: (.metadata.labels."agentex/generation" // "?")} | 
+      "\(.name) (role=\(.role) gen=\(.gen))"] | join(", ")' 2>/dev/null || echo "unknown")
+  
   log "EARLY CIRCUIT BREAKER TRIGGERED: System overloaded ($EARLY_ACTIVE_JOBS >= $CIRCUIT_BREAKER_LIMIT)"
+  log "Active jobs: $ACTIVE_JOB_NAMES"
   log "Exiting immediately BEFORE resource allocation (identity, inbox, git clone, etc.)"
   log "This prevents TOCTOU proliferation where many agents race through startup steps."
   


### PR DESCRIPTION
## Problem

When the circuit breaker triggers at startup, we log the count but not which jobs are active. This makes debugging proliferation events difficult.

## Solution

Added logging of active job names with role and generation labels when early circuit breaker triggers:

```
EARLY CIRCUIT BREAKER TRIGGERED: System overloaded (7 >= 6)
Active jobs: planner-123 (role=planner gen=4), worker-456 (role=worker gen=3), ...
```

This enables:
- Quick identification of role proliferation patterns (e.g., 5 planners vs 2 workers)
- Detection of stuck jobs (same job appearing in logs minutes apart)
- Better debugging of generation cascades
- Data for tuning circuit breaker limits

## Changes

- Added `ACTIVE_JOB_NAMES` query using kubectl+jq after line 296 in entrypoint.sh
- Logs job name, role label, and generation label for all active jobs
- Only runs when circuit breaker actually triggers (no overhead in normal path)

## Testing

Manual testing shows expected output format. Will observe in production when circuit breaker triggers next.

## Effort

S (10 minutes)

Closes #842