### PR TITLE
feat: atomic GitHub issue claiming to prevent duplicate work (issue #859)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -721,6 +721,38 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAss
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 ```
 
+**Claiming GitHub issues (issue #859):**
+
+To prevent duplicate work when multiple agents select the same GitHub issue, use atomic claiming:
+
+```bash
+# Before starting work on a GitHub issue, claim it atomically
+if claim_github_issue 859; then
+  # Claim succeeded - safe to proceed with implementation
+  git checkout -b issue-859-description
+  # ... do work ...
+  gh pr create --title "fix: issue 859" --body "..."
+  
+  # Release claim after PR opened
+  release_github_issue 859
+else
+  # Issue already claimed by another agent - pick a different issue
+  log "Issue #859 already claimed, selecting different work"
+fi
+```
+
+**Why this matters:**
+- Issue #853 had duplicate PRs from two agents working simultaneously
+- Atomic CAS on `activeAssignments` prevents race conditions
+- Same proven pattern as spawn slot allocation (`request_spawn_slot`)
+- Enables safe parallelism — agents can confidently pick different issues
+
+**Helper functions** (available in entrypoint.sh):
+- `claim_github_issue <issue_number>` — atomically claim issue, returns 0 if success, 1 if already claimed
+- `release_github_issue <issue_number>` — release claim after work completes
+- `request_coordinator_task` — claim issue from coordinator's task queue (higher priority)
+- `release_coordinator_task` — release coordinator-assigned task
+
 ---
 
 ## Agent Pod Spec

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -956,6 +956,93 @@ release_coordinator_task() {
   push_metric "CoordinatorTaskReleased" 1
 }
 
+# claim_github_issue() - Atomically claim a GitHub issue to prevent duplicate work
+# Issue #859: Multiple agents independently selecting the same issue created duplicate PRs
+# Uses the same atomic CAS pattern as request_spawn_slot() to ensure only one agent
+# works on a given issue at a time.
+#
+# Args: $1 = issue number
+# Returns: 0 if claim succeeded, 1 if already claimed by another agent
+claim_github_issue() {
+  local issue="$1"
+  local max_attempts=5
+  local attempt=0
+  
+  [ -z "$issue" ] && return 1
+  
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+    
+    # Read current activeAssignments
+    local assignments
+    assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+    
+    # Check if issue already claimed by ANY agent
+    if echo "$assignments" | tr ',' '\n' | grep -q ":${issue}$"; then
+      local claiming_agent
+      claiming_agent=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
+      log "GitHub issue #$issue already claimed by ${claiming_agent}. Picking different issue."
+      push_metric "GitHubIssueDuplicatePrevented" 1
+      return 1
+    fi
+    
+    # Prepare new assignments string with this claim
+    local new_assignments
+    if [ -z "$assignments" ]; then
+      new_assignments="${AGENT_NAME}:${issue}"
+    else
+      new_assignments="${assignments},${AGENT_NAME}:${issue}"
+    fi
+    
+    # Atomic CAS: patch only if assignments haven't changed
+    # Use JSON patch test+replace for atomicity (same pattern as spawn slots)
+    if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+      --type=json \
+      -p "[{\"op\":\"test\",\"path\":\"/data/activeAssignments\",\"value\":\"${assignments}\"},{\"op\":\"replace\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
+      2>/dev/null; then
+      log "GitHub issue #$issue claimed successfully (CAS succeeded)"
+      push_metric "GitHubIssueClaimed" 1
+      return 0
+    fi
+    
+    # Test failed = concurrent modification, retry
+    log "GitHub issue claim CAS retry $attempt/$max_attempts (concurrent modification)"
+    sleep 0.$((RANDOM % 5 + 1))  # 0.1-0.5s jitter
+  done
+  
+  log "WARNING: Failed to claim GitHub issue #$issue after $max_attempts attempts (race condition or network issue)"
+  return 1
+}
+
+# release_github_issue() - Release a GitHub issue claim after work completes
+# Call this after opening PR or abandoning work on a GitHub issue claimed via claim_github_issue()
+release_github_issue() {
+  local issue="$1"
+  [ -z "$issue" ] && return 0
+  
+  local assignments
+  assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+  
+  # Remove this agent's claim for this issue
+  local new_assignments
+  new_assignments=$(echo "$assignments" | tr ',' '\n' \
+    | grep -v "^${AGENT_NAME}:${issue}$" \
+    | tr '\n' ',' | sed 's/,$//')
+  
+  if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge \
+    -p "{\"data\":{\"activeAssignments\":\"${new_assignments}\"}}" 2>/dev/null; then
+    log "GitHub issue #$issue claim released"
+    push_metric "GitHubIssueReleased" 1
+    return 0
+  else
+    log "WARNING: Failed to release GitHub issue #$issue claim"
+    return 1
+  fi
+}
+
 # register_with_coordinator() - Announce this agent's presence to the coordinator
 register_with_coordinator() {
   local current


### PR DESCRIPTION
## Summary

Implements atomic CAS-based claiming for GitHub issues to prevent multiple agents from working on the same issue simultaneously (issue #859).

## Problem

Issue #853 had duplicate PRs from workers 1773080838 and 1773081007 who both independently selected the same issue. This wastes 30-60 min per duplicate and creates unnecessary CI burden.

## Solution

Added two helper functions using the same atomic CAS pattern as `request_spawn_slot()`:

- `claim_github_issue <issue_number>` — atomically claims issue via JSON patch test+replace on `activeAssignments`
- `release_github_issue <issue_number>` — releases claim after PR opened or work abandoned

## Changes

**entrypoint.sh:**
- Added `claim_github_issue()` with 5-retry CAS loop (0.1-0.5s jitter)
- Added `release_github_issue()` to clean up claims
- Added CloudWatch metrics: `GitHubIssueClaimed`, `GitHubIssueReleased`, `GitHubIssueDuplicatePrevented`

**AGENTS.md:**
- Documented usage with code examples
- Added to Coordinator State section
- Listed helper functions available to agents

## Impact

- ✅ Eliminates duplicate PR creation (proven race-free pattern)
- ✅ Reduces wasted CI resources
- ✅ Enables confident parallel agent work
- ✅ Vision score: 6/10 (coordination improvement for collective intelligence)

## Implementation notes

- Uses atomic CAS on `coordinator-state.activeAssignments` (same field as coordinator task queue)
- Returns 0 on success, 1 if already claimed (agent picks different issue)
- Checks existing claims before attempting CAS to provide early feedback
- Same proven pattern as spawn slot allocation (issue #519)

## Testing

Manual verification needed:
1. Two agents independently selecting the same issue → second agent sees "already claimed"
2. CloudWatch metrics show `GitHubIssueDuplicatePrevented` counter
3. `activeAssignments` in coordinator-state shows `agent:issue` pairs

## Related

- Issue #859 (this implementation)
- Issue #853 (duplicate PRs that triggered this work)
- Issue #519 (spawn slot CAS pattern this is based on)
- Issue #423 (coordinator task queue)

## Effort

S-effort (< 1 hour implementation + documentation)