### PR TITLE
fix: add plannerloops RBAC to install path files (issue #964 supplement)

### DIFF
--- a/chart/templates/kro-rbac.yaml
+++ b/chart/templates/kro-rbac.yaml
@@ -56,6 +56,7 @@ rules:
   - swarms
   - reports
   - coordinators
+  - plannerloops
   verbs:
   - get
   - list
@@ -74,6 +75,7 @@ rules:
   - swarms/status
   - reports/status
   - coordinators/status
+  - plannerloops/status
   verbs:
   - get
   - update

--- a/manifests/rbac/kro-rbac.yaml
+++ b/manifests/rbac/kro-rbac.yaml
@@ -18,11 +18,15 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # kro.run group — instances created by kro from RGD schemas (no group: field)
   - apiGroups: ["kro.run"]
-    resources: ["agents", "tasks", "messages", "thoughts", "swarms"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["kro.run"]
-    resources: ["agents/status", "tasks/status", "messages/status", "thoughts/status", "swarms/status"]
+    resources: ["agents/status", "tasks/status", "messages/status", "thoughts/status", "swarms/status", "reports/status", "coordinators/status", "plannerloops/status"]
     verbs: ["get", "update", "patch"]
+  # planner-loop-graph creates apps/v1 Deployments
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # agentex.io group — manually-applied CRDs (compatibility)
   - apiGroups: ["agentex.io"]
     resources: ["agents", "tasks", "messages", "thoughts", "swarms"]


### PR DESCRIPTION
## Summary

PR #965 fixed `manifests/system/kro-rbac.yaml` for issue #964, but missed the two files that are actually applied during installation:

- `manifests/rbac/kro-rbac.yaml` — applied by `kro-install.sh` (via `kubectl apply -f manifests/rbac/`)
- `chart/templates/kro-rbac.yaml` — used by Helm install

Without fixing these, fresh installs will still fail with the same kro permission error.

## Changes

1. **`manifests/rbac/kro-rbac.yaml`**:
   - Added `plannerloops` and `plannerloops/status` to kro.run resources
   - Added missing `reports`, `coordinators`, and their `/status` subresources
   - Added `apps/deployments` rule (needed by planner-loop-graph which creates Deployments)

2. **`chart/templates/kro-rbac.yaml`**:
   - Added `plannerloops` and `plannerloops/status` to kro.run resources

## Why This Matters

`kro-install.sh` runs `kubectl apply -f manifests/rbac/` — not `manifests/system/`. New gods installing agentex will still hit the forbidden error unless this file is fixed.

Closes #964