### PR TITLE
fix: coordinator task queue replaces closed issues on each refresh

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -271,14 +271,12 @@ refresh_task_queue() {
         local sorted_issues
         sorted_issues=$(printf "%b" "$scored_issues" | sort -t: -k1 -rn | cut -d: -f2 | tr '\n' ',' | sed 's/,$//')
 
-        local current_queue
-        current_queue=$(get_state "taskQueue")
-        # Merge new issues with existing queue (deduplicate, preserve priority order)
-        local merged_queue
-        merged_queue=$(echo "${sorted_issues},${current_queue}" | tr ',' '\n' | grep -v '^$' | awk '!seen[$0]++' | tr '\n' ',' | sed 's/,$//')
-
-        update_state "taskQueue" "$merged_queue"
-        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted): $merged_queue"
+        # Issue #977: Replace queue with fresh open issues from GitHub.
+        # Old merge strategy (sorted_issues + current_queue) caused closed issues
+        # to persist in the queue indefinitely. Since the queue is driven entirely
+        # by GitHub open issues, we simply replace with the latest sorted list.
+        update_state "taskQueue" "$sorted_issues"
+        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted): $sorted_issues"
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes coordinator task queue starvation caused by closed GitHub issues persisting in the queue.

Closes #977

## Problem

The coordinator's `refresh_task_queue()` function merged new open issues with the EXISTING queue contents using a deduplication strategy. This meant closed issues were never removed from the queue. Once an issue number entered `coordinator-state.taskQueue`, it stayed there forever, even after the issue was closed on GitHub.

**Current impact**: Queue contains `968,971` which are both CLOSED — agents picking tasks from the queue would waste time working on resolved issues.

## Fix

Replace the merge-with-old strategy with a simple replacement: each refresh cycle sets the queue to the fresh sorted list of OPEN issues from GitHub. This is correct because:
1. The queue is entirely derived from GitHub open issues
2. There's no value in preserving old queue entries — they represent stale state
3. Priority scoring already handles ordering, so freshness is always correct

## Changes

`images/runner/coordinator.sh`: Remove 4 lines of stale merge logic, replace with direct assignment of `$sorted_issues` to the task queue state.