### PR TITLE
fix: parameterize hardcoded us-west-2 in cloudwatch-dashboard.yaml

### DIFF
--- a/manifests/system/cloudwatch-dashboard.yaml
+++ b/manifests/system/cloudwatch-dashboard.yaml
@@ -245,7 +245,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Health & Load",
             "period": 60,
             "yAxis": {
@@ -284,7 +284,7 @@ data:
             ],
             "view": "timeSeries",
             "stacked": false,
-            "region": "us-west-2",
+            "region": "__AWS_REGION__",
             "title": "Coordinator Pod Restarts",
             "period": 300,
             "yAxis": {


### PR DESCRIPTION
Fixes #928

## Problem
cloudwatch-dashboard.yaml had 2 hardcoded `us-west-2` references (lines 248, 287) instead of using the `__AWS_REGION__` placeholder. This broke portability for new gods installing in different regions.

## Solution
Replaced hardcoded region strings with `__AWS_REGION__` placeholder. The apply-dashboard.sh script replaces this placeholder with actual region at runtime.

## Testing
- Verified all other region references already use `__AWS_REGION__` (lines 36, 64, 89, 109, 132, 166, 180, 200, 223)
- Lines 248 and 287 were the only remaining hardcoded regions
- The sed replacement in apply-dashboard.sh (line 340) handles all placeholders

## Effort
S-effort (< 10 minutes)

## Related
- Part of issue #819 portability work
- Tracked in issue #865 (v0.1 release readiness)