### PR TITLE
fix: coordinator task queue includes all actionable issues (not just labeled)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -241,17 +241,14 @@ refresh_task_queue() {
     # Build scored list: "score:number"
     local scored_issues=""
     local numbers
-    # Primary: issues with enhancement or bug labels (vision-priority)
-    numbers=$(echo "$issues_json" | jq -r '.[] | select(.labels[] | .name == "enhancement" or .name == "bug") | .number' 2>/dev/null | head -20)
-
-    # Issue #960 fallback: if no labeled issues found, use ALL open issues except
-    # meta-issues (GOD-REPORT, GOD-DELEGATE, architecture proposals without code)
-    if [ -z "$numbers" ]; then
-        echo "[$(date -u +%H:%M:%S)] No labeled issues found — falling back to all actionable open issues"
-        numbers=$(echo "$issues_json" | jq -r '.[] |
-            select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) |
-            .number' 2>/dev/null | head -20)
-    fi
+    
+    # Issue #960 fix: Always include unlabeled issues in the queue to prevent starvation.
+    # Strategy: Query ALL open issues, then filter out meta-issues only.
+    # This ensures queue is never empty when actionable work exists.
+    echo "[$(date -u +%H:%M:%S)] Fetching all actionable open issues (including unlabeled)..."
+    numbers=$(echo "$issues_json" | jq -r '.[] |
+        select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) |
+        .number' 2>/dev/null | head -20)
 
     for num in $numbers; do
         # Score based on labels already fetched (avoid extra API calls)


### PR DESCRIPTION
## Summary

Fixes coordinator task queue starvation when all labeled issues are resolved.

## Problem

The coordinator's `refresh_task_queue()` function was filtering to only fetch issues with `enhancement` or `bug` labels. When all labeled issues were resolved, the queue became empty and planners had no work, even though unlabeled actionable issues existed.

## Root Cause

Lines 245-254 had a fallback mechanism, but it only triggered when the labeled query returned zero results. This created a binary behavior:
- **Scenario A**: Labeled issues exist → queue contains ONLY labeled issues
- **Scenario B**: No labeled issues → queue contains ONLY unlabeled issues

The missing case: queue should contain BOTH labeled and unlabeled issues in every refresh, with priority scoring determining work order.

## Solution

Remove the label-based filter entirely:
- Always fetch ALL open issues except meta-issues (`[GOD-REPORT]`, `[GOD-DELEGATE]`)
- Vision priority scoring system still ranks labeled issues higher
- Unlabeled issues are available when labeled backlog is empty

## Changes

```diff
-    # Primary: issues with enhancement or bug labels (vision-priority)
-    numbers=$(echo "$issues_json" | jq -r '.[] | select(.labels[] | .name == "enhancement" or .name == "bug") | .number' 2>/dev/null | head -20)
-
-    # Issue #960 fallback: if no labeled issues found, use ALL open issues except...
-    if [ -z "$numbers" ]; then
-        numbers=$(echo "$issues_json" | jq -r '.[] | select(.title | test("...") | not) | .number' 2>/dev/null | head -20)
-    fi
+    # Issue #960 fix: Always include unlabeled issues to prevent starvation
+    numbers=$(echo "$issues_json" | jq -r '.[] | select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) | .number' 2>/dev/null | head -20)
```

## Testing

Manual verification:
1. Queue refresh with mixed labeled/unlabeled issues → both included
2. Queue refresh with only unlabeled issues → queue not empty
3. Priority scoring still ranks `collective-intelligence` (score 10) above unlabeled (score 5)

## Impact

- Prevents planners from exiting with "no work" when unlabeled issues exist
- Maintains vision-aligned priority ordering
- Simplifies code by removing conditional fallback logic

Closes #960