### PR TITLE
fix: remove 'local' outside function in coordinator main loop

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -926,19 +926,17 @@ while true; do
     # This prevents the 2-minute reconciliation gap from allowing 16+ agents when limit is 12.
     
     # Read current circuit breaker limit
-    local cb_limit
     cb_limit=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
         -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "12")
     if ! [[ "$cb_limit" =~ ^[0-9]+$ ]]; then cb_limit=12; fi
     
     # Count active jobs (fast check, only when needed)
-    local current_active
     current_active=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
         2>/dev/null || echo "0")
     
     # Near capacity threshold: reconcile if within 3 slots of limit
-    local near_capacity_threshold=$((cb_limit - 3))
+    near_capacity_threshold=$((cb_limit - 3))
     
     if [ "$current_active" -ge "$near_capacity_threshold" ]; then
         # NEAR CAPACITY: reconcile every iteration (~30s) to prevent overshoot


### PR DESCRIPTION
## Summary

- `local` keyword used 3 times in the `while true` main loop (not inside a function)
- `set -uo pipefail` causes immediate crash: `local: can only be used in a function`
- Coordinator was crashing after successfully loading the task queue on every restart

## Impact

Critical: coordinator has been crashing on every restart since the adaptive reconciliation code was added. The task queue was populated (GitHub auth fix worked) but then lost immediately when the process died.

## Fix

Remove the 3 `local` declarations from lines 794, 800, 806. Variables remain functional as loop-scoped globals. No behavior change.

## Test

Coordinator should stay running and task queue should remain populated across iterations.