### PR TITLE
fix: add ecrRegistry and awsRegion to constitution ConfigMap (issue #837, #819)

### DIFF
--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -25,6 +25,15 @@ data:
   # S3 bucket for agent memory persistence
   s3Bucket: {{ .Values.aws.s3Bucket | quote }}
 
+  # ECR registry base URL for agent container images (issue #837)
+  # Agents read this for spawn templates. God sets this to their AWS account ECR.
+  # Format: <account>.dkr.ecr.<region>.amazonaws.com (no trailing slash)
+  ecrRegistry: {{ .Values.image.registry | quote }}
+
+  # AWS region where the cluster and Bedrock run (issue #819)
+  # Agents read this for AWS API calls. Must match where EKS cluster lives.
+  awsRegion: {{ .Values.aws.region | quote }}
+
   # Current civilization generation (god increments this)
   civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
 

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -37,6 +37,10 @@ data:
   # Format: <account>.dkr.ecr.<region>.amazonaws.com (no trailing slash)
   ecrRegistry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"
 
+  # AWS region where the EKS cluster and Bedrock run (issue #819)
+  # Agents read this for AWS API calls. A new god sets this to their region.
+  awsRegion: "us-west-2"
+
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)
   visionUnlockGeneration: "10"


### PR DESCRIPTION
## Summary

Adds `ecrRegistry` and `awsRegion` portability fields to the `agentex-constitution` ConfigMap, part of the v0.1 release portability effort (issues #837, #819).

## Problem

When a new god installs Agentex in their own AWS account:
- Agent spawn templates in `entrypoint.sh` would reference the wrong ECR registry
- The Helm chart constitution template was missing the `ecrRegistry` field
- No canonical `awsRegion` field existed for agents needing the cluster region

## Changes

### `chart/templates/constitution.yaml`
- Added `ecrRegistry: {{ .Values.image.registry | quote }}` — populated from Helm `image.registry` value
- Added `awsRegion: {{ .Values.aws.region | quote }}` — populated from Helm `aws.region` value

### `manifests/system/constitution.yaml`
- Added `awsRegion: "us-west-2"` alongside the existing `ecrRegistry` field

## How it works

The `entrypoint.sh` already reads `ECR_REGISTRY` from the constitution:
```bash
ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
  -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
```

And uses it in fallback Job spawn templates (line 1319):
```yaml
image: ${ECR_REGISTRY}/agentex/runner:latest
```

Now a new god can do:
```bash
helm install agentex ./chart \
  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
  --set aws.region=us-east-1
```

And agents will spawn successors using their ECR registry, not ours.

## Part of
- Closes #837
- Part of #819 portability audit
- Part of v0.1 release readiness