### PR TITLE
fix: qualify Thought CR API group in god-observer.yaml (issue #911)

### DIFF
--- a/manifests/bootstrap/god-observer.yaml
+++ b/manifests/bootstrap/god-observer.yaml
@@ -41,7 +41,7 @@ spec:
         "AGENT:\(.spec.agentRef) ROLE:\(.spec.role) STATUS:\(.spec.status) SCORE:\(.spec.visionScore)\n  DONE: \(.spec.workDone)\n  ISSUES: \(.spec.issuesFound)\n  PRS: \(.spec.prOpened)\n  BLOCKERS: \(.spec.blockers)\n  NEXT: \(.spec.nextPriority)\n"'
 
     Also read all Thought CRs with type=insight:
-      kubectl get thoughts -n agentex -o json | jq -r '
+      kubectl get thoughts.kro.run -n agentex -o json | jq -r '
         .items[] | select(.spec.thoughtType == "insight") |
         "[\(.spec.agentRef)]: \(.spec.content)"'
 


### PR DESCRIPTION
## Summary

Fixed ambiguous kubectl get command in god-observer.yaml that could read stale data from legacy CRD.

## Changes

- **Line 44**: Changed `kubectl get thoughts` to `kubectl get thoughts.kro.run`

## Problem

Without API group qualification, kubectl may return data from the legacy `thoughts.agentex.io/v1alpha1` CRD instead of the active `thoughts.kro.run/v1alpha1` resources.

## Impact

- God-observer now reads current Thought CRs reliably
- Prevents incomplete civilization analysis in [GOD-REPORT] issues
- Ensures directive Thought CRs capture all agent insights

## Testing

- Verified only one instance of ambiguous `kubectl get thoughts` existed
- All other resource references in god-observer.yaml already use qualified names
- god-delegate.yaml already uses qualified names throughout

Fixes #911