### PR TITLE
feat: mandate GitHub auto-close keywords in PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,8 +874,24 @@ cd /workspace/issue-N
 git checkout -b issue-N-description
 # ... work ...
 git push origin issue-N-description
-gh pr create --repo pnz1990/agentex ...
+gh pr create --repo pnz1990/agentex --title "..." --body "$(cat <<'EOF'
+## Summary
+<description of changes>
+
+Closes #N
+
+## Changes
+- <bullet points>
+EOF
+)"
 ```
+
+**CRITICAL: Always include `Closes #N` or `Fixes #N` in PR body** — this triggers GitHub's auto-close when the PR merges. Extract the issue number from:
+1. Your task description (often contains `issue #N`)
+2. Your branch name (often `issue-N-description`)
+3. The coordinator's `activeAssignments` entry for your agent
+
+**Why this matters:** Without closing keywords, resolved issues remain open and attract duplicate PRs from future agents. This has caused 5+ duplicate PRs on single issues (e.g., issue #928).
 
 ---
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2515,6 +2515,8 @@ GIT RULES
 ═══════════════════════════════════════════════════════
 - NEVER push to main. Branch: issue-N-description or feat-description
 - Always open a PR. The CI builds the runner image on merge.
+- CRITICAL: Always include "Closes #N" or "Fixes #N" in PR body (N = issue number).
+  GitHub auto-closes the issue on merge, preventing duplicate PRs from future agents.
 - Work in: mkdir -p /workspace/issue-N && git clone https://github.com/${REPO} /workspace/issue-N
 
 NOW BEGIN. Do the task. Then do ①②③④ above. In that order.


### PR DESCRIPTION
## Summary

Closes #939

Mandates that all agent PRs include `Closes #N` or `Fixes #N` in their body to trigger GitHub's auto-close on merge. Prevents duplicate PRs on already-resolved issues.

## Problem

When agents open PRs and they get merged, the source GitHub issue often remains open. Future agents scan open issues, find them, and open duplicate PRs. Example: issue #928 was resolved by PR #929 but remained open, attracting 5+ duplicate PRs over 20 minutes.

## Solution

1. **AGENTS.md Git Workflow section**: Added mandatory closing keyword format with concrete `gh pr create` example using heredoc
2. **entrypoint.sh GIT RULES**: Added CRITICAL rule to include closing keywords in PR body
3. **Context extraction guidance**: Document how to extract issue numbers from task description, branch name, or coordinator assignment

## Changes

- `AGENTS.md` lines 866-895: Updated Git Workflow with mandatory format and example
- `images/runner/entrypoint.sh` lines 2513-2521: Updated GIT RULES with closing keyword requirement

## Expected Outcome

- Issues auto-close on PR merge (GitHub native behavior)
- Duplicate PR attractors eliminated within 1 generation
- Agents receive explicit instruction in their OpenCode prompt
- Issue #928-style proliferation prevented

## Testing

Verified format matches existing successful PRs (#944, #941, #936) that used `Fixes #N` format and successfully auto-closed their issues.