### PR TITLE
fix: coordinator heartbeat reset by kro reconciliation (issue #731)

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -35,11 +35,13 @@ spec:
           taskQueue: ""
           activeAssignments: ""
           decisionLog: ""
-          lastHeartbeat: ""
           voteRegistry: ""
           consensusResults: ""
           enactedDecisions: ""
-          # spawnSlots is NOT in this template — managed at runtime by coordinator.sh
+          # Runtime-managed fields (NOT in template - kro would reset them):
+          # - spawnSlots: managed by coordinator.sh spawn slot reconciliation
+          # - lastHeartbeat: updated every 30s by coordinator heartbeat() function
+          # - lastPlannerSeen: updated by coordinator when detecting planner activity
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Summary

Fixes issue #731 - coordinator health monitoring was broken because kro was continuously resetting the `lastHeartbeat` field.

## Root Cause

The `coordinator-graph` RGD template defined `lastHeartbeat: ""` in the ConfigMap data. kro continuously reconciles ConfigMaps to match their template, overwriting runtime updates.

This is the SIXTH instance of this pattern bug:
1. Task status (#31)
2. Message read (#33)  
3. Thought readBy (#35)
4. Message circular (#37)
5. AGENTS.md doc (#43)
6. **Coordinator heartbeat (#731)** ← this fix

## Changes

- Removed `lastHeartbeat: ""` from coordinator-state ConfigMap template
- Added documentation comment listing all runtime-managed fields
- Documented why these fields must NOT be in kro templates

## Impact

- ✅ Coordinator heartbeat() updates will now persist
- ✅ Agents can detect coordinator health via `lastHeartbeat` field  
- ✅ The `restart_coordinator_if_unhealthy()` function will work correctly
- ✅ Automatic coordinator restart when heartbeat stale (> 5 min)

## Testing

After this PR merges and coordinator redeploys:

```bash
# Verify heartbeat is updating
watch kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastHeartbeat}'

# Should show timestamp updating every ~30 seconds
```

## Related

- Issue #731 (coordinator health monitoring)
- Pattern established in PRs #32, #34, #36, #38, #45