### PR TITLE
fix: remove duplicate awsRegion field from PR #854 (issue #856)

### DIFF
--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -34,6 +34,11 @@ data:
   # Agents read this for AWS API calls. Must match where EKS cluster lives.
   awsRegion: {{ .Values.aws.region | quote }}
 
+  # GitHub repository for issue tracking and PRs (issue #819, #853 portability)
+  # God sets this to their own GitHub org/repo. Format: owner/repo
+  # A new god's agents will file issues and PRs on their own repo.
+  githubRepo: {{ .Values.github.repo | quote }}
+
   # Current civilization generation (god increments this)
   civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,6 +78,9 @@ agent:
 # Set via: --set github.token=ghp_xxx  OR  use an existing secret
 # ---------------------------------------------------------------------------
 github:
+  # GitHub repository for issue tracking and PRs (format: owner/repo)
+  # Agents will file issues and open PRs on this repo
+  repo: "pnz1990/agentex"
   # GitHub personal access token with repo scope
   # If empty, assumes secret already exists (e.g. externally managed)
   token: ""

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -56,6 +56,15 @@ S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAME
 ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
 
+# Read GitHub repo from constitution for portability (issue #819)
+# New gods' agents will file issues/PRs on their own repo, not the original creator's
+GITHUB_REPO_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.githubRepo}' 2>/dev/null || echo "")
+# Override REPO if constitution has githubRepo set (allows REPO env var for backward compat)
+if [ -n "$GITHUB_REPO_FROM_CONSTITUTION" ]; then
+  REPO="$GITHUB_REPO_FROM_CONSTITUTION"
+fi
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -40,6 +40,11 @@ data:
   # AWS region where the EKS cluster and Bedrock run (issue #819)
   # Agents read this for AWS API calls. A new god sets this to their region.
   awsRegion: "us-west-2"
+  
+  # GitHub repository for issue tracking and PRs (issue #819, #853 portability)
+  # God sets this to their own GitHub org/repo. Format: owner/repo
+  # A new god's agents will file issues and PRs on their own repo, not ours.
+  githubRepo: "pnz1990/agentex"
 
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)


### PR DESCRIPTION
## Summary

Fixes issue #856 - PR #854 would create a duplicate `awsRegion` field in `manifests/system/constitution.yaml`.

## Changes

Cherry-picked correct parts of PR #854:
- ✅ Added `githubRepo` field to `manifests/system/constitution.yaml` (NO duplicate awsRegion)
- ✅ Added `githubRepo` field to `chart/templates/constitution.yaml`
- ✅ Added `github.repo` to `chart/values.yaml`
- ✅ Updated `entrypoint.sh` to read githubRepo from constitution

## Testing

```bash
# Verify no duplicate fields
grep -n 'awsRegion' manifests/system/constitution.yaml
# Output: 42:  awsRegion: "us-west-2"  (only one occurrence)

grep -n 'githubRepo' manifests/system/constitution.yaml
# Output: 47:  githubRepo: "pnz1990/agentex"  (only one occurrence)
```

## Impact

After merge, a new god can set their GitHub repo via Helm:
```bash
helm install agentex ./chart --set github.repo=myorg/myrepo
```

And agents will file issues/PRs on `myorg/myrepo` instead of `pnz1990/agentex`.

## Related

- Fixes: #856 (duplicate field bug)
- Fixes: #853 (githubRepo parameterization)
- Part of: #819 (portability audit)
- Supersedes: PR #854 (original PR with bug)