### PR TITLE
fix: read REPO from constitution in system-status.sh (issue #907)

### DIFF
--- a/manifests/system/system-status.sh
+++ b/manifests/system/system-status.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 
 NAMESPACE="agentex"
 
+# Read GitHub repo from constitution (do not hardcode!)
+REPO=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.githubRepo}' 2>/dev/null)
+if [ -z "$REPO" ]; then REPO="${GITHUB_REPO:-pnz1990/agentex}"; fi
+
 # Read circuit breaker limit from constitution (do not hardcode!)
 CIRCUIT_BREAKER_LIMIT=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
@@ -96,8 +101,8 @@ echo ""
 # 6. OPEN GITHUB ISSUES/PRS
 echo -e "${BLUE}🔧 GitHub Status${NC}"
 if command -v gh &> /dev/null; then
-  OPEN_PRS=$(gh pr list --repo pnz1990/agentex --state open --limit 100 --json number 2>/dev/null | jq 'length' || echo "?")
-  OPEN_ISSUES=$(gh issue list --repo pnz1990/agentex --state open --limit 100 --json number 2>/dev/null | jq 'length' || echo "?")
+  OPEN_PRS=$(gh pr list --repo "$REPO" --state open --limit 100 --json number 2>/dev/null | jq 'length' || echo "?")
+  OPEN_ISSUES=$(gh issue list --repo "$REPO" --state open --limit 100 --json number 2>/dev/null | jq 'length' || echo "?")
   echo "   Open PRs: $OPEN_PRS"
   echo "   Open Issues: $OPEN_ISSUES"
 else


### PR DESCRIPTION
## Summary

Fixes #907 - Removes hardcoded `pnz1990/agentex` references from `manifests/system/system-status.sh`.

## Changes

- Added REPO variable at top of script, reading from:
  1. `agentex-constitution` ConfigMap (`githubRepo` field)
  2. `GITHUB_REPO` env var as fallback  
  3. `pnz1990/agentex` as last resort
- Updated GitHub section to use `$REPO` variable

## Why This Matters

Part of portability work from issue #819. When running system-status.sh in a fresh install with a different repo, it will now show the correct PR/issue counts.

## Effort: S (< 15 minutes)

This is a minimal, backward-compatible change - existing pnz1990/agentex installs work unchanged.