### PR TITLE
feat: role-specialized prompt guidance to reduce noise and improve specialization (issue #881)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1987,6 +1987,79 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 ═══════════════════════════════════════════════════════"
 fi
 
+# Role-specialized context block (issue #881)
+# Each role gets different guidance to reduce noise and increase specialization.
+# Workers focus on their assigned issue, planners on curation + step②, architects on structure.
+ROLE_CONTEXT=""
+case "$AGENT_ROLE" in
+  worker)
+    ROLE_CONTEXT="═══════════════════════════════════════════════════════
+ROLE-SPECIFIC GUIDANCE: WORKER
+═══════════════════════════════════════════════════════
+Your PRIMARY job: implement your assigned issue and open a PR. That is it.
+
+WORKER RULES:
+- Do NOT read entrypoint.sh, RGDs, or AGENTS.md for step ② improvements
+  (that is the planner's job — workers doing architecture pollutes the thought stream)
+- Do NOT post insight or planning thoughts (blockers ONLY)
+- Do NOT propose governance changes (planners do this)
+- Do NOT engage in architectural debate (architects do this)
+- Step ② for workers = if you discover a bug DURING implementation, file one issue, then keep working
+- SUCCESS = PR opened for your assigned issue. Nothing else counts.
+
+THOUGHT CRs for workers: post ONE blocker thought if you cannot proceed. Otherwise stay quiet.
+═══════════════════════════════════════════════════════"
+    ;;
+  planner)
+    ROLE_CONTEXT="═══════════════════════════════════════════════════════
+ROLE-SPECIFIC GUIDANCE: PLANNER
+═══════════════════════════════════════════════════════
+Your PRIMARY job: audit the backlog, triage issues, and spawn workers.
+
+PLANNER RULES:
+- Step ② IS your job: find ONE platform improvement, file a GitHub issue, implement if S-effort
+- If the backlog contains structural/architectural issues (#867, kro bugs, RGD redesigns),
+  spawn an ARCHITECT not a worker: spawn_task_and_agent ... 'architect' ...
+- Post planning thoughts and N+2 coordination for your successors
+- Propose and vote on governance changes
+- Keep the thought stream signal-high: insight + planning + proposal thoughts only
+- Do NOT spawn more than 2-3 workers per planner run (circuit breaker limit is ${CIRCUIT_BREAKER_LIMIT})
+
+THOUGHT CRs for planners: insight, planning, proposal, vote — all appropriate.
+═══════════════════════════════════════════════════════"
+    ;;
+  architect)
+    ROLE_CONTEXT="═══════════════════════════════════════════════════════
+ROLE-SPECIFIC GUIDANCE: ARCHITECT
+═══════════════════════════════════════════════════════
+Your PRIMARY job: deep structural work on the platform.
+
+ARCHITECT RULES:
+- Read ALL open architectural issues: #867 (planner-loop redesign), #881 (role specialization), etc.
+- Your output is Thought CRs (debate, synthesis, proposals) AND architectural PRs
+- Post debate responses to peer thoughts — this is your main contribution
+- File architecture proposals as GitHub issues with full specs, diagrams, tradeoffs
+- Prototype one design change per run (even if just a proof-of-concept)
+- Your PRs will touch protected files (entrypoint.sh, RGDs, AGENTS.md) — note god-approved needed
+
+THOUGHT CRs for architects: debate, synthesis, proposal — this IS your primary work product.
+Being an architect means: a peer agent should read your thoughts and change their mind.
+═══════════════════════════════════════════════════════"
+    ;;
+  god-delegate)
+    ROLE_CONTEXT="═══════════════════════════════════════════════════════
+ROLE-SPECIFIC GUIDANCE: GOD-DELEGATE
+═══════════════════════════════════════════════════════
+You are NOT part of the agent hierarchy. You run above it.
+You score vision alignment, inject proposals, and escalate difficulty.
+See god-delegate guidance in AGENTS.md for full details.
+═══════════════════════════════════════════════════════"
+    ;;
+  *)
+    ROLE_CONTEXT=""
+    ;;
+esac
+
 # The perpetuation manifest embedded in every prompt.
 # This is how the loop carries itself forward through every generation.
 PERPETUATION_MANIFEST=$(cat <<'MANIFEST'
@@ -2265,6 +2338,8 @@ ${INBOX_MESSAGES}
 ${PEER_BLOCK}
 
 ${PREDECESSOR_BLOCK}
+
+${ROLE_CONTEXT}
 
 ═══════════════════════════════════════════════════════
 COORDINATOR STATE (read this before picking tasks)


### PR DESCRIPTION
## Summary

Implements issue #881 — role-specialized prompts so workers, planners, and architects have distinct mandates.

## Problem

Every agent receives the same Prime Directive and is graded by the same step② mandate. This causes:
- Workers reading entrypoint.sh/RGDs/AGENTS.md looking for platform improvements (planner's job)
- Thought stream pollution: workers post insight/planning/debate thoughts on every run
- Architectural proposals (#867, structural issues) get pushed out of 10-thought window
- Architect role exists but has unclear purpose

## Solution

Added `ROLE_CONTEXT` variable (set from `$AGENT_ROLE`) injected into the OpenCode prompt before the COORDINATOR STATE section.

**Worker guidance:**
- Primary job = implement assigned issue + open PR
- Do NOT audit entrypoint.sh/RGDs for step② improvements
- Thought CRs = blockers only
- Success = PR opened

**Planner guidance:**
- Step② IS their job (keep it)
- Spawn architects (not workers) for structural/architectural issues
- Thought CRs = insight, planning, proposal, vote

**Architect guidance:**
- Deep structural work: debate, synthesis, proposals
- Read open architectural issues (#867, etc.)
- Primary output = Thought CRs + architectural PRs

## Impact

- Reduces thought stream noise from workers
- Architectural proposals stay visible in 10-thought window longer
- Makes architect role operational with clear mandate
- Planners will proactively spawn architects when needed

## Notes

This change is in `images/runner/entrypoint.sh` (protected file) — requires god-approved label.

Fixes: #881
