### PR TITLE
feat: parameterize RGDs with portability fields from constitution (issue #819)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -56,6 +56,14 @@ S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAME
 ECR_REGISTRY=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.ecrRegistry}' 2>/dev/null || echo "569190534191.dkr.ecr.us-west-2.amazonaws.com")
 
+# Read AWS region from constitution for portability (issue #819)
+# New gods run in their own region — override BEDROCK_REGION env var if constitution sets it
+AWS_REGION_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "")
+if [ -n "$AWS_REGION_FROM_CONSTITUTION" ]; then
+  BEDROCK_REGION="$AWS_REGION_FROM_CONSTITUTION"
+fi
+
 # Read GitHub repo from constitution for portability (issue #819)
 # New gods' agents will file issues/PRs on their own repo, not the original creator's
 GITHUB_REPO_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
@@ -63,6 +71,14 @@ GITHUB_REPO_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-co
 # Override REPO if constitution has githubRepo set (allows REPO env var for backward compat)
 if [ -n "$GITHUB_REPO_FROM_CONSTITUTION" ]; then
   REPO="$GITHUB_REPO_FROM_CONSTITUTION"
+fi
+
+# Read cluster name from constitution for portability (issue #819)
+# New gods run in their own cluster with a different name
+CLUSTER_FROM_CONSTITUTION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.clusterName}' 2>/dev/null || echo "")
+if [ -n "$CLUSTER_FROM_CONSTITUTION" ]; then
+  CLUSTER="$CLUSTER_FROM_CONSTITUTION"
 fi
 
 ts() { date +%s; }
@@ -1258,6 +1274,11 @@ spec:
   model: "${BEDROCK_MODEL}"
   swarmRef: "${SWARM_REF}"
   priority: 5
+  # Portability: pass constitution values so kro RGD uses correct image/region/repo (issue #819)
+  imageRegistry: "${ECR_REGISTRY}"
+  awsRegion: "${BEDROCK_REGION}"
+  githubRepo: "${REPO}"
+  clusterName: "${CLUSTER}"
 EOF
 ) || {
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -12,6 +12,12 @@ spec:
       model: string | default="us.anthropic.claude-sonnet-4-6"
       swarmRef: string | default=""
       priority: integer | default=5
+      # Portability fields — read from constitution by spawn_agent() (issue #819)
+      # A new god sets these in constitution ConfigMap; all agents inherit them automatically.
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      awsRegion: string | default="us-west-2"
+      githubRepo: string | default="pnz1990/agentex"
+      clusterName: string | default="agentex"
     status:
       jobName: ${agentJob.metadata.name}
       completionTime: ${agentJob.status.completionTime}
@@ -54,7 +60,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -73,11 +79,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      value: ${schema.spec.awsRegion}
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      value: ${schema.spec.githubRepo}
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: "agentex"
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -10,6 +10,11 @@ spec:
       enabled: boolean | default=true
       model: string | default="us.anthropic.claude-sonnet-4-6"
       imageTag: string | default="latest"
+      # Portability fields — set from constitution by install/bootstrap (issue #819)
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      awsRegion: string | default="us-west-2"
+      githubRepo: string | default="pnz1990/agentex"
+      clusterName: string | default="agentex"
     status:
       configMapName: ${coordinatorState.metadata.name}
       phase: ${coordinatorState.data.phase}
@@ -77,7 +82,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
                   imagePullPolicy: Always
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
                   securityContext:
@@ -91,11 +96,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      value: ${schema.spec.awsRegion}
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      value: ${schema.spec.githubRepo}
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -17,6 +17,10 @@ spec:
       consensusThreshold: integer | default=51
       githubRepo: string | default="pnz1990/agentex"
       model: string | default="us.anthropic.claude-sonnet-4-6"
+      # Portability fields — set by swarm creator from constitution (issue #819)
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      awsRegion: string | default="us-west-2"
+      clusterName: string | default="agentex"
     status:
       configMapName: ${swarmState.metadata.name}
       phase: ${swarmState.data.phase}
@@ -88,7 +92,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -107,11 +111,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      value: ${schema.spec.awsRegion}
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      value: ${schema.spec.githubRepo}
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -41,6 +41,10 @@ data:
   # Agents read this for AWS API calls. A new god sets this to their region.
   awsRegion: "us-west-2"
   
+  # Kubernetes cluster name (issue #819 portability)
+  # Used by agents to configure kubectl. A new god sets this to their cluster name.
+  clusterName: "agentex"
+  
   # GitHub repository for issue tracking and PRs (issue #819 portability)
   # God sets this to their own GitHub org/repo. Format: owner/repo
   # A new god's agents will file issues and PRs on their own repo, not ours.


### PR DESCRIPTION
## Summary

Implements portability for kro RGDs — the primary remaining blocker for v0.1 release.

Previously, agent-graph, coordinator-graph, and swarm-graph all had hardcoded values
for ECR registry, AWS region, GitHub repo, and cluster name. A new god installing
this system would have agents using OUR ECR, region, and GitHub repo silently.

## Changes

### RGDs (agent-graph, coordinator-graph, swarm-graph)
- Add 4 portability schema fields with safe defaults:
  - `imageRegistry` → used for container image URL
  - `awsRegion` → set as `BEDROCK_REGION` env var
  - `githubRepo` → set as `REPO` env var
  - `clusterName` → set as `CLUSTER` env var
- Replace hardcoded `569190534191.dkr.ecr.us-west-2.amazonaws.com`, `us-west-2`, `pnz1990/agentex`, `agentex` with `${schema.spec.*}` CEL expressions

### entrypoint.sh
- Read `awsRegion` from constitution, override `BEDROCK_REGION` env var
- Read `clusterName` from constitution, override `CLUSTER` env var
- `spawn_agent()` now passes `imageRegistry`, `awsRegion`, `githubRepo`, `clusterName` to Agent CR spec — so spawned successors use the same values

### constitution.yaml
- Add `clusterName: "agentex"` field (was missing; only `ecrRegistry`, `awsRegion`, `githubRepo` existed)

## How it works

A new god installs agentex and sets 4 fields in the constitution ConfigMap:
```bash
kubectl patch configmap agentex-constitution -n agentex --type=merge -p '{
  "data": {
    "ecrRegistry": "123456789.dkr.ecr.us-east-1.amazonaws.com",
    "awsRegion": "us-east-1",
    "clusterName": "my-cluster",
    "githubRepo": "myorg/myproject"
  }
}'
```

All agent Jobs spawned thereafter will use those values automatically.

## Backward compatibility

All new fields have safe defaults matching the current hardcoded values, so existing
deployments continue to work without any ConfigMap changes.

## Protected files

- `entrypoint.sh` — requires `god-approved` label
- `manifests/rgds/*.yaml` — requires `god-approved` label

## Vision Score: 8/10

This is release-readiness work (v0.1 milestone). Directly enables the goal of
"any Kubernetes-literate engineer can install this system without editing source files."

Partially closes #819