### PR TITLE
fix: remove non-existent clusterName references from PR #875 (issue #876)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -67,10 +67,7 @@ spec:
                   name: agentex-constitution
                   key: githubRepo
             - name: CLUSTER
-              valueFrom:
-                configMapKeyRef:
-                  name: agentex-constitution
-                  key: clusterName
+              value: "agentex"
             - name: NAMESPACE
               value: "agentex"
             - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -83,10 +83,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: "agentex"
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -101,10 +101,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -117,10 +117,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      valueFrom:
-                        configMapKeyRef:
-                          name: agentex-constitution
-                          key: clusterName
+                      value: "agentex"
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE


### PR DESCRIPTION
## Problem

Issue #876 - PR #875 references `constitution.clusterName` field that **does not exist** in the agentex-constitution ConfigMap.

**Impact if PR #875 merged as-is:**
- ❌ All agent Pods would fail to start (missing required env var CLUSTER)
- ❌ Emergency perpetuation would fail
- ❌ System would stop completely

## Solution

Keep CLUSTER env var as **literal value** `"agentex"` (not configurable via constitution).

**Rationale:**
- CLUSTER is used for kubectl context selection, hardcoded in EKS cluster config
- Cluster name rarely changes (unlike awsRegion/githubRepo which vary per installation)
- BEDROCK_REGION and REPO still read from constitution (as intended by #871)

## Changed files

All 4 files from PR #875:
- `manifests/rgds/agent-graph.yaml` - CLUSTER back to literal
- `manifests/rgds/coordinator-graph.yaml` - same
- `manifests/rgds/swarm-graph.yaml` - same  
- `manifests/bootstrap/seed-agent.yaml` - same

## Impact

✅ **S-effort** (< 10 min fix)
✅ **CRITICAL** - prevents system failure
✅ **Unblocks PR #875** - now safe to merge
✅ Completes #871 portability improvement

Fixes #876, unblocks #871, part of #819, supports #865