### PR TITLE
security: clean npm cache after install to remove false-positive PAT alerts (issue #897)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r2 (security: fix npm bundled dep CVEs - tar, minimatch, glob; apt-get upgrade; issue #858)
+# Image version: 2026-03-09-r3 (security: npm cache cleanup to remove false-positive PAT alerts; issue #897)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -37,7 +37,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # OpenCode CLI
-RUN npm install -g opencode-ai@${OPENCODE_VERSION}
+RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
+    && npm cache clean --force
 
 # Fix npm bundled dependency CVEs (issue #858)
 # npm bundles tar, minimatch, and glob in /usr/lib/node_modules/npm/node_modules/
@@ -50,7 +51,9 @@ RUN npm install -g npm@latest \
         tar@">=7.5.10" \
         minimatch@">=9.0.7" \
         glob@">=10.5.0" \
-    2>/dev/null || true
+    2>/dev/null || true \
+    && npm cache clean --force \
+    && rm -rf /root/.npm
 
 # ubuntu:24.04 ships with user/group "ubuntu" at UID/GID 1000.
 # Rename it to "agentex" and set up the home directory.


### PR DESCRIPTION
## Problem

GitHub code scanning reports 16 error-level alerts for `github-pat` (GitHub Personal Access Token) in the runner image. These are located in npm cache files:
```
/root/.npm/_cacache/content-v2/sha512/...
```

The alerts are triggered by `@octokit/auth-token` package source code containing example/placeholder token patterns. These are **false positives** (no real credentials exposed) but appear as CRITICAL severity in the security dashboard and block v0.1 release quality goals.

Additionally, the npm cache in `/root/.npm` is baked into Docker image layers unnecessarily.

## Solution

Add `npm cache clean --force && rm -rf /root/.npm` after npm global installs:

```dockerfile
# Before
RUN npm install -g opencode-ai@${OPENCODE_VERSION}

# After  
RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
    && npm cache clean --force
```

Same cleanup added after the bundled CVE fix block.

## Impact

- Removes ~16 error-level security alerts (63 → ~47 open alerts)
- Reduces Docker image size (removes /root/.npm cache directory)
- No functional change (npm cache serves no purpose post-install in image)
- Bumped image version to 2026-03-09-r3

## Files Changed

- `images/runner/Dockerfile`

## Testing

The existing CI build + Trivy scan will validate this. Trivy should report fewer vulnerabilities after this change.

## Related

- Issue #897 (this fix)
- Issue #658 (security: 145 open code scanning alerts)
- Issue #865 (v0.1 release readiness)