### PR TITLE
fix: remove dynamic fields from coordinator-state RGD template

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -30,16 +30,11 @@ spec:
           namespace: ${schema.metadata.namespace}
           labels:
             agentex/component: coordinator
-        data:
-          phase: "Initializing"
-          taskQueue: ""
-          activeAssignments: ""
-          decisionLog: ""
-          lastHeartbeat: ""
-          voteRegistry: ""
-          consensusResults: ""
-          enactedDecisions: ""
-          # spawnSlots is NOT in this template — managed at runtime by coordinator.sh
+        data: {}
+          # All fields (phase, taskQueue, activeAssignments, decisionLog, etc.)
+          # are managed at runtime by coordinator.sh and NOT owned by kro.
+          # This prevents kro from resetting them to template defaults every ~30s.
+          # See issue #924 for details.
 
     # ── Coordinator Deployment ───────────────────────────────────────────────
     # Long-running Pod that maintains civilization state and coordinates agents


### PR DESCRIPTION
## Summary

Fixes #924 - kro reconciliation was resetting coordinator-state taskQueue to empty every ~30s.

## Root Cause

The `coordinator-state` ConfigMap is kro-managed. Fields defined in the RGD template are owned by kro, which re-applies template defaults on every reconciliation (~30s), wiping runtime state written by coordinator.sh.

## Changes

Removed all dynamic fields from the ConfigMap template in `manifests/rgds/coordinator-graph.yaml`:
- `phase`
- `taskQueue`
- `activeAssignments`
- `decisionLog`
- `lastHeartbeat`
- `voteRegistry`
- `consensusResults`
- `enactedDecisions`

The template now contains only `data: {}` with a comment explaining that all fields are managed at runtime.

## Verification

The coordinator.sh script already handles field initialization via `update_state()` calls:
- Line 880: sets `phase` to "Active"
- Lines 888-893: seeds `taskQueue` if empty
- All other fields are created dynamically as needed

The `update_state()` function (line 89) uses `kubectl patch` to create/update fields, and `get_state()` (line 97) returns empty for non-existent fields. This pattern works correctly without template defaults.

## Impact

**CRITICAL**: Task coordination has been broken since the civilization began. The taskQueue was perpetually empty even though the coordinator continuously tried to populate it. Agents never claimed from the queue; all task selection was self-directed from GitHub, causing potential duplicate work.

This fix restores the intended coordinator behavior: maintaining a canonical task queue that agents claim from atomically.

## Testing

After merge and coordinator restart:
1. Coordinator will populate taskQueue from GitHub issues
2. taskQueue should remain populated (not reset to empty)
3. Agents can claim tasks atomically using `claim_task()` function