### PR TITLE
feat: v0.1 Helm chart — planner-loop RGD, bootstrap CR, install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,40 @@ aws s3 cp s3://agentex-thoughts/chronicle.json - | jq '.entries | .[-3:]'
 
 ---
 
-## Bootstrap (from scratch)
+## Install — new god quickstart (Helm)
+
+Prerequisites: EKS cluster, ECR repo with runner image, S3 bucket, GitHub token.
+
+```bash
+# 1. Install kro (the resource orchestrator that runs agents as Jobs)
+bash manifests/system/kro-install.sh
+
+# 2. Create GitHub token secret
+kubectl create namespace agentex
+kubectl create secret generic agentex-github-token \
+  --from-literal=token=ghp_YOUR_TOKEN \
+  -n agentex
+
+# 3. One-command install
+helm install agentex ./chart \
+  --namespace agentex \
+  --set god.repo=myorg/myrepo \
+  --set god.vision="Your civilization's purpose here" \
+  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
+  --set aws.region=us-east-1 \
+  --set aws.s3Bucket=my-agentex-thoughts \
+  --set cluster.name=my-cluster \
+  --set github.token=ghp_YOUR_TOKEN
+
+# 4. Watch the civilization start
+kubectl get jobs -n agentex -w
+```
+
+See `INSTALL.md` for full prerequisites, IAM setup, and troubleshooting.
+
+---
+
+## Bootstrap (from scratch — raw kubectl)
 
 ```bash
 # 1. Install kro

--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -39,6 +39,10 @@ data:
   # A new god's agents will file issues and PRs on their own repo.
   githubRepo: {{ .Values.github.repo | quote }}
 
+  # EKS cluster name (issue #819 portability)
+  # Agents use this to configure kubectl context. God sets this to their cluster name.
+  clusterName: {{ .Values.cluster.name | quote }}
+
   # Current civilization generation (god increments this)
   civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
 

--- a/chart/templates/planner-loop.yaml
+++ b/chart/templates/planner-loop.yaml
@@ -1,0 +1,14 @@
+# Bootstrap the planner loop — triggers planner-loop-graph RGD to create
+# the long-running Deployment that spawns planner Jobs with generational identity.
+# The planner loop is the civilization's heartbeat — it ensures planners always run.
+apiVersion: kro.run/v1alpha1
+kind: PlannerLoop
+metadata:
+  name: planner-loop
+  namespace: {{ include "agentex.namespace" . }}
+spec:
+  enabled: true
+  model: {{ .Values.agent.model | quote }}
+  imageTag: {{ .Values.image.tag | quote }}
+  imageRegistry: {{ .Values.image.registry | quote }}
+  clusterName: {{ .Values.cluster.name | quote }}

--- a/chart/templates/rgd-planner-loop.yaml
+++ b/chart/templates/rgd-planner-loop.yaml
@@ -1,0 +1,103 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: planner-loop-graph
+  namespace: {{ include "agentex.namespace" . }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: PlannerLoop
+    spec:
+      enabled: boolean | default=true
+      model: string | default={{ .Values.agent.model | quote }}
+      imageTag: string | default={{ .Values.image.tag | quote }}
+      imageRegistry: string | default={{ .Values.image.registry | quote }}
+      clusterName: string | default={{ .Values.cluster.name | quote }}
+    status:
+      deploymentName: ${plannerLoopDeployment.metadata.name}
+      phase: ${plannerLoopDeployment.metadata.name}
+  resources:
+    # ── Planner Loop Deployment ──────────────────────────────────────────────
+    # Long-running Pod that spawns planner Jobs with generational identity.
+    # Eliminates planner chain breaks and TOCTOU races (issue #867).
+    - id: plannerLoopDeployment
+      readyWhen:
+        - ${plannerLoopDeployment.status.availableReplicas == 1}
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: planner-loop
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-planner-loop
+            agentex/component: planner-loop
+        spec:
+          replicas: 1
+          strategy:
+            type: Recreate  # Only one planner-loop at a time
+          selector:
+            matchLabels:
+              app: agentex-planner-loop
+          template:
+            metadata:
+              labels:
+                app: agentex-planner-loop
+                agentex/component: planner-loop
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Always
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: planner-loop
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
+                  imagePullPolicy: {{ .Values.image.pullPolicy }}
+                  command: ["/bin/bash", "/usr/local/bin/planner-loop.sh"]
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "50m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "200m"
+                  livenessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 30
+                    periodSeconds: 60
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 10
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 2


### PR DESCRIPTION
## Summary

Completes the v0.1 Helm chart release by adding the missing planner-loop components and god onboarding docs.

Closes #961

## Changes

- **chart/templates/rgd-planner-loop.yaml** — Helm-templated PlannerLoop ResourceGraphDefinition. This RGD existed in `manifests/rgds/planner-loop-graph.yaml` but was missing from the Helm chart, meaning `helm install` would not deploy the planner-loop Deployment.
- **chart/templates/planner-loop.yaml** — Bootstrap `PlannerLoop` CR that triggers the `planner-loop-graph` RGD to create the long-running Deployment (the civilization heartbeat). Mirrors `coordinator.yaml` pattern.
- **chart/templates/constitution.yaml** — Added `clusterName` field (portability constant from issue #819). Agents read this at startup to configure kubectl context for their cluster.
- **README.md** — Added "Install — new god quickstart (Helm)" section with one-command `helm install`, prerequisites summary, and link to `INSTALL.md` for full details.

## Helm install (after this PR)

A new god can install agentex with one command:

\`\`\`bash
helm install agentex ./chart \
  --namespace agentex \
  --set god.repo=myorg/myrepo \
  --set god.vision="Your civilization's purpose" \
  --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
  --set aws.region=us-east-1 \
  --set aws.s3Bucket=my-agentex-thoughts \
  --set cluster.name=my-cluster \
  --set github.token=ghp_YOUR_TOKEN
\`\`\`