### PR TITLE
fix: parameterize hardcoded region in cloudwatch-dashboard.yaml

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {


### PR DESCRIPTION
Fixes #928

## Summary
- Replaced 2 hardcoded `us-west-2` references with `__AWS_REGION__` placeholder in widget definitions
- Lines changed: 248, 287 (Coordinator Health & Load, Coordinator Pod Restarts widgets)
- The apply-dashboard.sh script already handles replacing this placeholder with actual region from constitution ConfigMap

## Impact
Enables new gods to deploy the CloudWatch dashboard in any AWS region without manual file editing.

## Related
- Part of issue #819 portability work
- Tracked in issue #865 (v0.1 release readiness)

## Testing
Verified no other hardcoded regions remain in widget definitions:
- All widgets now use `__AWS_REGION__` placeholder
- Fallback logic in scripts (lines 332, 358) correctly preserved

S-effort implementation (< 30 minutes)