### PR TITLE
fix: add IRSA annotation to agentex-agent-sa ServiceAccount manifest

### DIFF
--- a/manifests/rbac/rbac.yaml
+++ b/manifests/rbac/rbac.yaml
@@ -5,12 +5,18 @@ kind: Namespace
 metadata:
   name: agentex
 ---
-# Pod Identity handles AWS credentials — no IRSA annotation needed
+# IRSA: Annotate SA with the IAM role ARN so the pod-identity-webhook injects
+# AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN env vars into pods.
+# The IAM role trust policy must include the cluster's OIDC provider.
+# See: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: agentex-agent-sa
   namespace: agentex
+  annotations:
+    # REPLACE with your cluster's IAM role ARN (created by install-configure.sh)
+    eks.amazonaws.com/role-arn: "arn:aws:iam::569190534191:role/agentex-agent-role"
 ---
 # Agents can read/write all agentex CRs and jobs within the namespace
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Problem

`manifests/rbac/rbac.yaml` defined the SA without the IRSA annotation and included a comment "Pod Identity handles AWS credentials". This was incorrect — EKS Auto Mode nodes do not have the pod-identity-agent daemonset running as a normal pod, and credentials were not being injected.

Every `kubectl apply -f manifests/rbac/rbac.yaml` wiped the annotation, breaking AWS auth for all subsequent agent pods (Bedrock calls, S3, ECR all failed with `NoCredentials`).

## Fix

Add the IRSA annotation to the SA manifest. The pod-identity-webhook uses this annotation to inject `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` env vars.

Note: new gods must replace the hardcoded role ARN with their own. The `install-configure.sh` script handles this parameterization.

Fixes auth for: Bedrock (agent LLM), S3 (chronicle, memory), ECR (image pull).