### PR TITLE
feat: add planner-loop to Helm chart and fix kro RBAC for plannerloops

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,35 @@ aws s3 cp s3://agentex-thoughts/chronicle.json - | jq '.entries | .[-3:]'
 
 ---
 
-## Bootstrap (from scratch)
+## Quickstart — Helm (recommended)
+
+Install the entire civilization with one command:
+
+```bash
+# 1. Prerequisites: EKS cluster, kubectl configured, kro installed
+bash manifests/system/kro-install.sh
+
+# 2. Install agentex via Helm
+helm install agentex ./chart \
+  --set god.repo=myorg/myrepo \
+  --set god.vision="Your civilization's purpose" \
+  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
+  --set aws.region=us-east-1 \
+  --set aws.s3Bucket=my-agentex-thoughts \
+  --set github.token=ghp_yourtoken \
+  --set cluster.name=my-cluster
+
+# 3. Watch it boot
+kubectl get jobs -n agentex -w
+```
+
+The Helm chart installs: RBAC, RGDs, constitution ConfigMap, coordinator, planner-loop, kill switch, and the seed agent. The seed starts the civilization and exits. The planner-loop keeps it running forever.
+
+For a full walkthrough, see [INSTALL.md](INSTALL.md).
+
+---
+
+## Bootstrap (from scratch — raw manifests)
 
 ```bash
 # 1. Install kro

--- a/chart/templates/kro-rbac.yaml
+++ b/chart/templates/kro-rbac.yaml
@@ -56,6 +56,7 @@ rules:
   - swarms
   - reports
   - coordinators
+  - plannerloops
   verbs:
   - get
   - list
@@ -74,6 +75,7 @@ rules:
   - swarms/status
   - reports/status
   - coordinators/status
+  - plannerloops/status
   verbs:
   - get
   - update

--- a/chart/templates/planner-loop.yaml
+++ b/chart/templates/planner-loop.yaml
@@ -1,0 +1,14 @@
+# Bootstrap the planner-loop — triggers planner-loop-graph RGD to create
+# the planner-loop Deployment. This is the civilization's heartbeat.
+# It runs continuously, spawning planner Jobs with generational identity.
+apiVersion: kro.run/v1alpha1
+kind: PlannerLoop
+metadata:
+  name: planner-loop
+  namespace: {{ include "agentex.namespace" . }}
+spec:
+  enabled: true
+  model: {{ .Values.agent.model | quote }}
+  imageTag: {{ .Values.image.tag | quote }}
+  imageRegistry: {{ .Values.image.registry | quote }}
+  clusterName: {{ .Values.cluster.name | quote }}

--- a/chart/templates/rgd-planner-loop.yaml
+++ b/chart/templates/rgd-planner-loop.yaml
@@ -1,0 +1,103 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: planner-loop-graph
+  namespace: {{ include "agentex.namespace" . }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: PlannerLoop
+    spec:
+      enabled: boolean | default=true
+      model: string | default={{ .Values.agent.model | quote }}
+      imageTag: string | default={{ .Values.image.tag | quote }}
+      imageRegistry: string | default={{ .Values.image.registry | quote }}
+      clusterName: string | default={{ .Values.cluster.name | quote }}
+    status:
+      deploymentName: ${plannerLoopDeployment.metadata.name}
+      phase: ${plannerLoopDeployment.metadata.name}
+  resources:
+    # ── Planner Loop Deployment ──────────────────────────────────────────────
+    # Long-running Pod that spawns planner Jobs with generational identity.
+    # This is the civilization's heartbeat — it must never stop.
+    - id: plannerLoopDeployment
+      readyWhen:
+        - ${plannerLoopDeployment.status.availableReplicas == 1}
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: planner-loop
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-planner-loop
+            agentex/component: planner-loop
+        spec:
+          replicas: 1
+          strategy:
+            type: Recreate  # Only one planner-loop at a time
+          selector:
+            matchLabels:
+              app: agentex-planner-loop
+          template:
+            metadata:
+              labels:
+                app: agentex-planner-loop
+                agentex/component: planner-loop
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Always
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: planner-loop
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
+                  imagePullPolicy: Always
+                  command: ["/bin/bash", "/usr/local/bin/planner-loop.sh"]
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "50m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "200m"
+                  livenessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 30
+                    periodSeconds: 60
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 10
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 2

--- a/manifests/system/kro-rbac.yaml
+++ b/manifests/system/kro-rbac.yaml
@@ -51,6 +51,7 @@ rules:
   - swarms
   - reports
   - coordinators
+  - plannerloops
   verbs:
   - get
   - list
@@ -69,6 +70,7 @@ rules:
   - swarms/status
   - reports/status
   - coordinators/status
+  - plannerloops/status
   verbs:
   - get
   - update


### PR DESCRIPTION
## Summary

- Add `chart/templates/rgd-planner-loop.yaml`: Helm-templated planner-loop-graph RGD (was missing from chart)
- Add `chart/templates/planner-loop.yaml`: PlannerLoop CR to bootstrap the civilization heartbeat
- Fix `kro-rbac` (chart + manifests): add `plannerloops` + `plannerloops/status` to ClusterRole
- Add Helm quickstart section to README.md with one-command install example

## Problem

`helm install agentex ./chart` was missing the planner-loop-graph RGD and PlannerLoop CR bootstrap templates. The civilization's heartbeat (planner-loop Deployment) would never be created. Additionally, even if applied manually, kro would immediately fail with a permission error because `plannerloops` was missing from the kro RBAC ClusterRole.

## Changes

- `chart/templates/rgd-planner-loop.yaml` — Helm-templated version of `manifests/rgds/planner-loop-graph.yaml` with values interpolation for image registry, tag, model, and cluster name
- `chart/templates/planner-loop.yaml` — PlannerLoop CR that triggers the RGD (same pattern as coordinator.yaml)
- `chart/templates/kro-rbac.yaml` + `manifests/system/kro-rbac.yaml` — Add `plannerloops` and `plannerloops/status` entries to ClusterRole rules
- `README.md` — Add prominent Helm quickstart section before the raw manifests bootstrap section

## Testing

`helm template agentex ./chart --set github.token=test` now renders the planner-loop RGD and CR. kro will be able to watch PlannerLoop resources without permission errors.

Closes #961
Fixes #964