### PR TITLE
feat: auto-rebase protected-file PRs when god-approved label added (issue #862)

### DIFF
--- a/.github/workflows/auto-rebase-god-approved.yml
+++ b/.github/workflows/auto-rebase-god-approved.yml
@@ -1,0 +1,75 @@
+name: Auto-Rebase God-Approved PRs
+
+# Triggered when god-approved label is added to a PR
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-rebase:
+    # Only run when god-approved label is added
+    if: github.event.label.name == 'god-approved'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          # Use GITHUB_TOKEN for authentication
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Configure git
+        run: |
+          git config --global user.name "agentex-bot"
+          git config --global user.email "agentex-bot@users.noreply.github.com"
+      
+      - name: Rebase on main
+        id: rebase
+        run: |
+          set -e
+          git fetch origin main
+          
+          # Attempt rebase
+          if git rebase origin/main; then
+            echo "rebase_status=success" >> $GITHUB_OUTPUT
+            echo "Rebase succeeded"
+          else
+            echo "rebase_status=conflict" >> $GITHUB_OUTPUT
+            echo "Rebase failed with conflicts"
+            git rebase --abort || true
+            exit 1
+          fi
+      
+      - name: Force push rebased branch
+        if: steps.rebase.outputs.rebase_status == 'success'
+        run: |
+          git push --force-with-lease origin ${{ github.event.pull_request.head.ref }}
+      
+      - name: Comment on PR
+        if: steps.rebase.outputs.rebase_status == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Auto-rebased on `main` after `god-approved` label was added. CI checks will re-run.'
+            })
+      
+      - name: Comment on conflict
+        if: steps.rebase.outputs.rebase_status == 'conflict'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ Auto-rebase failed due to merge conflicts. God must rebase this branch manually.'
+            })


### PR DESCRIPTION
## Summary

Implements issue #862 by adding a GitHub Action workflow that automatically rebases PR branches on `main` when the `god-approved` label is added.

## Problem

Protected-file PRs (`entrypoint.sh`, `AGENTS.md`, `manifests/rgds/*.yaml`) wait for god to add the `god-approved` label before they can merge. During this wait:
1. Other PRs merge to main
2. The protected-file PR branch goes stale with merge conflicts
3. God must manually rebase before the PR can merge

This wastes god's time and delays PR merges.

## Solution

New workflow: `.github/workflows/auto-rebase-god-approved.yml`

**Triggers:** When `god-approved` label is added to any PR

**Behavior:**
- Attempts `git rebase origin/main`
- If rebase succeeds: force-pushes and triggers CI re-run
- If conflicts: comments on PR alerting god to manual rebase needed

## Impact

- ✅ Reduces manual rebase work for god
- ✅ PRs can merge faster after god approves
- ✅ Graceful fallback if conflicts exist

## Testing

This can be tested by:
1. Opening a test PR touching protected files
2. Letting it sit while other PRs merge to main
3. Adding `god-approved` label
4. Verifying workflow rebases automatically

## Vision Score: 5/10

Platform stability improvement. Reduces god intervention, making the system more autonomous.

## Effort: S (< 30 min)

Fixes #862