### PR TITLE
fix: instruct planners to use claim_task for self-selected issues (issue #866)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1751,7 +1751,10 @@ if [ "$AGENT_ROLE" = "planner" ]; then
     push_metric "CoordinatorAssignment" 1
   else
     log "Coordinator queue empty or unavailable — planner will self-select from GitHub"
-    COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue."
+    COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue.
+
+IMPORTANT: Before starting work, atomically claim the issue with: claim_task <issue_number>
+If claim fails (returns 1), pick a different issue — another agent already claimed it."
   fi
   
   # Cleanup old thoughts (24h+) to prevent cluster resource buildup (issue #593)


### PR DESCRIPTION
## Summary

Fixes issue #866 - when the coordinator queue is empty, planners self-select from GitHub issues but the task prompt didn't instruct them to use `claim_task()`, leaving a duplicate-work race condition.

## Problem

PR #864 adds `claim_task()` for atomic task claiming and updates emergency perpetuation to instruct its use. However, the standard planner task prompt (when coordinator queue is empty) still says:

> Pick the highest-priority open issue and implement a fix or feature

Without explicit instruction to call `claim_task` before starting, two planners finding an empty queue can both pick the same GitHub issue and create duplicate PRs.

## Solution

Update the coordinator context string at line 1754 of entrypoint.sh to explicitly instruct:

```
IMPORTANT: Before starting work, atomically claim the issue with: claim_task <issue_number>
If claim fails (returns 1), pick a different issue — another agent already claimed it.
```

## Changes

- **images/runner/entrypoint.sh line 1754**: Added 3-line instruction to coordinator context string

## Impact

- S-effort (< 5 min implementation)
- Completes the atomic claiming mechanism from #859 / PR #864
- Ensures planners self-selecting from GitHub benefit from race-free claiming
- Vision score: 6/10 (coordination improvement for collective intelligence)

## Testing

Manual verification needed:
1. Deploy with empty coordinator queue
2. Two planners should both call `claim_task()` before starting work
3. Second planner sees "already claimed" and picks different issue
4. No duplicate PRs created

## Related

- Issue #859 (atomic task claiming - root implementation)
- PR #864 (adds `claim_task()` function - dependency)
- Issue #853 (duplicate PRs that triggered this work)

Closes #866