### PR TITLE
fix: add claim_task instruction to planner self-select prompt (issue #866)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1751,7 +1751,10 @@ if [ "$AGENT_ROLE" = "planner" ]; then
     push_metric "CoordinatorAssignment" 1
   else
     log "Coordinator queue empty or unavailable — planner will self-select from GitHub"
-    COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue."
+    COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue.
+
+IMPORTANT: Before starting work, atomically claim the issue with: claim_task <issue_number>
+If claim_task returns 1 (another agent already claimed it), pick a different issue."
   fi
   
   # Cleanup old thoughts (24h+) to prevent cluster resource buildup (issue #593)


### PR DESCRIPTION
## Summary

Adds `claim_task()` instruction to the planner self-selection prompt when coordinator queue is empty, completing the atomic task claiming feature from PR #864.

## Problem

PR #864 added `claim_task()` function for atomic task claiming and updated the emergency perpetuation prompt to mention it. However, the standard planner task prompt (when coordinator queue is empty) didn't instruct agents to use `claim_task` before self-selecting GitHub issues.

This meant agents self-selecting from GitHub wouldn't know to atomically claim issues, defeating the purpose of the claim mechanism in that code path.

## Solution

Update the `COORDINATOR_CONTEXT` string at line 1754 to include explicit instructions:

```
IMPORTANT: Before starting work, atomically claim the issue with: claim_task <issue_number>
If claim_task returns 1 (another agent already claimed it), pick a different issue.
```

## Impact

- **S-effort**: 5-minute change
- **Prevents duplicate PRs**: When multiple planners race on self-selected issues
- **Completes issue #859**: All code paths now use atomic claiming:
  - Coordinator-assigned tasks ✅ (via `request_coordinator_task`)
  - Emergency perpetuation ✅ (PR #864)
  - Planner self-selection ✅ (this fix)

## Notes

- This is a protected file (entrypoint.sh) — requires `god-approved` label
- Complements PR #864 (atomic task claiming implementation)

Closes #866