### PR TITLE
fix: parameterize region in cloudwatch-dashboard.yaml (issue #928)

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -33,7 +33,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Active Agent Pods",
             "period": 300,
             "yAxis": {
@@ -61,7 +61,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Agent Task Throughput",
             "period": 300,
             "yAxis": {
@@ -86,7 +86,7 @@ data:
               [ "...", { "stat": "Sum", "id": "m4", "label": "architect" } ]
             ],
             "view": "pie",
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Agent Runs by Role",
             "period": 3600,
             "setPeriodToTimeRange": true
@@ -106,7 +106,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": true,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Agent Communication Volume",
             "period": 300,
             "yAxis": {
@@ -129,7 +129,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Agent Job Failures",
             "period": 300,
             "yAxis": {
@@ -163,7 +163,7 @@ data:
               [ ".", "IssueCreated", { "stat": "Sum", "label": "Issues Created" } ]
             ],
             "view": "singleValue",
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Output Quality Metrics",
             "period": 86400,
             "setPeriodToTimeRange": true
@@ -177,7 +177,7 @@ data:
           "type": "log",
           "properties": {
             "query": "SOURCE '/aws/containerinsights/agentex/application'\n| fields @timestamp, log as message\n| filter kubernetes.namespace_name = 'agentex'\n| filter log like /ERROR|WARNING|CRITICAL/\n| sort @timestamp desc\n| limit 20",
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "stacked": false,
             "title": "Recent Agent Errors",
             "view": "table"
@@ -197,7 +197,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Bedrock API Usage",
             "period": 300,
             "yAxis": {
@@ -220,7 +220,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "REGION_PLACEHOLDER",
             "title": "Agent Memory Usage",
             "period": 300,
             "yAxis": {
@@ -252,12 +252,17 @@ data:
     # Deploy the agentex CloudWatch dashboard from the ConfigMap definition
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to env var, then default
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
     echo "Fetching dashboard definition from ConfigMap..."
     DASHBOARD_JSON=$(kubectl get configmap agentex-dashboard-definition -n agentex \
       -o jsonpath='{.data.dashboard\.json}')
+    
+    echo "Parameterizing dashboard with region: $REGION"
+    # Replace REGION_PLACEHOLDER with actual region
+    DASHBOARD_JSON=$(echo "$DASHBOARD_JSON" | sed "s/REGION_PLACEHOLDER/$REGION/g")
     
     echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME"
     aws cloudwatch put-dashboard \
@@ -273,7 +278,8 @@ data:
     # Delete the agentex CloudWatch dashboard
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to env var, then default
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
     echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME"


### PR DESCRIPTION
## Summary

Fixes #928 - Parameterize hardcoded region references in cloudwatch-dashboard.yaml for multi-region portability.

## Changes

1. **Dashboard JSON**: Replaced all 9 hardcoded `"region": "us-west-2"` with `"region": "REGION_PLACEHOLDER"`
2. **apply-dashboard.sh**: Enhanced to:
   - Read region from `agentex-constitution` ConfigMap (`awsRegion` field)
   - Fall back to `AWS_REGION` env var
   - Default to `us-west-2`
   - Substitute `REGION_PLACEHOLDER` with actual region before deploying
3. **delete-dashboard.sh**: Updated with same region resolution logic

## Impact

- New gods can install agentex in any AWS region (us-east-1, eu-west-1, etc.)
- Dashboard automatically uses correct region from constitution ConfigMap
- No manual YAML editing required
- Maintains backward compatibility (defaults to us-west-2)

## Testing

Tested logic:
```bash
# Simulate region resolution
REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
echo "REGION_PLACEHOLDER" | sed "s/REGION_PLACEHOLDER/$REGION/g"
```

## Part of

- Issue #819 (portability work)
- Issue #865 (v0.1 release readiness tracking)

## Effort

S-effort (< 30 minutes)