### PR TITLE
fix: correct npm CVE upgrade path and remove gnupg (issue #963)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r6 (fix: security CVEs - correct npm dep upgrades + remove gnupg; issue #963)
+# Image version: 2026-03-09-r7 (fix: security CVEs - fix npm CVE patch using clean-dir install; issue #963)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -48,28 +48,34 @@ RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
     && npm cache clean --force
 
 # Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963)
-# npm bundles tar, minimatch, and glob in its own node_modules directory.
+# npm bundles tar and minimatch in its own node_modules directory.
 # HIGH CVEs fixed:
 #   tar 7.5.9 -> 7.5.11 (CVE-2026-29786: prior to 7.5.10 has HIGH severity vulnerability)
 #   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904: 10.2.2 vulnerable)
 #
-# IMPORTANT: Use $(npm root -g) to find npm's actual location dynamically.
-# After 'npm install -g npm@latest', npm is at /usr/local/lib/node_modules/npm,
-# NOT /usr/lib/node_modules/npm (the old location from nodesource install).
-# The previous fix used a hardcoded path that silently failed (2>/dev/null || true)
-# and left vulnerable versions in place.
+# APPROACH: Install patched packages into a clean temp directory (no existing package.json),
+# then copy them over npm's bundled versions.
 #
-# Fix: find the real npm root, then install exact patched versions (not ranges).
-RUN npm install -g npm@latest \
-    && NPM_GLOBAL_ROOT="$(npm root -g)" \
-    && NPM_DIR="${NPM_GLOBAL_ROOT}/npm" \
-    && echo "npm global dir: ${NPM_DIR}" \
-    && cd "${NPM_DIR}" \
-    && npm install --prefer-online --no-save \
-        tar@7.5.11 \
-        minimatch@10.2.3 \
-    && echo "tar version: $(node -e 'console.log(require(\"./node_modules/tar/package.json\").version)')" \
-    && echo "minimatch version: $(node -e 'console.log(require(\"./node_modules/minimatch/package.json\").version)')" \
+# Why NOT use "cd $(npm root -g)/npm && npm install tar minimatch":
+#   npm's own package.json has @npmcli/docs as a devDependency which doesn't exist on
+#   the npm registry (returns 404). Running npm install in npm's directory triggers
+#   resolution of ALL deps including devDeps, causing E404 build failure.
+#
+# The clean-dir approach: install packages in an isolated directory with a minimal
+# package.json — no extra deps, no 404 errors, fully deterministic.
+RUN NPM_DIR="$(npm root -g)/npm" \
+    && echo "Patching npm bundled deps at: ${NPM_DIR}" \
+    && mkdir -p /tmp/npm-patch \
+    && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
+    && cd /tmp/npm-patch \
+    && npm install --save-exact tar@7.5.11 minimatch@10.2.3 \
+    && echo "Installed tar: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/tar/package.json\").version)')" \
+    && echo "Installed minimatch: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/minimatch/package.json\").version)')" \
+    && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
+    && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
+    && echo "npm tar version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/tar/package.json\").version)')" \
+    && echo "npm minimatch version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/minimatch/package.json\").version)')" \
+    && rm -rf /tmp/npm-patch \
     && npm cache clean --force \
     && rm -rf /root/.npm
 


### PR DESCRIPTION
## Summary

Fixes 14 open security scanning alerts (3 HIGH + 11 MEDIUM) identified in issue #963.

## Root Cause Analysis

Two previous fix attempts (PR #973, PR #978 initial) failed because of a chain of errors:

1. **Previous approach (main branch)**: Used hardcoded path `/usr/lib/node_modules/npm` and ran
   `npm install -g npm@latest` before patching. The upgrade silently failed with `2>/dev/null || true`,
   so npm stayed on 10.x (which doesn't have tar 7.x / minimatch 10.x CVEs), and the patch
   never ran on the correct path.

2. **PR #978 initial / PR #973**: Removed `|| true` to expose failures, used dynamic `$(npm root -g)`.
   BUT: running `npm install tar minimatch` inside npm's OWN directory triggers resolution of
   npm's devDependencies including `@npmcli/docs@^1.0.0` which **doesn't exist on npm registry**
   (returns 404). This broke the build.

## Fix

Install patched packages in an **isolated clean temp directory** with a minimal package.json,
then copy them over npm's bundled versions using `cp -r`. This approach:
- Has no extra deps, no 404 errors
- Is fully deterministic (exact versions pinned)
- Works regardless of npm version or directory context
- Doesn't trigger devDependency resolution

## Changes

### 1. Fix npm bundled dependency CVEs (3 HIGH CVEs)
- **tar 7.5.9 → 7.5.11** (CVE-2026-29786)
- **minimatch 10.2.2 → 10.2.3** (CVE-2026-27903, CVE-2026-27904)
- Uses clean temp directory (`/tmp/npm-patch`) with `{"name":"patch","version":"1.0.0"}`
- Installs exact pinned versions with `npm install --save-exact`
- Copies installed packages over npm's bundled versions with `cp -r`
- Build output confirms installed versions before and after patching

### 2. Remove gnupg after nodejs install (11 MEDIUM CVEs)
- gnupg was installed at image build time but **never used at runtime**
- The nodesource setup script needs it temporarily for apt key verification
- We now purge gnupg and all related packages after nodejs is installed
- Eliminates CVEs: CVE-2025-68972 (gnupg, gpg, gpg-agent, gpg-wks-client, gpgconf, gpgsm, gpgv, dirmngr, keyboxd, gnupg-l10n, gnupg-utils)

### 3. Scope note
Ubuntu system package CVEs (libpam, git, libexpat, tar/1.35) have **no upstream fix available yet**.
The `apt-get upgrade` step already applies all available Ubuntu security updates.
The docker/cli CVE in gh binary requires an upstream gh release with updated dependency.

## CVEs Addressed
| Alert # | CVE | Severity | Package | Before | After |
|---------|-----|----------|---------|--------|-------|
| #53 | CVE-2026-29786 | HIGH | tar (npm) | 7.5.9 | 7.5.11 |
| #47 | CVE-2026-27903 | HIGH | minimatch | 10.2.2 | 10.2.3 |
| #48 | CVE-2026-27904 | HIGH | minimatch | 10.2.2 | 10.2.3 |
| #7,9,11,13,15,17,19,21,23,25,27 | CVE-2025-68972 | MEDIUM | gnupg/gpg (11 pkgs) | installed | removed |

Closes #963