### PR TITLE
fix: parameterize GitHub repo in constitution (issue #853, #819)

### DIFF
--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -34,6 +34,11 @@ data:
   # Agents read this for AWS API calls. Must match where EKS cluster lives.
   awsRegion: {{ .Values.aws.region | quote }}
 
+  # GitHub repository for issue tracking and PRs (issue #819, #853 portability)
+  # God sets this to their own GitHub org/repo. Format: owner/repo
+  # A new god's agents will file issues and PRs on their own repo.
+  githubRepo: {{ .Values.github.repo | quote }}
+
   # Current civilization generation (god increments this)
   civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,6 +78,9 @@ agent:
 # Set via: --set github.token=ghp_xxx  OR  use an existing secret
 # ---------------------------------------------------------------------------
 github:
+  # GitHub repository for issue tracking and PRs (format: owner/repo)
+  # Agents will file issues and open PRs on this repo
+  repo: "pnz1990/agentex"
   # GitHub personal access token with repo scope
   # If empty, assumes secret already exists (e.g. externally managed)
   token: ""

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -56,6 +56,15 @@ S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAME
 ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
 
+# Read GitHub repo from constitution for portability (issue #819)
+# New gods' agents will file issues/PRs on their own repo, not the original creator's
+GITHUB_REPO_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.githubRepo}' 2>/dev/null || echo "")
+# Override REPO if constitution has githubRepo set (allows REPO env var for backward compat)
+if [ -n "$GITHUB_REPO_FROM_CONSTITUTION" ]; then
+  REPO="$GITHUB_REPO_FROM_CONSTITUTION"
+fi
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -36,6 +36,15 @@ data:
   # God sets this to their AWS account ECR or any container registry
   # Format: <account>.dkr.ecr.<region>.amazonaws.com (no trailing slash)
   ecrRegistry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"
+  
+  # AWS region where the EKS cluster and Bedrock run (issue #819)
+  # Agents read this for AWS API calls. A new god sets this to their region.
+  awsRegion: "us-west-2"
+  
+  # GitHub repository for issue tracking and PRs (issue #819 portability)
+  # God sets this to their own GitHub org/repo. Format: owner/repo
+  # A new god's agents will file issues and PRs on their own repo, not ours.
+  githubRepo: "pnz1990/agentex"
 
   # AWS region where the EKS cluster and Bedrock run (issue #819)
   # Agents read this for AWS API calls. A new god sets this to their region.


### PR DESCRIPTION
## Summary

Adds `githubRepo` field to the `agentex-constitution` ConfigMap, enabling new gods to install Agentex in their own GitHub org without agents filing issues on pnz1990/agentex.

## Problem

When a new god installs Agentex:
- Agents would file issues/PRs on **our repo** (pnz1990/agentex) instead of theirs
- The `REPO` env var in `entrypoint.sh` had a hardcoded default
- No constitution field existed for GitHub repo portability

This blocks v0.1 release (issue #819).

## Changes

### `manifests/system/constitution.yaml`
- Added `githubRepo: "pnz1990/agentex"` field
- Added `awsRegion: "us-west-2"` field (companion to PR #852)

### `chart/templates/constitution.yaml`
- Added `githubRepo: {{ .Values.github.repo | quote }}`

### `chart/values.yaml`
- Added `github.repo: "pnz1990/agentex"` field

### `images/runner/entrypoint.sh`
- Added constitution read: reads `githubRepo` from ConfigMap
- Overrides `REPO` env var if constitution has `githubRepo` set
- Maintains backward compatibility (REPO env var still works)

## How it works

Priority: constitution githubRepo > REPO env var > hardcoded default

A new god can now do:
```bash
helm install agentex ./chart \
  --set github.repo=myorg/myproduct \
  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
  --set aws.region=us-east-1
```

And agents will file issues and PRs on `myorg/myproduct`.

## Part of
- Closes #853
- Part of #819 portability audit
- v0.1 release readiness