### PR TITLE
fix: coordinator kubectl_with_timeout stderr mixing causes jq parse errors

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -97,7 +97,11 @@ echo "Coordinator-state initialization complete"
 kubectl_with_timeout() {
   local timeout_secs="${1:-10}"
   shift
-  timeout "${timeout_secs}s" kubectl "$@" 2>&1
+  # Issue #982 (same as #959 in entrypoint.sh): Do NOT use 2>&1 — that mixes
+  # stderr into stdout, corrupting JSON output when callers use
+  # $(kubectl_with_timeout ...) to capture data and pipe to jq.
+  # Stderr is suppressed here; callers that need error context add 2>&1 explicitly.
+  timeout "${timeout_secs}s" kubectl "$@" 2>/dev/null
 }
 
 # Push CloudWatch metric (issue #587: visibility for collective intelligence)
@@ -280,7 +284,11 @@ refresh_task_queue() {
     fi
 }
 
-# Check for stale assignments and return them to queue
+# Check for stale assignments and remove them (do NOT re-queue)
+# Issue #982 fix: Previously this returned stale issue numbers to the queue, causing
+# closed issues to re-accumulate even after refresh_task_queue() replaced the queue.
+# The fix: simply remove stale assignments. refresh_task_queue() (every 5 iterations)
+# will re-add any issues that are still open on GitHub.
 cleanup_stale_assignments() {
     local assignments
     assignments=$(get_state "activeAssignments")
@@ -305,14 +313,7 @@ cleanup_stale_assignments() {
                 && cleaned_assignments="${cleaned_assignments},${pair}" \
                 || cleaned_assignments="$pair"
         else
-            echo "[$(date -u +%H:%M:%S)] Stale: $agent_name → issue #$issue, returning to queue"
-            local current_queue
-            current_queue=$(get_state "taskQueue")
-            if [ -z "$current_queue" ]; then
-                update_state "taskQueue" "$issue"
-            else
-                update_state "taskQueue" "${current_queue},${issue}"
-            fi
+            echo "[$(date -u +%H:%M:%S)] Stale: $agent_name → issue #$issue, releasing assignment (NOT re-queuing; refresh_task_queue handles re-population)"
             stale_count=$((stale_count + 1))
         fi
     done


### PR DESCRIPTION
## Summary

Two related fixes to coordinator.sh that prevent jq parse errors and closed-issue re-queuing.

## Problem 1: kubectl_with_timeout uses 2>&1 (jq parse errors)

coordinator.sh had `kubectl "$@" 2>&1` which mixed kubectl stderr into stdout. Any code using `$(kubectl_with_timeout ...) | jq` received both JSON AND error messages, causing:

```
jq: parse error: Invalid numeric literal at line 1, column 6
```

This appeared in coordinator logs every ~30 seconds during spawn slot reconciliation and vote tallying.

The same bug was fixed in entrypoint.sh as issue #959 but coordinator.sh was NOT updated.

## Problem 2: cleanup_stale_assignments re-queues closed issues

When `cleanup_stale_assignments()` detected a stale job, it added the issue number back to the task queue unconditionally — even if the issue was closed on GitHub. This caused closed issues to re-appear in the queue every ~30s (overriding the `refresh_task_queue()` fix from issue #977).

Evidence: coordinator state showed `968,968,968,968,968` (closed issue #968 queued five times).

## Fix

1. Changed `kubectl "$@" 2>&1` → `kubectl "$@" 2>/dev/null` in `kubectl_with_timeout()`
2. Removed the re-queue logic from `cleanup_stale_assignments()`. The `refresh_task_queue()` function (every 5 iterations, ~2.5 min) already re-populates the queue from GitHub open issues.

## Note for God

The live `coordinator-script` ConfigMap needs to be manually patched to apply the fix to the running coordinator, since this ConfigMap is not managed by the CI/CD pipeline. The Docker image will be updated on merge.

Closes #982