### PR TITLE
fix: parameterize ECR registry and cluster name in RGDs (issue #871)

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -12,6 +12,8 @@ spec:
       model: string | default="us.anthropic.claude-sonnet-4-6"
       swarmRef: string | default=""
       priority: integer | default=5
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      clusterName: string | default="agentex"
     status:
       jobName: ${agentJob.metadata.name}
       completionTime: ${agentJob.status.completionTime}
@@ -54,7 +56,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -83,7 +85,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: "agentex"
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -10,6 +10,8 @@ spec:
       enabled: boolean | default=true
       model: string | default="us.anthropic.claude-sonnet-4-6"
       imageTag: string | default="latest"
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      clusterName: string | default="agentex"
     status:
       configMapName: ${coordinatorState.metadata.name}
       phase: ${coordinatorState.data.phase}
@@ -77,7 +79,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:${schema.spec.imageTag}
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
                   imagePullPolicy: Always
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
                   securityContext:
@@ -101,7 +103,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/manifests/rgds/swarm-graph.yaml
+++ b/manifests/rgds/swarm-graph.yaml
@@ -17,6 +17,8 @@ spec:
       consensusThreshold: integer | default=51
       githubRepo: string | default="pnz1990/agentex"
       model: string | default="us.anthropic.claude-sonnet-4-6"
+      imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
+      clusterName: string | default="agentex"
     status:
       configMapName: ${swarmState.metadata.name}
       phase: ${swarmState.data.phase}
@@ -88,7 +90,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: agent
-                  image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -117,7 +119,7 @@ spec:
                           name: agentex-constitution
                           key: githubRepo
                     - name: CLUSTER
-                      value: "agentex"
+                      value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE


### PR DESCRIPTION
## Summary

Completes issue #871 and #819 portability goals. RGD manifests now read ECR registry and cluster name from schema fields instead of hardcoding them.

## Changes

**agent-graph.yaml:**
- Added `imageRegistry` and `clusterName` schema fields with backward-compatible defaults
- Changed `image:` from hardcoded `569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest` to `${schema.spec.imageRegistry}/agentex/runner:latest`
- Changed `CLUSTER` env var from `"agentex"` to `${schema.spec.clusterName}`

**coordinator-graph.yaml:**
- Same changes as agent-graph (image + CLUSTER parameterization)

**swarm-graph.yaml:**
- Same changes as agent-graph (image + CLUSTER parameterization)

## Why This Matters

**Before:** Fresh install required editing 3 RGD files + seed-agent.yaml + constitution.yaml (5 files)

**After:** Fresh install only requires editing constitution.yaml (1 file). Agent/Coordinator/Swarm CRs can override imageRegistry/clusterName when created.

## Testing

Backward compatibility: defaults match current hardcoded values, so existing Agent CRs work unchanged.

## Related

- Issue #871 (this fix)
- Issue #819 (parent: portability audit)
- Issue #886 (live constitution sync - also fixed in this run)
- PR #884 (sibling: BEDROCK_REGION/REPO via configMapKeyRef)
- PR #880 (sibling: seed-agent.yaml args parameterization)

## Effort

S-effort (< 30 minutes). Vision score: 6/10 (platform portability for v0.1 release).
