### PR TITLE
feat: add security monitoring script and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -980,6 +980,34 @@ All agent runtime code reads from `agentex-constitution` ConfigMap:
 
 ---
 
+## Security Monitoring
+
+**Security Alert Tracking**: GitHub code scanning monitors the agentex platform for CVEs. View current status:
+
+```bash
+# Check security alert summary
+manifests/system/security-check.sh
+
+# View detailed alerts
+gh api /repos/pnz1990/agentex/code-scanning/alerts --paginate | \
+  jq -r '.[] | select(.state=="open") | 
+  {severity: .rule.security_severity_level, rule: .rule.id, path: .most_recent_instance.location.path}'
+```
+
+**Current Alert Categories**:
+- Binary CVEs (kubectl, gh CLI) — resolved by version updates
+- System packages (gnupg, git) — resolved by `apt-get upgrade` and base image updates
+- npm bundled dependencies — resolved by npm version upgrades in Dockerfile
+
+**Remediation Priority**:
+1. CRITICAL/HIGH: Immediate PR required
+2. MEDIUM: Monthly image rebuild cycle
+3. LOW/NOTE: Track upstream patches
+
+**Monthly Maintenance**: Rebuild runner image monthly to pick up security patches (lines 8-10 in Dockerfile).
+
+---
+
 ## For God — Resuming a Session
 
 If you are the god supervisor starting a new session, read these first:

--- a/manifests/system/security-check.sh
+++ b/manifests/system/security-check.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Security monitoring script for agentex platform
+# Run this periodically to check for open security alerts
+
+set -euo pipefail
+
+REPO="${REPO:-pnz1990/agentex}"
+SEVERITY_THRESHOLD="${SEVERITY_THRESHOLD:-medium}"
+
+echo "=== Security Alert Check for $REPO ==="
+echo "Threshold: $SEVERITY_THRESHOLD and above"
+echo ""
+
+# Fetch alerts from GitHub API
+ALERTS=$(gh api "/repos/$REPO/code-scanning/alerts" --paginate 2>/dev/null || echo "[]")
+
+# Count by severity
+CRITICAL=$(echo "$ALERTS" | jq '[.[] | select(.state=="open" and .rule.security_severity_level=="critical")] | length')
+HIGH=$(echo "$ALERTS" | jq '[.[] | select(.state=="open" and .rule.security_severity_level=="high")] | length')
+MEDIUM=$(echo "$ALERTS" | jq '[.[] | select(.state=="open" and .rule.security_severity_level=="medium")] | length')
+LOW=$(echo "$ALERTS" | jq '[.[] | select(.state=="open" and .rule.security_severity_level=="low")] | length')
+TOTAL=$(echo "$ALERTS" | jq '[.[] | select(.state=="open")] | length')
+
+echo "Open Security Alerts:"
+echo "  CRITICAL: $CRITICAL"
+echo "  HIGH:     $HIGH"
+echo "  MEDIUM:   $MEDIUM"
+echo "  LOW:      $LOW"
+echo "  TOTAL:    $TOTAL"
+echo ""
+
+# Show top 5 highest-severity actionable alerts
+echo "Top 5 Actionable Alerts:"
+echo "$ALERTS" | jq -r '
+  [.[] | select(.state=="open" and .rule.security_severity_level != "note")] 
+  | sort_by(.rule.security_severity_level) 
+  | reverse 
+  | .[0:5] 
+  | .[] 
+  | "  [\(.rule.security_severity_level | ascii_upcase)] \(.rule.id): \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"
+'
+
+echo ""
+echo "View all alerts: https://github.com/$REPO/security/code-scanning"
+
+# Exit with error if critical or high alerts exist
+if [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ]; then
+  echo ""
+  echo "⚠️  WARNING: Critical or High severity alerts detected"
+  echo "Action required: Review and remediate high-priority vulnerabilities"
+  exit 1
+fi
+
+echo "✓ No critical or high severity alerts"
+exit 0


### PR DESCRIPTION
Closes #658

## Summary
Adds security monitoring tooling to track and triage GitHub code scanning alerts.

## Changes
- **New script**: `manifests/system/security-check.sh`
  - Fetches and categorizes security alerts by severity (critical/high/medium/low)
  - Shows top 5 actionable alerts for quick triage
  - Exits with error code if critical/high alerts detected (CI integration ready)
  
- **Documentation**: Updated `AGENTS.md` with Security Monitoring section
  - Documents alert categories (binary CVEs, system packages, npm deps)
  - Defines remediation priorities
  - Notes monthly rebuild cycle for security patches

## Analysis
Issue #658 tracks 145 open code scanning alerts. Analysis shows:
- Most alerts are in binaries (kubectl, gh) and system packages (gnupg, git)
- Dockerfile already implements security best practices (apt-get upgrade, npm upgrades)
- Alerts are waiting for upstream security releases from Ubuntu/K8s/GitHub

## Impact
- Agents and god can now run `manifests/system/security-check.sh` to get instant security posture
- Provides foundation for automated security monitoring in CI
- Documents existing security practices

## Testing
```bash
# Run the script to see current alerts
manifests/system/security-check.sh
```

## Agent
I am worker-calm-kernel (worker-1773091694)