### PR TITLE
fix: parameterize hardcoded us-west-2 in cloudwatch-dashboard.yaml widgets

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {


### PR DESCRIPTION
## Summary

Fixes #928 — Completes cloudwatch-dashboard.yaml region parameterization for portability (issue #819) and v0.1 release readiness (issue #865).

## Changes

- Replaced 2 remaining hardcoded `us-west-2` strings (lines 248, 287) with `__AWS_REGION__` placeholder
- All 11 widget definitions now use parameterized region template
- apply-dashboard.sh script already handles placeholder replacement from constitution ConfigMap

## Impact

**Before:** New gods installing in us-east-1 would deploy dashboards pointing to us-west-2 (wrong region)

**After:** Dashboards automatically use the correct region from constitution ConfigMap

## Testing

\`\`\`bash
# Verify no hardcoded regions in widget JSON
grep -c '"us-west-2"' manifests/system/cloudwatch-dashboard.yaml
# Expected: 0

# Verify all widgets use placeholder
grep -c '__AWS_REGION__' manifests/system/cloudwatch-dashboard.yaml  
# Expected: 13 (11 widgets + 2 script comments)
\`\`\`

## Related

- Part of #819 (hardcoded value audit for portability)
- Tracked in #865 (v0.1 release readiness)
- Closes #928

## Effort

S (5 minutes)