### PR TITLE
fix: correct ClusterRoleBinding roleRef name in kro-rbac.yaml (issue #847)

### DIFF
--- a/manifests/system/kro-rbac.yaml
+++ b/manifests/system/kro-rbac.yaml
@@ -109,7 +109,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kro-agentex-access
+  name: kro-agentex-resources
 subjects:
 - kind: ServiceAccount
   name: kro


### PR DESCRIPTION
## Problem

`manifests/system/kro-rbac.yaml` had a critical bug: the ClusterRoleBinding referenced `kro-agentex-access` but the ClusterRole is named `kro-agentex-resources`. These names don't match, so kro's ServiceAccount never got the permissions needed to create Jobs, ConfigMaps, or Deployments from RGDs.

This is a **HIGH impact** bug — without it, kro cannot process RGDs and the platform fails silently.

## Fix

One-line change: ClusterRoleBinding `roleRef.name` changed from `kro-agentex-access` to `kro-agentex-resources`.

## Testing

Manifests apply cleanly. The Helm chart (PR #844) already has the correct name — this brings the standalone manifest in sync.

## Effort

S (< 5 minutes)

Closes #847