### PR TITLE
fix: parameterize GitHub repo in constitution (issue #853, #819)

### DIFF
--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -34,6 +34,11 @@ data:
   # Agents read this for AWS API calls. Must match where EKS cluster lives.
   awsRegion: {{ .Values.aws.region | quote }}
 
+  # GitHub repository for agent code/issues/PRs (issue #853)
+  # Agents use this as REPO. A new god sets this to their own org/repo.
+  # Format: <org>/<repo> (e.g. myorg/myproduct)
+  githubRepo: {{ .Values.god.repo | quote }}
+
   # Current civilization generation (god increments this)
   civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -56,6 +56,17 @@ S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAME
 ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
 
+# Read GitHub repo from constitution for portability (issue #853)
+# Allows new gods to use their own GitHub repo without editing entrypoint.sh
+# REPO env var may already be set by Pod spec; constitution value overrides the default (not the explicit env)
+_CONSTITUTION_REPO=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.githubRepo}' 2>/dev/null || echo "")
+if [ -n "$_CONSTITUTION_REPO" ] && [ "${REPO}" = "pnz1990/agentex" ]; then
+  # Only override if REPO is still the default (not explicitly set by Pod spec)
+  REPO="$_CONSTITUTION_REPO"
+fi
+unset _CONSTITUTION_REPO
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -41,6 +41,11 @@ data:
   # Agents read this for AWS API calls. A new god sets this to their region.
   awsRegion: "us-west-2"
 
+  # GitHub repository for agent code/issues/PRs (issue #853)
+  # A new god sets this to their own org/repo. Agents read this as the REPO variable.
+  # Format: <org>/<repo> (e.g. myorg/myproduct)
+  githubRepo: "pnz1990/agentex"
+
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)
   visionUnlockGeneration: "10"


### PR DESCRIPTION
## Summary

Adds `githubRepo` field to the `agentex-constitution` ConfigMap so a new god can install Agentex pointing to their own GitHub repo. Part of v0.1 release portability audit.

## Problem

When a new god installs Agentex in their own GitHub org, agents would file issues/PRs on **pnz1990/agentex** instead of theirs. This is because `REPO` had a hardcoded default in `entrypoint.sh` with no way to override it via constitution.

## Changes

### `manifests/system/constitution.yaml`
- Added `githubRepo: "pnz1990/agentex"` — canonical reference value

### `chart/templates/constitution.yaml`
- Added `githubRepo: {{ .Values.god.repo | quote }}` — populated from the existing `god.repo` Helm value (already where gods configure their repo)

### `images/runner/entrypoint.sh`
- Read `githubRepo` from constitution at startup
- Override `REPO` default when constitution has a different value
- Preserves explicit env var overrides (only overrides when `REPO` is still the default)

## How it works

A new god can now do:
```bash
helm install agentex ./chart \
  --set god.repo=myorg/myproduct \
  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
  --set aws.region=us-east-1
```

And agents will file issues/PRs on `myorg/myproduct`, not `pnz1990/agentex`.

## Part of
- Closes #853
- Part of #819 portability audit
- Part of v0.1 release readiness
- Companion to PR #852 (ecrRegistry + awsRegion)