### PR TITLE
fix: enforce single-planner constraint to prevent simultaneous planners (#947)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -812,6 +812,24 @@ The civilization needs mediators, not just voters." \
 PLANNER_LIVENESS_TIMEOUT=300  # 5 minutes: if no planner active for 5 min, spawn one
 
 ensure_planner_chain_alive() {
+    # Issue #947: Guard against scheduling-lag false positives.
+    # After spawning a recovery planner, the pod takes 20-90s to become active.
+    # During that window active_planners=0 and the watchdog would double-spawn.
+    # Solution: write pendingPlannerSpawn timestamp after every spawn and skip
+    # the watchdog for PENDING_PLANNER_GRACE seconds after a recent spawn.
+    local PENDING_PLANNER_GRACE=90
+    local pending_spawn
+    pending_spawn=$(get_state "pendingPlannerSpawn")
+    if [ -n "$pending_spawn" ]; then
+        local pending_epoch
+        pending_epoch=$(date -d "$pending_spawn" +%s 2>/dev/null || echo "0")
+        local pending_age=$(( $(date +%s) - pending_epoch ))
+        if [ "$pending_age" -lt "$PENDING_PLANNER_GRACE" ]; then
+            echo "[$(date -u +%H:%M:%S)] Planner liveness: planner recently spawned (${pending_age}s ago, grace=${PENDING_PLANNER_GRACE}s). Skipping to avoid double-spawn."
+            return 0
+        fi
+    fi
+
     # Count active planner jobs
     local active_planners
     active_planners=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
@@ -827,8 +845,9 @@ ensure_planner_chain_alive() {
     fi
 
     if [ "$active_planners" -gt 0 ]; then
-        # Planner chain healthy — reset last-seen timestamp
+        # Planner chain healthy — reset last-seen timestamp and clear pending spawn
         update_state "lastPlannerSeen" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        update_state "pendingPlannerSpawn" ""
         return 0
     fi
 
@@ -904,8 +923,10 @@ This is the coordinator's planner-chain liveness watchdog. Gap threshold: ${PLAN
 The planner chain is the civilization heartbeat — it must never stay dead for more than 5 minutes." \
         "insight"
 
-    # Reset last-seen so we don't double-spawn
+    # Reset last-seen AND record pending spawn timestamp so watchdog skips
+    # the next PENDING_PLANNER_GRACE seconds (pod scheduling lag window, issue #947)
     update_state "lastPlannerSeen" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    update_state "pendingPlannerSpawn" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     echo "[$(date -u +%H:%M:%S)] Recovery planner ${agent_name} spawned."
 }

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2841,9 +2841,21 @@ if [ "$NEEDS_EMERGENCY_SPAWN" = true ]; then
     NEXT_ROLE="$ESCALATED_ROLE"
     log "Using escalated role: $NEXT_ROLE"
   else
-    # Default role cycling to ensure the platform keeps improving itself
+   # Default role cycling to ensure the platform keeps improving itself
     case "$AGENT_ROLE" in
-      worker)    NEXT_ROLE="planner" ;;
+      worker)
+        # Issue #947: single-planner constraint — before spawning a planner,
+        # verify no planner is already running (TOCTOU race: two workers completing
+        # simultaneously both see no successor and both spawn planners).
+        ACTIVE_PLANNERS_COUNT=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+          jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0) | select(.metadata.name | test("planner"))] | length' 2>/dev/null || echo "0")
+        if [ "$ACTIVE_PLANNERS_COUNT" -gt 0 ]; then
+          log "Single-planner constraint: $ACTIVE_PLANNERS_COUNT planner(s) already active. Spawning worker instead."
+          NEXT_ROLE="worker"
+        else
+          NEXT_ROLE="planner"
+        fi
+        ;;
       planner)   NEXT_ROLE="worker" ;;
       reviewer)  NEXT_ROLE="worker" ;;
       architect) NEXT_ROLE="worker" ;;


### PR DESCRIPTION
## Problem

Multiple planner jobs run simultaneously (observed: up to 4 concurrent). This wastes compute, causes redundant work, and violates the design constraint: **at most 1 active planner at any time**.

Two root causes (issue #947):

### 1. Emergency perp TOCTOU race (entrypoint.sh)
When a worker exits without spawning a successor, emergency perpetuation cycles `worker → planner`. Two workers completing simultaneously both see no successor → both spawn planners. No check for existing active planners before spawning.

### 2. Coordinator watchdog scheduling lag (coordinator.sh)
`ensure_planner_chain_alive()` checks `active_planners > 0` — but a newly spawned planner takes 20–90s to reach `active` state (pod scheduling, image pull). During this window the watchdog sees 0 active planners and spawns another recovery planner.

## Fix

### entrypoint.sh — check before spawning planner
```bash
# Issue #947: single-planner constraint
ACTIVE_PLANNERS_COUNT=$(kubectl get jobs ... | jq '... | test("planner") | length')
if [ "$ACTIVE_PLANNERS_COUNT" -gt 0 ]; then
  NEXT_ROLE="worker"  # planner already running
else
  NEXT_ROLE="planner"
fi
```

### coordinator.sh — pendingPlannerSpawn grace window
After spawning a recovery planner, write `pendingPlannerSpawn` timestamp to coordinator-state. At the top of `ensure_planner_chain_alive()`, skip for 90s if a planner was recently spawned (covers scheduling lag). Clear the timestamp when a live planner is confirmed active.

## Testing

The fix is behaviorally correct:
- Two simultaneous workers: first reads `active_planners=0` → spawns planner. Second reads `active_planners=1` (planner now running) → spawns worker instead.
- Coordinator watchdog: after spawning recovery planner, subsequent calls see `pendingPlannerSpawn` < 90s → skip. Once planner becomes active, `pendingPlannerSpawn` is cleared.

Closes #947