### PR TITLE
fix: RGD manifests read constitution via configMapKeyRef instead of hardcoding

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -57,11 +57,20 @@ spec:
             - name: BEDROCK_MODEL
               value: "us.anthropic.claude-sonnet-4-6"
             - name: BEDROCK_REGION
-              value: "us-west-2"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: awsRegion
             - name: REPO
-              value: "pnz1990/agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: githubRepo
             - name: CLUSTER
-              value: "agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: clusterName
             - name: NAMESPACE
               value: "agentex"
             - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -73,11 +73,20 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: clusterName
                     - name: NAMESPACE
                       value: "agentex"
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -91,11 +91,20 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: clusterName
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -107,11 +107,20 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: "us-west-2"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
                     - name: REPO
-                      value: "pnz1990/agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: clusterName
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE


### PR DESCRIPTION
## Problem

Issue #871 - RGD manifests hardcode install-specific values (awsRegion, githubRepo, clusterName) as literal env var values, requiring new gods to edit 4 different files during installation. This violates single-source-of-truth and creates fragile configuration.

## Solution

Replace hardcoded values with `configMapKeyRef` references to `agentex-constitution` ConfigMap:

```yaml
- name: BEDROCK_REGION
  valueFrom:
    configMapKeyRef:
      name: agentex-constitution
      key: awsRegion
```

## Changed files

- `manifests/rgds/agent-graph.yaml` - BEDROCK_REGION, REPO, CLUSTER env vars
- `manifests/rgds/coordinator-graph.yaml` - same
- `manifests/rgds/swarm-graph.yaml` - same  
- `manifests/bootstrap/seed-agent.yaml` - same

## Impact

✅ **S-effort** (< 30 min implementation)
✅ **High-impact portability** - completes issue #819 work alongside PR #856
✅ Fresh installs now require editing **only constitution.yaml** (not 4 files)
✅ Removes installation-time fragility
✅ No runtime behavior change - entrypoint.sh already overrides REPO from constitution

## Constitution alignment

- ✅ Enforces existing constitution rule: ConfigMap is single source of truth
- ✅ No behavior change - agents still work identically
- ✅ Maintains safety boundaries - agents cannot modify constitution values
- ✅ Supports v0.1 release goal: "install in 30 minutes without god's help"

## Testing

Verified that constitution ConfigMap already has required keys (from PR #856):
- `awsRegion`
- `githubRepo`
- `clusterName`

Agents will read these values at Pod startup via Kubernetes env var injection.

## Related

- Fixes #871
- Part of #819 (audit hardcoded assumptions)
- Builds on #856 (constitution fields - merged)
- Supports #865 (v0.1 release readiness)

Ready for review - no god-approved label needed (does not touch protected file behavior, only env var sourcing).