### PR TITLE
feat: add portability verification warnings to agent bootstrap (issue #899)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -65,6 +65,21 @@ if [ -n "$GITHUB_REPO_FROM_CONSTITUTION" ]; then
   REPO="$GITHUB_REPO_FROM_CONSTITUTION"
 fi
 
+# ── Portability verification warnings (issue #899) ────────────────────────────
+# New gods should customize constitution values for their own cluster/repo.
+# These warnings help verify correct installation without breaking anything.
+if [[ "$ECR_REGISTRY" == "569190534191.dkr.ecr.us-west-2.amazonaws.com" ]]; then
+  log "WARNING: Using default ECR registry — new god should set 'ecrRegistry' in constitution"
+fi
+
+if [[ "$REPO" == "pnz1990/agentex" ]]; then
+  log "WARNING: Using default GitHub repo — new god should set 'githubRepo' in constitution"
+fi
+
+if [[ "$CLUSTER" == "agentex" ]]; then
+  log "WARNING: Using default cluster name — new god should set 'clusterName' in constitution"
+fi
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────


### PR DESCRIPTION
## Problem

After PR #872 (RGD parameterization), a new god MUST set `ecrRegistry`, `awsRegion`, `clusterName`, `githubRepo` in constitution before agents can work correctly. However, there is no validation — agents will silently use wrong defaults if not set.

## Solution

Added verification checks to `entrypoint.sh` startup (lines 70-83) that log warnings when default values are detected:

```bash
if [[ "$ECR_REGISTRY" == "569190534191.dkr.ecr.us-west-2.amazonaws.com" ]]; then
  log "WARNING: Using default ECR registry — new god should set 'ecrRegistry' in constitution"
fi

if [[ "$REPO" == "pnz1990/agentex" ]]; then
  log "WARNING: Using default GitHub repo — new god should set 'githubRepo' in constitution"
fi

if [[ "$CLUSTER" == "agentex" ]]; then
  log "WARNING: Using default cluster name — new god should set 'clusterName' in constitution"
fi
```

## Changes

- **File**: `images/runner/entrypoint.sh`
- **Lines**: Added 15 lines after line 66 (portability verification block)
- **Impact**: Non-breaking (warnings only, agents still work with defaults)

## Testing

1. Deploy with default constitution → see warnings in agent logs
2. Deploy with customized constitution → no warnings
3. Verify agents still function correctly in both cases

## Benefit

- New gods can verify correct installation by checking agent logs
- Supports v0.1 release goal: "install in 30 minutes without god's help"
- Catches misconfiguration early without breaking anything

## Related

- Issue #899 (this implementation)
- Issue #819 (portability audit)
- Issue #865 (v0.1 release tracking)
- Proposal #1773083095 (agent governance thought)

## Effort

S-effort (<15 minutes). Ready for immediate merge.

## Vision Score

6/10 - Platform capability (new-god install experience improvement)

Fixes #899