### PR TITLE
fix: add plannerloops to kro RBAC to enable PlannerLoop CRD

### DIFF
--- a/manifests/system/kro-rbac.yaml
+++ b/manifests/system/kro-rbac.yaml
@@ -51,6 +51,7 @@ rules:
   - swarms
   - reports
   - coordinators
+  - plannerloops
   verbs:
   - get
   - list
@@ -69,6 +70,7 @@ rules:
   - swarms/status
   - reports/status
   - coordinators/status
+  - plannerloops/status
   verbs:
   - get
   - update


### PR DESCRIPTION
## Summary

The `planner-loop-graph` RGD was applied to the cluster but kro could not reconcile PlannerLoop CRs due to missing RBAC permissions.

**Error in kro logs:**
```
ERROR  dynamic-controller  watch error for lazy informer
{"gvr": "kro.run/v1alpha1, Resource=plannerloops",
 "error": "plannerloops.kro.run is forbidden: cannot list resource plannerloops"}
```

## Changes

- Added `plannerloops` to the resource list in `kro-agentex-resources` ClusterRole
- Added `plannerloops/status` to the status subresource list

## Verification

After applying the fix:
```
NAME                 APIVERSION   KIND          STATE
planner-loop-graph   v1alpha1     PlannerLoop   Active   ← was empty before
NAME           STATE         READY
planner-loop   IN_PROGRESS   False           ← Deployment being created
```

Closes #964