### PR TITLE
security: fix minimatch HIGH CVEs - upgrade constraint to >=10.2.3 (issue #658)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r3 (security: npm cache cleanup to remove false-positive PAT alerts; issue #897)
+# Image version: 2026-03-09-r4 (security: fix minimatch HIGH CVEs by upgrading to >=10.2.3; issue #658)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -40,16 +40,21 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
     && npm cache clean --force
 
-# Fix npm bundled dependency CVEs (issue #858)
+# Fix npm bundled dependency CVEs (issue #858, issue #658)
 # npm bundles tar, minimatch, and glob in /usr/lib/node_modules/npm/node_modules/
-# These bundled versions have HIGH CVEs: tar@7.4.3->7.5.10, minimatch@9.0.5->9.0.7, glob@10.4.5->10.5.0
+# HIGH CVEs fixed:
+#   tar: >=7.5.10 (CVE-2026-29786: prior to 7.5.10 has HIGH severity vulnerability)
+#   minimatch: >=10.2.3 (CVE-2026-27903, CVE-2026-27904: 10.2.2 vulnerable, 10.2.3 is fixed)
+#     NOTE: constraint must be >=10.2.3 not >=9.0.7 because npm 11 resolves to v10.x series
+#     and 10.2.2 has HIGH CVEs; using >=9.0.7 installs 10.2.2 (latest matching), not 10.2.3
+#   glob: >=10.5.0 (CVE for glob <10.5.0)
 # Fix: upgrade npm itself (npm 11+ ships with patched bundled deps)
 # Also: upgrade specific vulnerable packages directly in npm's own node_modules
 RUN npm install -g npm@latest \
     && cd /usr/lib/node_modules/npm \
     && npm install --prefer-online \
         tar@">=7.5.10" \
-        minimatch@">=9.0.7" \
+        minimatch@">=10.2.3" \
         glob@">=10.5.0" \
     2>/dev/null || true \
     && npm cache clean --force \


### PR DESCRIPTION
## Summary

Fixes HIGH severity security vulnerabilities in npm's bundled minimatch package.

## Root Cause

The previous Dockerfile fix for issue #858 used constraint `minimatch@'>=9.0.7'`.
However, npm 11 bundles minimatch in the v10.x series (via `^10` dependency).
This meant `>=9.0.7` resolved to minimatch@10.2.2 (latest matching), which has
two HIGH severity CVEs:

- **CVE-2026-27903** (HIGH): minimatch DoS via unbounded recursive backtracking
- **CVE-2026-27904** (HIGH): minimatch DoS via catastrophic backtracking in glob expressions

## Fix

Changed constraint from `minimatch@'>=9.0.7'` to `minimatch@'>=10.2.3'`.

minimatch 10.2.3 is the patched version that resolves both CVEs.

## Impact

- Closes 2 HIGH severity Trivy code scanning alerts (#47, #48)
- Does not change any runtime behavior (minimatch is an internal npm dependency)
- Updated image version comment to 2026-03-09-r4

## Remaining Alerts

The other 49 open alerts fall into categories that cannot be addressed at this time:
- **System packages** (linux-pam, libexpat, gnupg, tar, openssh): Most have no fixed version
  available in Ubuntu 24.04 repos. Already have `apt-get upgrade -y` to pick up patches when available.
- **Binary vulnerabilities** (kubectl, gh stdlib): In compiled Go binaries, require new upstream releases.
  Both kubectl (v1.35.2) and gh (v2.87.3) are already at latest releases.
- **docker/cli in gh binary**: CVE-2025-15558 is in the docker/cli Go package bundled in gh,
  cannot be patched without upstream gh release.

Closes #658 (partial - addresses HIGH severity npm CVEs)