### PR TITLE
fix: parameterize hardcoded region in cloudwatch-dashboard.yaml

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -33,7 +33,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Active Agent Pods",
             "period": 300,
             "yAxis": {
@@ -61,7 +61,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Agent Task Throughput",
             "period": 300,
             "yAxis": {
@@ -86,7 +86,7 @@ data:
               [ "...", { "stat": "Sum", "id": "m4", "label": "architect" } ]
             ],
             "view": "pie",
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Agent Runs by Role",
             "period": 3600,
             "setPeriodToTimeRange": true
@@ -106,7 +106,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": true,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Agent Communication Volume",
             "period": 300,
             "yAxis": {
@@ -129,7 +129,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Agent Job Failures",
             "period": 300,
             "yAxis": {
@@ -163,7 +163,7 @@ data:
               [ ".", "IssueCreated", { "stat": "Sum", "label": "Issues Created" } ]
             ],
             "view": "singleValue",
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Output Quality Metrics",
             "period": 86400,
             "setPeriodToTimeRange": true
@@ -177,7 +177,7 @@ data:
           "type": "log",
           "properties": {
             "query": "SOURCE '/aws/containerinsights/agentex/application'\n| fields @timestamp, log as message\n| filter kubernetes.namespace_name = 'agentex'\n| filter log like /ERROR|WARNING|CRITICAL/\n| sort @timestamp desc\n| limit 20",
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "stacked": false,
             "title": "Recent Agent Errors",
             "view": "table"
@@ -197,7 +197,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Bedrock API Usage",
             "period": 300,
             "yAxis": {
@@ -220,7 +220,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Agent Memory Usage",
             "period": 300,
             "yAxis": {
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "AGENTEX_AWS_REGION",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {
@@ -327,14 +327,18 @@ data:
     # Deploy the agentex CloudWatch dashboard from the ConfigMap definition
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to AWS_REGION env, then us-west-2
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
     echo "Fetching dashboard definition from ConfigMap..."
     DASHBOARD_JSON=$(kubectl get configmap agentex-dashboard-definition -n agentex \
       -o jsonpath='{.data.dashboard\.json}')
     
-    echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME"
+    # Substitute AGENTEX_AWS_REGION placeholder with actual region
+    DASHBOARD_JSON=$(echo "$DASHBOARD_JSON" | sed "s/AGENTEX_AWS_REGION/$REGION/g")
+    
+    echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME (region: $REGION)"
     aws cloudwatch put-dashboard \
       --dashboard-name "$DASHBOARD_NAME" \
       --dashboard-body "$DASHBOARD_JSON" \
@@ -348,10 +352,11 @@ data:
     # Delete the agentex CloudWatch dashboard
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap, fallback to AWS_REGION env, then us-west-2
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null || echo "${AWS_REGION:-us-west-2}")
     DASHBOARD_NAME="agentex-activity"
     
-    echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME"
+    echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME (region: $REGION)"
     aws cloudwatch delete-dashboards \
       --dashboard-names "$DASHBOARD_NAME" \
       --region "$REGION"


### PR DESCRIPTION
## Summary
- Replaces 11 hardcoded us-west-2 references in CloudWatch dashboard widget definitions
- Uses AGENTEX_AWS_REGION placeholder that gets substituted at deployment time
- Updates apply-dashboard.sh and delete-dashboard.sh to read region from constitution ConfigMap

## Changes
- Widget regions (lines 36, 64, 89, 109, 132, 166, 180, 200, 223, 248, 287): hardcoded strings → placeholder
- apply-dashboard.sh: reads awsRegion from agentex-constitution ConfigMap, substitutes placeholder
- delete-dashboard.sh: reads awsRegion from agentex-constitution ConfigMap

## Portability
A new god installing agentex in a different region (e.g., eu-west-1) can now:
1. Run install-configure.sh to set awsRegion in constitution
2. Deploy dashboard with `kubectl apply -f manifests/system/cloudwatch-dashboard.yaml`
3. Run apply-dashboard.sh — dashboard deploys to their region automatically

## Testing
Verified:
- All 11 widget region fields use placeholder
- Deployment scripts have constitution fallback → AWS_REGION env → us-west-2
- sed substitution correctly replaces placeholder with actual region

## Related
Fixes #928
Part of #819 (portability work)
Tracked in #865 (v0.1 release readiness)

## Effort
S-effort (20 minutes)