### PR TITLE
Parameterize CloudWatch dashboard region (issue #928)

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -33,7 +33,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Active Agent Pods",
             "period": 300,
             "yAxis": {
@@ -61,7 +61,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Task Throughput",
             "period": 300,
             "yAxis": {
@@ -86,7 +86,7 @@ data:
               [ "...", { "stat": "Sum", "id": "m4", "label": "architect" } ]
             ],
             "view": "pie",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Runs by Role",
             "period": 3600,
             "setPeriodToTimeRange": true
@@ -106,7 +106,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": true,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Communication Volume",
             "period": 300,
             "yAxis": {
@@ -129,7 +129,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Job Failures",
             "period": 300,
             "yAxis": {
@@ -163,7 +163,7 @@ data:
               [ ".", "IssueCreated", { "stat": "Sum", "label": "Issues Created" } ]
             ],
             "view": "singleValue",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Output Quality Metrics",
             "period": 86400,
             "setPeriodToTimeRange": true
@@ -177,7 +177,7 @@ data:
           "type": "log",
           "properties": {
             "query": "SOURCE '/aws/containerinsights/agentex/application'\n| fields @timestamp, log as message\n| filter kubernetes.namespace_name = 'agentex'\n| filter log like /ERROR|WARNING|CRITICAL/\n| sort @timestamp desc\n| limit 20",
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "stacked": false,
             "title": "Recent Agent Errors",
             "view": "table"
@@ -197,7 +197,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Bedrock API Usage",
             "period": 300,
             "yAxis": {
@@ -220,7 +220,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Agent Memory Usage",
             "period": 300,
             "yAxis": {
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {
@@ -327,12 +327,17 @@ data:
     # Deploy the agentex CloudWatch dashboard from the ConfigMap definition
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap (issue #819 portability)
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null)
+    REGION="${REGION:-${AWS_REGION:-us-west-2}}"
     DASHBOARD_NAME="agentex-activity"
     
     echo "Fetching dashboard definition from ConfigMap..."
     DASHBOARD_JSON=$(kubectl get configmap agentex-dashboard-definition -n agentex \
       -o jsonpath='{.data.dashboard\.json}')
+    
+    echo "Substituting region placeholder with: $REGION"
+    DASHBOARD_JSON=$(echo "$DASHBOARD_JSON" | sed "s|__AWS_REGION__|${REGION}|g")
     
     echo "Creating/updating CloudWatch dashboard: $DASHBOARD_NAME"
     aws cloudwatch put-dashboard \
@@ -348,7 +353,9 @@ data:
     # Delete the agentex CloudWatch dashboard
     set -euo pipefail
     
-    REGION="${AWS_REGION:-us-west-2}"
+    # Read region from constitution ConfigMap (issue #819 portability)
+    REGION=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.awsRegion}' 2>/dev/null)
+    REGION="${REGION:-${AWS_REGION:-us-west-2}}"
     DASHBOARD_NAME="agentex-activity"
     
     echo "Deleting CloudWatch dashboard: $DASHBOARD_NAME"


### PR DESCRIPTION
## Summary
- Replaced 11 hardcoded `us-west-2` region references in cloudwatch-dashboard.yaml with `__AWS_REGION__` placeholder
- Updated `apply-dashboard.sh` to read region from `agentex-constitution` ConfigMap and substitute placeholder before deployment
- Updated `delete-dashboard.sh` to read region from constitution with same fallback pattern
- Maintains fallback chain: constitution → AWS_REGION env var → us-west-2 default

## Problem
CloudWatch dashboard had hardcoded `us-west-2` in all widget definitions (lines 36, 64, 89, 109, 132, 166, 180, 200, 223, 248, 287). A new god installing in us-east-1 would deploy a dashboard pointing to the wrong region.

## Solution
Dashboard JSON now uses `__AWS_REGION__` placeholder. Deployment script reads `awsRegion` from constitution ConfigMap at deploy time and substitutes the placeholder with actual region value.

## Testing
Verified:
- All 11 widget region fields now use placeholder
- Deployment scripts read from constitution with proper fallback chain
- No hardcoded regions remain except in fallback defaults

## Related
- Part of issue #819 (portability work)
- Tracked in issue #865 (v0.1 release readiness)
- S-effort (< 30 minutes)

## Impact
New gods can now install agentex in any AWS region without modifying cloudwatch-dashboard.yaml.