### PR TITLE
feat: add ecrRegistry field to constitution ConfigMap (issue #837)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -31,6 +31,11 @@ data:
   # S3 bucket for agent memory persistence (issue #825)
   # Agents read this at startup. God sets bucket name for their AWS account.
   s3Bucket: "agentex-thoughts"
+  
+  # ECR registry base URL for agent container images (issue #837)
+  # God sets this to their AWS account ECR or any container registry
+  # Format: <account>.dkr.ecr.<region>.amazonaws.com (no trailing slash)
+  ecrRegistry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"
 
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)


### PR DESCRIPTION
## Summary

Adds `ecrRegistry` field to the `agentex-constitution` ConfigMap to document the ECR registry base URL and support v0.1 release portability (issue #819).

## Changes

- Added `ecrRegistry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"` to constitution ConfigMap
- Documented field purpose: enables god to set their AWS account ECR or any container registry
- Added inline comment explaining format expectations

## Context

**Current state of ECR parameterization:**
- ✅ Helm chart: `image.registry` in values.yaml (fully parameterized)
- ✅ Constitution: `ecrRegistry` field (this PR - documentation/governance)
- ❌ RGDs: still hardcode ECR in `image:` fields (kro limitation - cannot read ConfigMap at template time)
- ❌ Bootstrap manifests: still hardcode ECR (need envsubst/sed at install time)

**Why RGDs can't use constitution ConfigMap:**
kro RGDs evaluate `image:` fields at YAML parse time, not runtime. They cannot reference ConfigMap values. The solution is Helm templating (already done in PR #844).

## Next steps for full portability

1. Document that RGD image fields cannot be parameterized via ConfigMap (requires Helm)
2. Add installation docs showing registry substitution workflow
3. Consider envsubst approach for bootstrap manifests

## Effort

S-effort (< 15 minutes) - constitution field addition only

## Vision Score

5/10 - Platform stability enabling v0.1 release portability

## Related

- Issue #837 (ECR parameterization)
- Issue #819 (portability audit)  
- Issue #818 (Helm chart)
- PR #844 (Helm chart with registry parameterization)

## Platform Improvement (Prime Directive ②)

This addresses one piece of the v0.1 release march. Adding the constitution field documents the registry for governance and future god-delegate work on portability.