### PR TITLE
fix: RGD manifests read constitution values via envFrom instead of hardcoding

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -41,6 +41,8 @@ spec:
               mountPath: /prompt
       containers:
         - name: agent
+          # NOTE: Image registry should match agentex-constitution ConfigMap ecrRegistry field
+          # A fresh install requires updating this to match your AWS account ECR
           image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
           imagePullPolicy: Always
           securityContext:
@@ -57,9 +59,15 @@ spec:
             - name: BEDROCK_MODEL
               value: "us.anthropic.claude-sonnet-4-6"
             - name: BEDROCK_REGION
-              value: "us-west-2"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: awsRegion
             - name: REPO
-              value: "pnz1990/agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: githubRepo
             - name: CLUSTER
               value: "agentex"
             - name: NAMESPACE

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -54,6 +54,8 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
+                  # NOTE: Image registry should match agentex-constitution ConfigMap ecrRegistry field
+                  # A fresh install requires updating this to match your AWS account ECR
                   image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
@@ -73,9 +75,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -77,6 +77,8 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
+                  # NOTE: Image registry should match agentex-constitution ConfigMap ecrRegistry field
+                  # A fresh install requires updating this to match your AWS account ECR
                   image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}
                   imagePullPolicy: Always
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
@@ -91,9 +93,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -88,6 +88,8 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
+                  # NOTE: Image registry should match agentex-constitution ConfigMap ecrRegistry field
+                  # A fresh install requires updating this to match your AWS account ECR
                   image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
@@ -107,9 +109,15 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
                       value: "agentex"
                     - name: NAMESPACE


### PR DESCRIPTION
## Summary

Fixes #871 - Make constitution ConfigMap the single source of truth for installation parameters.

## Changes

**All 4 files now use `configMapKeyRef` for runtime env vars:**
- `manifests/rgds/agent-graph.yaml`: BEDROCK_REGION and REPO
- `manifests/rgds/coordinator-graph.yaml`: BEDROCK_REGION and REPO  
- `manifests/rgds/swarm-graph.yaml`: BEDROCK_REGION and REPO
- `manifests/bootstrap/seed-agent.yaml`: BEDROCK_REGION and REPO

**Documentation improvements:**
- Added comments documenting that image field should match constitution ecrRegistry

## Before (fragile hardcoding)
```yaml
env:
  - name: BEDROCK_REGION
    value: "us-west-2"
  - name: REPO
    value: "pnz1990/agentex"
```

## After (single source of truth)
```yaml
env:
  - name: BEDROCK_REGION
    valueFrom:
      configMapKeyRef:
        name: agentex-constitution
        key: awsRegion
  - name: REPO
    valueFrom:
      configMapKeyRef:
        name: agentex-constitution
        key: githubRepo
```

## Benefits

✅ **Fresh install only requires editing constitution.yaml** - no hunting through 4 different files  
✅ **Runtime values guaranteed to match constitution** - no divergence possible  
✅ **Completes #819 portability goal** - env vars aspect done (image field still needs manual edit)  
✅ **Removes fragile hardcoding pattern** - one change point for new gods  

## Testing

Runtime values are already read from constitution by entrypoint.sh (lines 59-66), so this change ensures the initial pod env vars match what agents will read. No behavior change for existing installations.

## Effort

S-effort (~20 min) - 4 files, straightforward find-replace pattern

## Vision Alignment

visionScore: 5/10 (platform stability - removes installation friction for new gods)