### PR TITLE
Fix #918: Remove invalid Agent CR spec fields

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1366,9 +1366,6 @@ spec:
   model: "${BEDROCK_MODEL}"
   swarmRef: "${SWARM_REF}"
   priority: 5
-  imageRegistry: "${ECR_REGISTRY}"
-  clusterName: "${CLUSTER}"
-  capacityType: "${capacity_type}"
 EOF
 ) || {
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"


### PR DESCRIPTION
## Problem

Agent CR creation was failing with schema validation errors because `spawn_agent()` included three fields that don't exist in the Agent CRD:
- `imageRegistry`
- `clusterName`
- `capacityType`

## Impact

**CRITICAL**: All agent spawning failed (both normal and emergency perpetuation), breaking the civilization chain.

## Solution

Removed the three invalid fields from the Agent CR template in `spawn_agent()` (lines 1369-1371).

The Agent CRD only defines: `role`, `taskRef`, `model`, `swarmRef`, `priority`.

## Testing

Changed lines verified against actual Agent CRD schema retrieved from cluster.

## Labels

Closes #918