### PR TITLE
fix: planner-loop count functions and --validate=false for CRD permission

### DIFF
--- a/images/runner/planner-loop.sh
+++ b/images/runner/planner-loop.sh
@@ -58,12 +58,14 @@ push_metric() {
 }
 
 count_active_jobs() {
-    kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    # Redirect stderr to /dev/null to avoid mixing error output with the integer result
+    timeout 10s kubectl get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0"
 }
 
 count_active_planners() {
-    kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -l agentex/role=planner -o json 2>/dev/null | \
+    # Redirect stderr to /dev/null to avoid mixing error output with the integer result
+    timeout 10s kubectl get jobs -n "$NAMESPACE" -l agentex/role=planner -o json 2>/dev/null | \
         jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0"
 }
 
@@ -75,7 +77,7 @@ spawn_planner_job() {
     echo "[$(date -u +%H:%M:%S)] Spawning planner Job: $name (generation $generation)"
     
     # Create Task CR first
-    kubectl apply -f - <<EOF
+    kubectl apply --validate=false -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Task
 metadata:
@@ -94,7 +96,7 @@ spec:
 EOF
     
     # Create Agent CR (triggers Job via agent-graph RGD)
-    kubectl apply -f - <<EOF
+    kubectl apply --validate=false -f - <<EOF
 apiVersion: kro.run/v1alpha1
 kind: Agent
 metadata:


### PR DESCRIPTION
## Summary

Fixes two bugs in the newly deployed planner-loop.sh (from PR #953).

Closes #867 (follow-up fix — planner-loop is deployed but crashing on iteration 1)

## Bugs Fixed

### 1. count_active_jobs/count_active_planners return non-integer output

`kubectl_with_timeout` redirects stderr to stdout. When kubectl emits any warning or info line, the output becomes multiline (e.g., `0\n0`) causing:
```
/usr/local/bin/planner-loop.sh: line 174: [: 0\n0: integer expression expected
```

Fix: use bare `timeout Ns kubectl ... 2>/dev/null` instead of `kubectl_with_timeout`.

### 2. kubectl apply fails on CRD validation permission

The `agentex-agent-sa` ServiceAccount cannot list CRDs at cluster scope, causing:
```
error validating data: failed to check CRD: ... cannot list resource "customresourcedefinitions"
```

Fix: add `--validate=false` to both `kubectl apply` calls in `spawn_planner_job()`.

## Observed in Cluster

```
[22:24:40] Active jobs: 0\n0 / 6
/usr/local/bin/planner-loop.sh: line 174: [: 0\n0: integer expression expected
[22:24:52] No active planner detected. Ready to spawn.
error: error validating "STDIN": ... customresourcedefinitions.apiextensions.k8s.io is forbidden
[22:24:54] ERROR: Failed to spawn planner Job
```