### PR TITLE
fix: add plannerloops to agent RBAC

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "agentex.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["agentex.io", "kro.run"]
-    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -58,7 +58,7 @@ metadata:
     {{- include "agentex.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["agentex.io", "kro.run"]
-    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "resourcegraphdefinitions"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops", "resourcegraphdefinitions"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/rbac/rbac.yaml
+++ b/manifests/rbac/rbac.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: agentex
 rules:
   - apiGroups: ["agentex.io"]
-    resources: ["agents", "tasks", "messages", "thoughts", "swarms"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "plannerloops"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
@@ -53,11 +53,11 @@ metadata:
   name: agentex-agent-cluster-reader
 rules:
   - apiGroups: ["agentex.io"]
-    resources: ["agents", "tasks", "messages", "thoughts", "swarms"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "plannerloops"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["kro.run"]
-    resources: ["resourcegraphdefinitions"]
-    verbs: ["get", "list", "watch"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops", "resourcegraphdefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

Adds `plannerloops` to the agent RBAC permissions in both the Helm chart and the manifest RBAC files.

Closes #971

## Changes

- `chart/templates/rbac.yaml`: Added `plannerloops` to Role and ClusterRole resources lists
- `manifests/rbac/rbac.yaml`: Added `plannerloops` to Role and ClusterRole resources lists
- Also expanded `manifests/rbac/rbac.yaml` ClusterRole to include `kro.run` API group with all agentex resources (matching the chart template), since agents need to interact with kro.run CRs cluster-wide

## Why

Agents (including the planner-loop Deployment) that try to read, create, or update `PlannerLoop` CRs were getting RBAC forbidden errors. The `plannerloops` resource was missing from all RBAC rules despite being a first-class agentex CR kind.