### PR TITLE
feat: add HTTP health endpoint to coordinator (issue #699)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -892,7 +892,64 @@ if [ -z "$INITIAL_QUEUE" ]; then
     refresh_task_queue
 fi
 
+# ── HTTP Health Endpoint (issue #699) ───────────────────────────────────────
+# Start a background HTTP server that responds to health checks
+# Returns 200 if heartbeat is fresh (< 120s old), 503 if stale
+start_health_endpoint() {
+    local health_port=8080
+    echo "[$(date -u +%H:%M:%S)] Starting HTTP health endpoint on port ${health_port}..."
+    
+    while true; do
+        # Use netcat to listen for HTTP requests
+        # Read the request (we don't parse it, just respond to any GET)
+        response=$(mktemp)
+        
+        # Get lastHeartbeat from ConfigMap
+        last_heartbeat=$(get_state "lastHeartbeat")
+        current_time=$(date +%s)
+        
+        # Calculate age of last heartbeat
+        if [ -n "$last_heartbeat" ]; then
+            heartbeat_epoch=$(date -d "$last_heartbeat" +%s 2>/dev/null || echo "0")
+            age=$((current_time - heartbeat_epoch))
+        else
+            age=999999  # No heartbeat yet
+        fi
+        
+        # Stale threshold: 120 seconds (4 missed heartbeats)
+        if [ "$age" -lt 120 ]; then
+            # Healthy
+            cat > "$response" <<EOF
+HTTP/1.1 200 OK
+Content-Type: application/json
+Connection: close
+
+{"status":"healthy","lastHeartbeat":"$last_heartbeat","ageSeconds":$age}
+EOF
+        else
+            # Unhealthy
+            cat > "$response" <<EOF
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+Connection: close
+
+{"status":"unhealthy","lastHeartbeat":"$last_heartbeat","ageSeconds":$age,"reason":"heartbeat_stale"}
+EOF
+        fi
+        
+        # Send response using netcat
+        cat "$response" | nc -l -p "$health_port" -q 1 2>/dev/null || true
+        rm -f "$response"
+    done
+}
+
+# Start health endpoint in background
+start_health_endpoint &
+HEALTH_ENDPOINT_PID=$!
+echo "[$(date -u +%H:%M:%S)] HTTP health endpoint started (PID: $HEALTH_ENDPOINT_PID)"
+
 # Create health check files for Kubernetes probes (issue #619)
+# Note: These are legacy - we now have HTTP endpoint, but keep for backward compatibility
 touch /tmp/coordinator-alive
 touch /tmp/coordinator-ready
 echo "[$(date -u +%H:%M:%S)] Health check files initialized"

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -108,6 +108,10 @@ spec:
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE
                       value: "/var/secrets/github/token"
+                  ports:
+                    - name: health
+                      containerPort: 8080
+                      protocol: TCP
                   resources:
                     requests:
                       memory: "256Mi"
@@ -116,17 +120,21 @@ spec:
                       memory: "512Mi"
                       cpu: "500m"
                   livenessProbe:
-                    exec:
-                      command: ["/bin/sh", "-c", "test -f /tmp/coordinator-alive"]
-                    initialDelaySeconds: 30
-                    periodSeconds: 60
+                    httpGet:
+                      path: /health
+                      port: health
+                      scheme: HTTP
+                    initialDelaySeconds: 60
+                    periodSeconds: 30
                     timeoutSeconds: 5
                     failureThreshold: 3
                   readinessProbe:
-                    exec:
-                      command: ["/bin/sh", "-c", "test -f /tmp/coordinator-ready"]
-                    initialDelaySeconds: 10
-                    periodSeconds: 30
+                    httpGet:
+                      path: /health
+                      port: health
+                      scheme: HTTP
+                    initialDelaySeconds: 30
+                    periodSeconds: 10
                     timeoutSeconds: 5
                     failureThreshold: 2
                   volumeMounts:


### PR DESCRIPTION
## Summary

Implements HTTP health endpoint for the coordinator to enable better Kubernetes health monitoring and external observability.

## Changes

**Coordinator Script (`images/runner/coordinator.sh`):**
- Added `start_health_endpoint()` function that runs in background
- Listens on port 8080 using netcat
- Returns HTTP 200 if heartbeat is fresh (< 120s old)
- Returns HTTP 503 if heartbeat is stale (≥ 120s)
- JSON response includes: `status`, `lastHeartbeat`, `ageSeconds`, and `reason`
- Kept legacy file-based health checks for backward compatibility

**RGD (`manifests/rgds/coordinator-graph.yaml`):**
- Exposed port 8080 as `health` port in container spec
- Updated livenessProbe to use `httpGet` on `/health` endpoint
- Updated readinessProbe to use `httpGet` on `/health` endpoint
- Adjusted timing: liveness checks every 30s, readiness every 10s

## Benefits

✅ Kubernetes can automatically detect and restart stuck coordinator  
✅ More detailed health information (heartbeat age, status reason)  
✅ External monitoring tools can query health endpoint  
✅ Standard HTTP health check pattern (CloudWatch, Prometheus, etc)  

## Testing

- Syntax validated: `bash -n coordinator.sh` ✓
- YAML validated: `kubectl --dry-run=client apply` ✓
- Health endpoint will start automatically on coordinator deployment

## Deployment

After merge, the coordinator will automatically restart with the new health endpoint when the runner image is rebuilt.

To verify after deployment:
```bash
# Port-forward to coordinator pod
kubectl port-forward -n agentex deployment/coordinator 8080:8080

# Check health endpoint
curl http://localhost:8080/health
```

Fixes #699

---
I am worker-deep-parser (worker-1773087159)