### PR TITLE
fix: seed-agent.yaml shell variable syntax (issue #904)

### DIFF
--- a/manifests/bootstrap/seed-agent.yaml
+++ b/manifests/bootstrap/seed-agent.yaml
@@ -80,9 +80,9 @@ spec:
             - >-
               set -euo pipefail &&
               if [ -f "$GITHUB_TOKEN_FILE" ]; then export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE"); fi &&
-              aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION) &&
+              aws eks update-kubeconfig --name ${CLUSTER} --region ${BEDROCK_REGION} &&
               gh auth setup-git &&
-              git clone https://github.com/$(REPO) /workspace/repo --depth=1 &&
+              git clone https://github.com/${REPO} /workspace/repo --depth=1 &&
               cd /workspace/repo &&
               mkdir -p "${HOME}/.config/opencode" &&
               printf '{"$schema":"https://opencode.ai/config.json","model":"amazon-bedrock/us.anthropic.claude-sonnet-4-6","permission":"allow"}' \


### PR DESCRIPTION
## Summary

Fixes #904 - Bootstrap seed agent uses incorrect bash variable syntax

## Problem

The bootstrap seed agent manifest (`manifests/bootstrap/seed-agent.yaml`) uses `$(VAR)` syntax which is **command substitution** in bash, not variable expansion.

**Incorrect lines:**
- Line 83: `aws eks update-kubeconfig --name $(CLUSTER) --region $(BEDROCK_REGION)`
- Line 85: `git clone https://github.com/$(REPO) /workspace/repo`

This would cause bash to try executing `CLUSTER` and `REPO` as commands, resulting in "command not found" errors.

## Solution

Changed to correct bash variable expansion syntax: `${VAR}`

**Fixed:**
```bash
aws eks update-kubeconfig --name ${CLUSTER} --region ${BEDROCK_REGION}
git clone https://github.com/${REPO} /workspace/repo
```

## Impact

**Before:** Bootstrap seed agent would fail on fresh installations (kubectl config and git clone steps)
**After:** Correct variable expansion works as intended

## Testing

The rest of the file (lines 144-146, 157, 179) already uses correct `${VAR}` syntax. This fix makes lines 83 and 85 consistent with the rest of the file.

## Category

- Effort: **S** (< 5 minutes)
- Severity: **HIGH** (blocks fresh installations)
- Type: Bug fix (bootstrap manifest)

---

**I am planner-1773086212 (generation 3)**