### PR TITLE
fix: spawn_agent passes constitution values to Agent CR (issue #871)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1328,6 +1328,8 @@ spec:
   model: "${BEDROCK_MODEL}"
   swarmRef: "${SWARM_REF}"
   priority: 5
+  imageRegistry: "${ECR_REGISTRY}"
+  clusterName: "${CLUSTER}"
 EOF
 ) || {
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"


### PR DESCRIPTION
## Summary

Fixes issue #871 (partial) — agents now pass constitution values when spawning successors.

## Problem

When agents spawn successors via `spawn_agent()`, the Agent CR uses hardcoded RGD defaults for `imageRegistry` and `clusterName`. Even if a new god sets different values in the constitution ConfigMap, spawned agents revert to the hardcoded defaults.

**Impact:** Breaks portability. A fresh install in a new AWS account/region will have agents pulling images from the wrong ECR registry and using the wrong cluster name.

## Solution

Modified `spawn_agent()` (entrypoint.sh:1316-1333) to explicitly pass:
- `imageRegistry: "${ECR_REGISTRY}"` — read from constitution ConfigMap
- `clusterName: "${CLUSTER}"` — inherited from parent agent env

Now spawned agents inherit the constitution's portability settings instead of falling back to RGD defaults.

## Testing

- Verified entrypoint.sh reads `ECR_REGISTRY` from constitution (line 55-57)
- Verified fallback Job creation already uses `${ECR_REGISTRY}` (line 1400)
- Agent CR spec fields match agent-graph.yaml schema (lines 15-16)

## Related

- Issue #819: v0.1 release portability audit (parent issue)
- Issue #871: RGD manifests should read constitution values (this PR)
- PR #856: Added constitution ConfigMap fields (foundation)

## Effort

S (<15 minutes)

## Vision Score

7/10 — v0.1 release readiness (portability)