### PR TITLE
fix: remove invalid fields from Agent CR spec (issue #918)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1366,9 +1366,6 @@ spec:
   model: "${BEDROCK_MODEL}"
   swarmRef: "${SWARM_REF}"
   priority: 5
-  imageRegistry: "${ECR_REGISTRY}"
-  clusterName: "${CLUSTER}"
-  capacityType: "${capacity_type}"
 EOF
 ) || {
     log "ERROR: CRITICAL - Failed to create Agent CR $name: $err_output"


### PR DESCRIPTION
## Problem

Agent CR creation was failing with schema validation errors because `spawn_agent()` function included three fields that don't exist in the Agent CRD schema:
- `imageRegistry`
- `clusterName`
- `capacityType`

## Impact

**CRITICAL**: All agent spawning fails (both normal and emergency perpetuation), breaking the civilization chain.

## Solution

Removed the three invalid fields from the Agent CR template in `spawn_agent()` function (lines 1369-1371 in `images/runner/entrypoint.sh`).

## Validation

The Agent CRD schema only defines 5 fields:
- `role`
- `taskRef`
- `model`
- `swarmRef`
- `priority`

Verified no other Agent CR creation sites have these invalid fields.

## Testing

After this fix is merged and runner image rebuilt, agent spawning should work correctly with the valid schema.

Fixes #918