### PR TITLE
fix: seed-agent portability - read cluster/region/repo from constitution (issue #877)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -57,11 +57,20 @@ spec:
             - name: BEDROCK_MODEL
               value: "us.anthropic.claude-sonnet-4-6"
             - name: BEDROCK_REGION
-              value: "us-west-2"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: awsRegion
             - name: REPO
-              value: "pnz1990/agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: githubRepo
             - name: CLUSTER
-              value: "agentex"
+              valueFrom:
+                configMapKeyRef:
+                  name: agentex-constitution
+                  key: clusterName
             - name: NAMESPACE
               value: "agentex"
             - name: GITHUB_TOKEN_FILE
@@ -71,9 +80,9 @@ spec:
             - >-
               set -euo pipefail &&
               if [ -f "$GITHUB_TOKEN_FILE" ]; then export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE"); fi &&
-              aws eks update-kubeconfig --name agentex --region us-west-2 &&
+              aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION) &&
               gh auth setup-git &&
-              git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1 &&
+              git clone https://github.com/$(REPO) /workspace/repo --depth=1 &&
               cd /workspace/repo &&
               mkdir -p "${HOME}/.config/opencode" &&
               printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-6","permission":"allow"}' \
@@ -123,15 +132,18 @@ data:
     #!/usr/bin/env bash
     # Bootstrap seed prompt (generation 0).
     # Outputs the prompt text to stdout for: opencode run --print-logs
-    cat << 'ENDOFPROMPT'
+    # Note: env vars (REPO, CLUSTER, BEDROCK_REGION) are expanded by the shell here,
+    # having been injected from the agentex-constitution ConfigMap.
+    cat << ENDOFPROMPT
     You are the bootstrap seed agent (generation 0) for the agentex platform.
 
     agentex is a SELF-IMPROVING, SELF-REPLICATING distributed AI agent system.
     Its primary project is ITSELF. Agents develop the platform that runs them.
     The human does not want to manage this. Your job: make it self-sustaining forever.
 
-    You are on the agentex EKS cluster (us-west-2, account 569190534191).
-    Tools available: kubectl, gh (authenticated to pnz1990/agentex), aws, git, opencode.
+    You are on the ${CLUSTER} EKS cluster (${BEDROCK_REGION}).
+    GitHub repository: ${REPO}
+    Tools available: kubectl, gh (authenticated to ${REPO}), aws, git, opencode.
 
     STEP 1 - Read the codebase
       Read AGENTS.md, manifests/rgds/agent-graph.yaml, images/runner/entrypoint.sh
@@ -142,7 +154,7 @@ data:
       If not: kubectl describe resourcegraphdefinition NAME, fix + PR
 
     STEP 3 - Pick top 3 open issues to work
-      gh issue list --repo pnz1990/agentex --state open --limit 30
+      gh issue list --repo ${REPO} --state open --limit 30
       For each of the top 3 create BOTH a Task CR AND an Agent CR.
       The Agent CR is what triggers a new Job via kro. A Task alone does nothing.
       Example Agent CR (fill in your values):
@@ -164,8 +176,8 @@ data:
       Create planner-001 Agent CR referencing task-planner-001.
 
     STEP 5 - Post bootstrap GitHub Issue
-      gh issue create --repo pnz1990/agentex
-        --title "Bootstrap complete - system status DATE"
+      gh issue create --repo ${REPO}
+        --title "Bootstrap complete - system status $(date -u '+%Y-%m-%d')"
         --body "RGD states, agents spawned, issues picked, errors if any"
 
     RULES:

--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -41,6 +41,11 @@ data:
   # Agents read this for AWS API calls. A new god sets this to their region.
   awsRegion: "us-west-2"
   
+  # Kubernetes cluster name (issue #877 portability)
+  # Used in: aws eks update-kubeconfig --name $(CLUSTER), seed-agent bootstrap command.
+  # A new god sets this to match their EKS cluster name.
+  clusterName: "agentex"
+  
   # GitHub repository for issue tracking and PRs (issue #819 portability)
   # God sets this to their own GitHub org/repo. Format: owner/repo
   # A new god's agents will file issues and PRs on their own repo, not ours.


### PR DESCRIPTION
## Summary

Fixes issue #877 - completes the portability work in seed-agent.yaml that PR #875 started.

## Problem

PR #875 fixes the `env` section (BEDROCK_REGION, REPO, CLUSTER now use `configMapKeyRef`). However, the `args` command section and seed prompt still had hardcoded values:

**Before (args)**:
```yaml
args:
  - >-
    aws eks update-kubeconfig --name agentex --region us-west-2 &&
    git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1 &&
```

**Before (seed prompt)**:
```
You are on the agentex EKS cluster (us-west-2, account 569190534191).
Tools available: kubectl, gh (authenticated to pnz1990/agentex)
```

A new god would have their seed agent try to configure kubectl for the wrong cluster name, pull the wrong GitHub repo, and tell the seed it's on the original god's cluster.

## Solution

Kubernetes env vars injected via `configMapKeyRef` can be referenced in `args` using `$(VAR_NAME)` syntax:

**After (args)**:
```yaml
args:
  - >-
    aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION) &&
    git clone https://github.com/$(REPO) /workspace/repo --depth=1 &&
```

For the seed prompt: removed single-quotes from heredoc (`cat << ENDOFPROMPT` instead of `cat << 'ENDOFPROMPT'`) so bash expands `${CLUSTER}`, `${BEDROCK_REGION}`, `${REPO}` env vars at runtime.

## Changes

- `manifests/bootstrap/seed-agent.yaml`:
  - `env`: BEDROCK_REGION, REPO, CLUSTER → `configMapKeyRef` from constitution
  - `args`: hardcoded names → `$(CLUSTER)`, `$(BEDROCK_REGION)`, `$(REPO)`
  - seed prompt: hardcoded cluster/region/repo → `${CLUSTER}`, `${BEDROCK_REGION}`, `${REPO}`
  - heredoc: `'ENDOFPROMPT'` → `ENDOFPROMPT` (enables env var expansion)

- `manifests/system/constitution.yaml`:
  - Add `clusterName: "agentex"` field (referenced by configMapKeyRef)

## Impact

- ✅ **S-effort** (< 30 min)
- ✅ **Release blocker fixed** (issue #819, #865)
- ✅ A fresh install only requires editing `agentex-constitution` ConfigMap
- ✅ No existing deployment changes needed (safe defaults preserved)

## Notes

- Complements PR #875 which fixed the `env` section
- `constitution.yaml` is a protected file — requires `god-approved` label
- `seed-agent.yaml` is a bootstrap file (not in the protected list but touches install flow)

Closes #877
Part of #819, #865