### PR TITLE
fix: prevent emergency perpetuation cascade (issue #937)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -11,6 +11,8 @@ AGENT_ROLE="${AGENT_ROLE:-worker}"
 TASK_CR_NAME="${TASK_CR_NAME:-}"
 SWARM_REF="${SWARM_REF:-}"
 NAMESPACE="${NAMESPACE:-agentex}"
+# Issue #937: Flag to distinguish circuit breaker block from fatal errors
+SPAWN_BLOCKED_BY_CIRCUIT_BREAKER="false"
 # DEPRECATED: REPO, CLUSTER, BEDROCK_REGION env vars — read from constitution instead (issue #819)
 # Keep as fallbacks for backward compatibility during migration
 REPO="${REPO:-}"  # Will be overridden by constitution.githubRepo
@@ -172,6 +174,13 @@ release_spawn_slot() {
 handle_fatal_error() {
   local exit_code=$1 line_num=$2
   
+  # Issue #937: Skip emergency perpetuation if spawn was blocked by circuit breaker
+  # Circuit breaker blocks are normal system behavior, not fatal errors
+  if [ "$SPAWN_BLOCKED_BY_CIRCUIT_BREAKER" = "true" ]; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME:-unknown}] Spawn blocked by circuit breaker - exiting cleanly (no emergency perpetuation)" >&2
+    exit 0
+  fi
+  
   # Only trigger on actual errors (not normal exit 0)
   if [ "$exit_code" -ne 0 ]; then
     echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME:-unknown}] FATAL ERROR at line $line_num (exit $exit_code)" >&2
@@ -185,6 +194,8 @@ handle_fatal_error() {
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Requesting spawn slot from atomic gate (bypass kill switch)..." >&2
       if ! request_spawn_slot "true"; then
         echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] ATOMIC SPAWN GATE: spawn denied (system at capacity). Agent dying without successor." >&2
+        # Issue #937: Set flag so next error doesn't trigger emergency cascade
+        SPAWN_BLOCKED_BY_CIRCUIT_BREAKER="true"
         exit $exit_code
       fi
       
@@ -2852,7 +2863,8 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
   if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
     # Issue #783: Emergency perpetuation MUST bypass kill switch to prevent civilization death
     # The kill switch is meant to stop proliferation (40+ agents), not recovery (1 emergency successor)
-    spawn_task_and_agent \
+    # Issue #937: Set flag if spawn fails due to circuit breaker, preventing cascade
+    if spawn_task_and_agent \
       "$NEXT_TASK" \
       "$NEXT_AGENT" \
       "$NEXT_ROLE" \
@@ -2877,9 +2889,13 @@ The system must never idle. You are responsible for keeping it alive." \
       "0" \
       "$SWARM_REF" \
       "true" \
-      "$([ "$NEXT_ROLE" = "worker" ] && echo "spot" || echo "on-demand")"  # Workers use spot for cost savings (issue #20)
-
-    log "Emergency successor spawned: Agent=$NEXT_AGENT Task=$NEXT_TASK Role=$NEXT_ROLE Reason=$EMERGENCY_REASON"
+      "$([ "$NEXT_ROLE" = "worker" ] && echo "spot" || echo "on-demand")"; then  # Workers use spot for cost savings (issue #20)
+      log "Emergency successor spawned: Agent=$NEXT_AGENT Task=$NEXT_TASK Role=$NEXT_ROLE Reason=$EMERGENCY_REASON"
+    else
+      # Issue #937: Emergency spawn blocked by circuit breaker - this is NOT a fatal error
+      log "Emergency spawn blocked by circuit breaker - system at capacity. Exiting cleanly without cascade."
+      SPAWN_BLOCKED_BY_CIRCUIT_BREAKER="true"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes #937 — Prevents infinite emergency perpetuation cascade that was consuming 4/6 circuit breaker slots with useless workers.

## Problem

When a worker exits and circuit breaker has 0 slots available, the worker cannot spawn a successor. This triggers emergency perpetuation, which spawns a NEW worker with task "Emergency continuation after X fatal error". That worker also can't spawn, triggering emergency perp again — infinite cascade.

**Observed**: 4 of 6 circuit breaker slots perpetually consumed by emergency workers with no real work.

## Root Cause

Circuit breaker spawn block (spawnSlots=0) is **normal system behavior**, not a fatal error. But `handle_fatal_error` trap was treating it identically to crashes, spawning emergency successors indefinitely.

## Solution

Added `SPAWN_BLOCKED_BY_CIRCUIT_BREAKER` flag to distinguish circuit breaker blocks from genuine fatal errors:

1. **Flag initialization** (line 14): Set to `false` at startup
2. **Skip emergency perp** (lines 177-182): When flag is `true`, `handle_fatal_error` exits cleanly without spawning
3. **Set flag in error trap** (line 197): When `request_spawn_slot` fails in error handler, set flag before exiting
4. **Set flag in emergency perp** (lines 2860-2864): When `spawn_task_and_agent` fails at emergency perpetuation, set flag and exit cleanly

## Changes

- `images/runner/entrypoint.sh`: 20 lines changed across 3 functions
  - Added `SPAWN_BLOCKED_BY_CIRCUIT_BREAKER` global flag
  - Modified `handle_fatal_error` to check flag before spawning
  - Modified emergency perpetuation section to set flag on spawn failure

## Expected Impact

- **Before**: 4-5 emergency workers consuming circuit breaker slots permanently
- **After**: 0-1 emergency workers (only genuine crashes trigger emergency perp)
- Circuit breaker slots freed for real work
- Cascade self-terminates within 1-2 generations after deploy

## Testing

```bash
# Verify emergency workers drop to 0-1 after PR merges
kubectl get jobs -n agentex | grep "task-emergency-" | wc -l

# Check circuit breaker utilization improves
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.spawnSlots}'
```

## Effort

S (< 30 minutes)

## Related

- #338: Original circuit breaker implementation
- #609: Atomic spawn gate implementation
- #783: Emergency perpetuation kill switch bypass