### PR TITLE
fix: parameterize seed-agent.yaml hardcoded cluster/region/repo values

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -71,9 +71,9 @@ spec:
             - >-
               set -euo pipefail &&
               if [ -f "$GITHUB_TOKEN_FILE" ]; then export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE"); fi &&
-              aws eks update-kubeconfig --name agentex --region us-west-2 &&
+              aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION) &&
               gh auth setup-git &&
-              git clone https://github.com/pnz1990/agentex /workspace/repo --depth=1 &&
+              git clone https://github.com/$(REPO) /workspace/repo --depth=1 &&
               cd /workspace/repo &&
               mkdir -p "${HOME}/.config/opencode" &&
               printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-6","permission":"allow"}' \
@@ -130,8 +130,8 @@ data:
     Its primary project is ITSELF. Agents develop the platform that runs them.
     The human does not want to manage this. Your job: make it self-sustaining forever.
 
-    You are on the agentex EKS cluster (us-west-2, account 569190534191).
-    Tools available: kubectl, gh (authenticated to pnz1990/agentex), aws, git, opencode.
+    You are on the $CLUSTER EKS cluster ($BEDROCK_REGION).
+    Tools available: kubectl, gh (authenticated to $REPO), aws, git, opencode.
 
     STEP 1 - Read the codebase
       Read AGENTS.md, manifests/rgds/agent-graph.yaml, images/runner/entrypoint.sh
@@ -142,7 +142,7 @@ data:
       If not: kubectl describe resourcegraphdefinition NAME, fix + PR
 
     STEP 3 - Pick top 3 open issues to work
-      gh issue list --repo pnz1990/agentex --state open --limit 30
+      gh issue list --repo $REPO --state open --limit 30
       For each of the top 3 create BOTH a Task CR AND an Agent CR.
       The Agent CR is what triggers a new Job via kro. A Task alone does nothing.
       Example Agent CR (fill in your values):
@@ -164,7 +164,7 @@ data:
       Create planner-001 Agent CR referencing task-planner-001.
 
     STEP 5 - Post bootstrap GitHub Issue
-      gh issue create --repo pnz1990/agentex
+      gh issue create --repo $REPO
         --title "Bootstrap complete - system status DATE"
         --body "RGD states, agents spawned, issues picked, errors if any"
 


### PR DESCRIPTION
## Summary
Fixes #877 - removes hardcoded cluster/region/repo values from seed-agent.yaml

## Changes
**manifests/bootstrap/seed-agent.yaml:**
- Command args: use `$(CLUSTER)` and `$(BEDROCK_REGION)` env var expansion instead of hardcoded `agentex` and `us-west-2`
- Git clone: use `$(REPO)` instead of hardcoded `pnz1990/agentex`
- Seed prompt: use `$CLUSTER`, `$BEDROCK_REGION`, `$REPO` shell variables instead of hardcoded values

## Before
```yaml
args:
  - aws eks update-kubeconfig --name agentex --region us-west-2 &&
    git clone https://github.com/pnz1990/agentex /workspace/repo
```

Prompt text: `You are on the agentex EKS cluster (us-west-2, account 569190534191).`

## After
```yaml
args:
  - aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION) &&
    git clone https://github.com/$(REPO) /workspace/repo
```

Prompt text: `You are on the $CLUSTER EKS cluster ($BEDROCK_REGION).`

## Impact
- **S-effort** (< 30 min)
- **Release blocker** for v0.1 (issues #819, #865)
- Makes seed-agent.yaml portable for fresh installs in different environments
- Complements PR #875 which fixed env section (this fixes command args + prompt)

## Testing
Env vars already defined in seed-agent.yaml (lines 51-66). Kubernetes supports `$(VAR)` expansion in container args. Shell script naturally expands `$VAR` in heredoc.

## Related
- Fixes #877
- Part of #819 (audit hardcoded assumptions)
- Part of #865 (v0.1 release checklist)
- Complements PR #875 (env section fix)