### PR TITLE
feat: mandate 'Closes #N' in PR body to auto-close issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,8 +874,16 @@ cd /workspace/issue-N
 git checkout -b issue-N-description
 # ... work ...
 git push origin issue-N-description
-gh pr create --repo pnz1990/agentex ...
+gh pr create --repo pnz1990/agentex --title "..." --body "$(cat <<'EOF'
+## Summary
+<description>
+
+Closes #N
+EOF
+)"
 ```
+
+**MANDATORY (issue #939):** Every PR body MUST include `Closes #N` to auto-close the issue on merge. This prevents duplicate PRs on already-solved issues. Extract the issue number from your task description, branch name, or coordinator assignment.
 
 ---
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2517,6 +2517,21 @@ GIT RULES
 - Always open a PR. The CI builds the runner image on merge.
 - Work in: mkdir -p /workspace/issue-N && git clone https://github.com/${REPO} /workspace/issue-N
 
+MANDATORY PR BODY FORMAT (issue #939):
+Every PR MUST include "Closes #N" in the body to auto-close the issue on merge.
+Extract issue number from:
+1. Your task description (often contains "issue #NNN")
+2. Your branch name (often "issue-NNN-description")
+3. COORDINATOR_CONTEXT above (if assigned by coordinator)
+
+Example PR body:
+  ## Summary
+  Fixed circuit breaker bug by adding atomic spawn gate.
+  
+  Closes #338
+
+This prevents duplicate PRs on already-solved issues.
+
 NOW BEGIN. Do the task. Then do ①②③④ above. In that order.
 PROMPT
 )


### PR DESCRIPTION
## Summary

Fixed issue #939 by adding mandatory PR body format guidance to ensure all PRs include `Closes #N` to auto-close their corresponding GitHub issues on merge.

## Changes

1. **entrypoint.sh GIT RULES section** (lines 2513-2535):
   - Added MANDATORY PR BODY FORMAT subsection
   - Instructs agents to include `Closes #N` in every PR body
   - Explains 3 sources for extracting issue number: task description, branch name, coordinator assignment
   - Provides example PR body format

2. **AGENTS.md Git Workflow section** (lines 866-884):
   - Updated `gh pr create` example to show proper body format with heredoc
   - Added mandatory note about `Closes #N` requirement
   - Links back to issue #939 for context

## Problem Solved

Before: Issues remained open after their PRs merged, attracting duplicate PRs from future agents (e.g., issue #928 attracted 5 duplicate PRs over 20 minutes)

After: GitHub auto-closes issues when PRs merge, preventing duplicate work

## Testing

This PR itself demonstrates the format - it includes `Closes #939` below.

## Effort

S - two documentation updates, no runtime logic changes

Closes #939