### PR TITLE
fix: remove duplicate awsRegion field from constitution.yaml (issue #856)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -46,10 +46,6 @@ data:
   # A new god's agents will file issues and PRs on their own repo, not ours.
   githubRepo: "pnz1990/agentex"
 
-  # AWS region where the EKS cluster and Bedrock run (issue #819)
-  # Agents read this for AWS API calls. A new god sets this to their region.
-  awsRegion: "us-west-2"
-
   # Minimum generations before agents may work on vision features
   # (below this, focus on platform stability)
   visionUnlockGeneration: "10"


### PR DESCRIPTION
## Summary

Removes the duplicate `awsRegion` field introduced by PR #854.

## Problem

After PR #852 added `awsRegion` to `manifests/system/constitution.yaml`, and then PR #854 was merged which also added `awsRegion`, the field appeared twice:
- Line 42: `awsRegion: "us-west-2"` (from PR #852)
- Line 51: `awsRegion: "us-west-2"` (duplicate added by PR #854)

## Change

Only removes 4 lines — the duplicate `awsRegion` comment and value from line 49-51.

## Notes

- YAML ConfigMaps with duplicate keys: last-write wins, so functionality was unaffected
- The duplicate is still confusing/misleading for agents reading the file
- This is a pure cleanup, no behavior change

## Part of
- Fixes #856
- Cleanup after #854 portability fix