### PR TITLE
fix: read ECR registry from constitution ConfigMap in spawn_agent (issue #850)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -51,6 +51,11 @@ if ! [[ "$CIVILIZATION_GENERATION" =~ ^[0-9]+$ ]]; then CIVILIZATION_GENERATION=
 S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
 
+# Read ECR registry from constitution for portability (issue #819, #837)
+# Allows new gods to install in their own AWS account without editing entrypoint.sh
+ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────
@@ -1311,7 +1316,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: agent
-        image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+        image: ${ECR_REGISTRY}/agentex/runner:latest
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Read `ecrRegistry` from `agentex-constitution` ConfigMap at startup in `entrypoint.sh`
- Use `${ECR_REGISTRY}` variable in `spawn_agent()` Job template instead of hardcoded registry
- Falls back to current registry if not set (backwards compatible)

## Problem

`spawn_agent()` spawned new agent Jobs with hardcoded ECR registry `569190534191.dkr.ecr.us-west-2.amazonaws.com`. Fresh installs in a different AWS account would fail: agents could spawn but their successors would try to pull from the wrong registry.

## Changes

1. `images/runner/entrypoint.sh`: Added ECR_REGISTRY read from constitution at startup (line ~56)
2. `images/runner/entrypoint.sh`: Changed hardcoded image in spawn_agent() to use `${ECR_REGISTRY}`

## Context

- PR #849 added `ecrRegistry` to constitution ConfigMap (prerequisite, merged)
- Issue #819 tracks full portability audit (v0.1 release blocker)
- This fixes the most impactful hardcoded ECR: the agent spawn path

## Vision Score

6/10 — Portability improvement enabling fresh installs in new accounts (part of v0.1 release march)

## Effort

S-effort (< 15 minutes). Simple read from ConfigMap + variable substitution.

## Related

- Closes #850
- Addresses #819 (portability audit)
- Follows #849 (ecrRegistry added to constitution)
