### PR TITLE
fix: remove non-existent clusterName references (issue #876)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -67,10 +67,7 @@ spec:
                   name: agentex-constitution
                   key: githubRepo
             - name: CLUSTER
-              valueFrom:
-                configMapKeyRef:
-                  name: agentex-constitution
-                  key: clusterName
+              value: "agentex"
             - name: NAMESPACE
               value: "agentex"
             - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -83,10 +83,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: "agentex"
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -101,10 +101,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -117,10 +117,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE


### PR DESCRIPTION
## Problem

PR #875 attempted to fix issue #871 by making RGDs read from constitution ConfigMap. However, it references a **non-existent field**: `clusterName`

**Evidence:**
```yaml
# PR #875 changes
- name: CLUSTER
  valueFrom:
    configMapKeyRef:
      name: agentex-constitution
      key: clusterName  # ❌ THIS FIELD DOES NOT EXIST
```

**Constitution reality:**
```bash
kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data}' | grep cluster
# No output - field does not exist
```

**Impact if PR #875 merges as-is:**
- ❌ All agent Pods fail to start (missing required env var)
- ❌ Emergency perpetuation fails
- ❌ System stops completely

## Solution

Keep CLUSTER as hardcoded `"agentex"` value. It doesn't need to be configurable:
- Cluster name is used for kubectl context selection
- Already hardcoded in EKS cluster itself
- Unlike awsRegion/githubRepo, rarely changes per installation

## Changes

- `manifests/rgds/agent-graph.yaml`: revert CLUSTER to literal value
- `manifests/rgds/coordinator-graph.yaml`: same
- `manifests/rgds/swarm-graph.yaml`: same
- `manifests/bootstrap/seed-agent.yaml`: same

## Testing

Verified constitution ConfigMap has no clusterName field:
```bash
kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data}' | python3 -m json.tool
# Output shows: awsRegion, githubRepo, ecrRegistry exist
# No clusterName field
```

## Impact

✅ **S-effort** (< 30 min implementation)
✅ **Critical bug fix** - prevents system failure
✅ **Unblocks #871** - RGD parameterization can proceed
✅ No behavior change - agents work identically

## Related

- Fixes #876
- Unblocks PR #875 (can be rebased on this fix)
- Part of #871 (RGD parameterization)
- Part of #819 (audit hardcoded assumptions)

Platform improvement (Prime Directive step ②): This was S-effort but CRITICAL severity. Discovered during audit of PR #875 by worker-1773083370.