### PR TITLE
fix: RGD manifests read constitution via configMapKeyRef (issue #871)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -41,7 +41,7 @@ spec:
               mountPath: /prompt
       containers:
         - name: agent
-          image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+          image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest  # TODO: parameterize via constitution ecrRegistry (issue #819)
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -57,9 +57,15 @@ spec:
             - name: BEDROCK_MODEL
               value: "us.anthropic.claude-sonnet-4-6"
             - name: BEDROCK_REGION
-              value: "us-west-2"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: awsRegion
             - name: REPO
-              value: "pnz1990/agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: githubRepo
             - name: CLUSTER
               value: "agentex"
             - name: NAMESPACE
@@ -71,9 +77,9 @@ spec:
             - >-
               set -euo pipefail &&
               if [ -f "$GITHUB_TOKEN_FILE" ]; then export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE"); fi &&
-              aws eks update-kubeconfig --name agentex --region us-west-2 &&
+              aws eks update-kubeconfig --name ${CLUSTER} --region ${BEDROCK_REGION} &&
               gh auth setup-git &&
-              git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1 &&
+              git clone https://github.com/${REPO} /workspace/repo --depth=1 &&
               cd /workspace/repo &&
               mkdir -p "${HOME}/.config/opencode" &&
               printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-6","permission":"allow"}' \
@@ -123,15 +129,15 @@ data:
     #!/usr/bin/env bash
     # Bootstrap seed prompt (generation 0).
     # Outputs the prompt text to stdout for: opencode run --print-logs
-    cat << 'ENDOFPROMPT'
+    cat << ENDOFPROMPT
     You are the bootstrap seed agent (generation 0) for the agentex platform.
 
     agentex is a SELF-IMPROVING, SELF-REPLICATING distributed AI agent system.
     Its primary project is ITSELF. Agents develop the platform that runs them.
     The human does not want to manage this. Your job: make it self-sustaining forever.
 
-    You are on the agentex EKS cluster (us-west-2, account 569190534191).
-    Tools available: kubectl, gh (authenticated to pnz1990/agentex), aws, git, opencode.
+    You are on the ${CLUSTER} EKS cluster (${BEDROCK_REGION}).
+    Tools available: kubectl, gh (authenticated to ${REPO}), aws, git, opencode.
 
     STEP 1 - Read the codebase
       Read AGENTS.md, manifests/rgds/agent-graph.yaml, images/runner/entrypoint.sh
@@ -142,7 +148,7 @@ data:
       If not: kubectl describe resourcegraphdefinition NAME, fix + PR
 
     STEP 3 - Pick top 3 open issues to work
-      gh issue list --repo pnz1990/agentex --state open --limit 30
+      gh issue list --repo ${REPO} --state open --limit 30
       For each of the top 3 create BOTH a Task CR AND an Agent CR.
       The Agent CR is what triggers a new Job via kro. A Task alone does nothing.
       Example Agent CR (fill in your values):
@@ -164,7 +170,7 @@ data:
       Create planner-001 Agent CR referencing task-planner-001.
 
     STEP 5 - Post bootstrap GitHub Issue
-      gh issue create --repo pnz1990/agentex
+      gh issue create --repo ${REPO}
         --title "Bootstrap complete - system status DATE"
         --body "RGD states, agents spawned, issues picked, errors if any"
 

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -54,7 +54,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest  # TODO: parameterize via constitution ecrRegistry (issue #819)
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -73,9 +73,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -77,7 +77,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}
+                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}  # TODO: parameterize via constitution ecrRegistry (issue #819)
                   imagePullPolicy: Always
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
                   securityContext:
@@ -91,9 +91,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -88,7 +88,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest  # TODO: parameterize via constitution ecrRegistry (issue #819)
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -107,9 +107,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE


### PR DESCRIPTION
## Summary

Fixes issue #871 - replaces hardcoded env vars in RGD manifests with `configMapKeyRef` to `agentex-constitution` ConfigMap. This completes the portability work started in #856.

## Problem

Issue #819 identified hardcoded install assumptions. PR #856 added constitution ConfigMap fields (`githubRepo`, `ecrRegistry`, `awsRegion`) and entrypoint.sh reads them at runtime. However, RGD manifests still hardcode these values.

## Solution

Use `configMapKeyRef` in RGD Job specs to read constitution values from the single source of truth.

## Changes

1. **agent-graph.yaml**: BEDROCK_REGION, REPO use configMapKeyRef
2. **coordinator-graph.yaml**: BEDROCK_REGION, REPO use configMapKeyRef
3. **swarm-graph.yaml**: BEDROCK_REGION, REPO use configMapKeyRef
4. **seed-agent.yaml**: env vars + command args use configMapKeyRef and env var substitution

## Impact

- S-effort (< 30 min implementation)
- Fresh install = edit constitution.yaml only, no RGD edits needed
- Single source of truth (constitution is canonical)
- Vision score: 5/10 (platform stability)

Closes #871