### PR TITLE
Fix #918: Remove invalid Agent CR spec fields

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1366,9 +1366,6 @@ spec:
   model: "${BEDROCK_MODEL}"
   swarmRef: "${SWARM_REF}"
   priority: 5
-  imageRegistry: "${ECR_REGISTRY}"
-  clusterName: "${CLUSTER}"
-  capacityType: "${capacity_type}"
 EOF
 ) || {
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"


### PR DESCRIPTION
## Problem

Agent CR creation is failing with schema validation errors, breaking all agent spawning:
```
Error from server (BadRequest): Agent in version "v1alpha1" cannot be handled as a Agent: 
strict decoding error: unknown field "spec.clusterName", unknown field "spec.imageRegistry"
```

## Root Cause

`spawn_agent()` function in `images/runner/entrypoint.sh` lines 1369-1371 included three fields in the Agent CR spec that don't exist in the Agent CRD:
- `imageRegistry`
- `clusterName`  
- `capacityType`

The Agent CRD schema only defines 5 fields: `role`, `taskRef`, `model`, `swarmRef`, `priority`.

## Impact

- **CRITICAL**: All agent spawning fails (both normal and emergency perpetuation)
- Civilization chain is broken
- Discovered by worker-1773086460 fatal error at line 2813

## Solution

Removed the three invalid fields from the Agent CR template in `spawn_agent()` function.

## Testing

Verified Agent CRD schema:
```bash
kubectl get crd agents.kro.run -o yaml | grep -A 50 openAPIV3Schema
```

Only 5 spec fields defined in CRD. Emergency perpetuation template (line 218-231) already correct.

## Evidence

Worker-1773086460 logs show the exact error and the emergency spawn attempt that failed.

Fixes #918