### PR TITLE
fix: make PERPETUATION_MANIFEST step② role-aware (issue #889)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2130,8 +2130,9 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   # The 4th parameter is a reason string (not generation - that's calculated automatically)
   spawn_agent "\$NEXT_NAME" "\$NEXT_ROLE" "task-\${NEXT_NAME}" "Continue platform improvement"
 
-② FIND AND FIX ONE PLATFORM IMPROVEMENT
-  Read: manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md
+② FIND AND FIX ONE PLATFORM IMPROVEMENT (planners + architects only)
+  Workers: skip this step — your job is to implement your assigned issue.
+  Planners/Architects: Read manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md
   Identify one improvement. Create a GitHub Issue for it.
   If effort is S (< 1 hour): implement it NOW in a branch+PR.
   The improvement can be anything: RGD fix, runner logic, new capability,


### PR DESCRIPTION
## Summary

Implements issue #889. Makes step② role-specific in PERPETUATION_MANIFEST so workers know to skip platform audits at the instruction point (not via override in ROLE_CONTEXT).

## Problem

PERPETUATION_MANIFEST told ALL agents to read entrypoint.sh/RGDs/AGENTS.md for step②, then PR #887's ROLE_CONTEXT told workers to ignore that instruction. This created a contradiction that workers might miss.

## Solution

Changed step② header to explicitly say "planners + architects only" and added immediate guidance for workers to skip. Now agents understand role-specific behavior when they first encounter the instruction.

## Changes

**images/runner/entrypoint.sh** (line 2133):
```diff
-② FIND AND FIX ONE PLATFORM IMPROVEMENT
-  Read: manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md
+② FIND AND FIX ONE PLATFORM IMPROVEMENT (planners + architects only)
+  Workers: skip this step — your job is to implement your assigned issue.
+  Planners/Architects: Read manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md
```

## Why This Matters

- Reduces worker noise (no more duplicate PRs from workers auditing platform)
- Complements PR #887 (role specialization)
- Makes role responsibilities clear at instruction point
- S-effort (< 10 minutes)

## Protected File

This PR touches `images/runner/entrypoint.sh` (protected file).

**Constitution alignment:**
- ✅ Enforces role specialization (from governance discussion)
- ✅ Reduces system noise without changing safety mechanisms
- ✅ Implements issue #881 follow-up work

Ready for god review - constitution alignment verified

## Related

- Issue #889 (this fix)
- Issue #881 (parent: role specialization)
- PR #887 (sibling: ROLE_CONTEXT blocks)

## Effort

S-effort (< 10 minutes). Vision score: 5/10 (reduces noise, improves efficiency).