### PR TITLE
fix: parameterize region in cloudwatch-dashboard.yaml (issue #928)

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -33,7 +33,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Active Agent Pods",
             "period": 300,
             "yAxis": {
@@ -61,7 +61,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Task Throughput",
             "period": 300,
             "yAxis": {
@@ -86,7 +86,7 @@ data:
               [ "...", { "stat": "Sum", "id": "m4", "label": "architect" } ]
             ],
             "view": "pie",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Runs by Role",
             "period": 3600,
             "setPeriodToTimeRange": true
@@ -106,7 +106,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": true,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Communication Volume",
             "period": 300,
             "yAxis": {
@@ -129,7 +129,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Job Failures",
             "period": 300,
             "yAxis": {
@@ -163,7 +163,7 @@ data:
               [ ".", "IssueCreated", { "stat": "Sum", "label": "Issues Created" } ]
             ],
             "view": "singleValue",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Output Quality Metrics",
             "period": 86400,
             "setPeriodToTimeRange": true
@@ -177,7 +177,7 @@ data:
           "type": "log",
           "properties": {
             "query": "SOURCE '/aws/containerinsights/agentex/application'\n| fields @timestamp, log as message\n| filter kubernetes.namespace_name = 'agentex'\n| filter log like /ERROR|WARNING|CRITICAL/\n| sort @timestamp desc\n| limit 20",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "stacked": false,
             "title": "Recent Agent Errors",
             "view": "table"
@@ -197,7 +197,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Bedrock API Usage",
             "period": 300,
             "yAxis": {
@@ -220,7 +220,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Memory Usage",
             "period": 300,
             "yAxis": {
@@ -327,14 +327,19 @@ data:
     # Deploy the agentex CloudWatch dashboard from the ConfigMap definition
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to AWS_REGION env var, then us-west-2
+    REGION=$(kubectl get configmap agentex-constitution -n agentex \
+      -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
     echo "Fetching dashboard definition from ConfigMap..."
     DASHBOARD_JSON=$(kubectl get configmap agentex-dashboard-definition -n agentex \
       -o jsonpath='{.data.dashboard\.json}')
     
-    echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME"
+    # Replace placeholder __AWS_REGION__ with actual region
+    DASHBOARD_JSON=$(echo "$DASHBOARD_JSON" | sed "s/__AWS_REGION__/$REGION/g")
+    
+    echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME in region $REGION"
     aws cloudwatch put-dashboard \
       --dashboard-name "$DASHBOARD_NAME" \
       --dashboard-body "$DASHBOARD_JSON" \
@@ -348,10 +353,12 @@ data:
     # Delete the agentex CloudWatch dashboard
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to AWS_REGION env var, then us-west-2
+    REGION=$(kubectl get configmap agentex-constitution -n agentex \
+      -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
-    echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME"
+    echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME from region $REGION"
     aws cloudwatch delete-dashboards \
       --dashboard-names "$DASHBOARD_NAME" \
       --region "$REGION"


### PR DESCRIPTION
## Summary

Fixes #928 - Parameterizes hardcoded AWS region in CloudWatch dashboard configuration.

## Changes

**Dashboard JSON template (9 occurrences):**
- Replaced hardcoded `"region": "us-west-2"` with `"region": "__AWS_REGION__"` placeholder in all widget definitions

**Deployment scripts (apply-dashboard.sh, delete-dashboard.sh):**
- Read region from `agentex-constitution` ConfigMap (`awsRegion` field)
- Fall back to `AWS_REGION` env var
- Fall back to `us-west-2` as last resort
- Use `sed` to replace `__AWS_REGION__` placeholder with actual region before deploying

## Impact

✅ New gods can deploy CloudWatch dashboards in their own region without editing YAML
✅ Maintains backward compatibility (us-west-2 is final fallback)
✅ Consistent with other portability work (constitution-based parameterization)

## Testing

Dashboard JSON structure is unchanged (only region field values modified).
Scripts tested for syntax (bash -n clean).

## Related Work

- Part of issue #819 (portability work)
- Tracked in issue #865 (v0.1 release readiness)
- Completes CloudWatch dashboard portability (11 total parameterizations)

## Effort

S-effort (< 30 minutes)