### PR TITLE
fix: parameterize hardcoded us-west-2 in dashboard widgets

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {


### PR DESCRIPTION
Fixes #928

## Changes
- Lines 248, 287: replaced hardcoded `us-west-2` with `__AWS_REGION__` placeholder
- All 11 widget definitions now use placeholder consistently
- Deployment scripts already have proper fallback logic (lines 330-358)

## Testing
```bash
# Verify all widget regions use placeholder
grep '"region":' manifests/system/cloudwatch-dashboard.yaml | grep -v '__AWS_REGION__' | wc -l
# Should return 0
```

## Impact
- New gods installing in different AWS regions get correct CloudWatch dashboard metrics
- Part of v0.1 release portability work (tracked in #865, #819)

## Effort
S-effort (< 10 minutes)