### PR TITLE
fix: Dockerfile npm patch quoting crash (issue #963)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r7 (fix: security CVEs - fix npm CVE patch using clean-dir install; issue #963)
+# Image version: 2026-03-09-r8 (fix: Dockerfile npm patch quoting crash; issue #963)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -50,31 +50,17 @@ RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
 # Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963)
 # npm bundles tar and minimatch in its own node_modules directory.
 # HIGH CVEs fixed:
-#   tar 7.5.9 -> 7.5.11 (CVE-2026-29786: prior to 7.5.10 has HIGH severity vulnerability)
-#   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904: 10.2.2 vulnerable)
+#   tar 7.5.9 -> 7.5.11 (CVE-2026-29786)
+#   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904)
 #
-# APPROACH: Install patched packages into a clean temp directory (no existing package.json),
+# Install patched packages in an isolated temp dir (avoids npm's @npmcli/docs 404 issue),
 # then copy them over npm's bundled versions.
-#
-# Why NOT use "cd $(npm root -g)/npm && npm install tar minimatch":
-#   npm's own package.json has @npmcli/docs as a devDependency which doesn't exist on
-#   the npm registry (returns 404). Running npm install in npm's directory triggers
-#   resolution of ALL deps including devDeps, causing E404 build failure.
-#
-# The clean-dir approach: install packages in an isolated directory with a minimal
-# package.json — no extra deps, no 404 errors, fully deterministic.
-RUN NPM_DIR="$(npm root -g)/npm" \
-    && echo "Patching npm bundled deps at: ${NPM_DIR}" \
-    && mkdir -p /tmp/npm-patch \
+RUN mkdir -p /tmp/npm-patch \
     && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
-    && cd /tmp/npm-patch \
-    && npm install --save-exact tar@7.5.11 minimatch@10.2.3 \
-    && echo "Installed tar: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/tar/package.json\").version)')" \
-    && echo "Installed minimatch: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/minimatch/package.json\").version)')" \
+    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 \
+    && NPM_DIR="$(npm root -g)/npm" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
-    && echo "npm tar version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/tar/package.json\").version)')" \
-    && echo "npm minimatch version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/minimatch/package.json\").version)')" \
     && rm -rf /tmp/npm-patch \
     && npm cache clean --force \
     && rm -rf /root/.npm


### PR DESCRIPTION
## Summary

- Fixes the Docker build failure introduced in PR #978
- The `node -e` verification commands had shell quoting issues inside the Docker `RUN` context
- Simplifies the npm patch approach using `--prefix` flag instead of `cd`

## Root Cause

The previous code used:
```dockerfile
RUN NPM_DIR="$(npm root -g)/npm" \
    && cd /tmp/npm-patch \
    && npm install ... \
    && echo "... $(node -e 'console.log(require("'${NPM_DIR}'/node_modules/tar/package.json").version)')" \
```

The `${NPM_DIR}` variable is expanded OUTSIDE the single quotes, breaking the quoting context for the `node -e` argument. This caused:
- `SyntaxError: Invalid or unexpected token`
- `Error: ENOENT: no such file or directory, uv_cwd`

## Fix

Use `npm install --prefix /tmp/npm-patch` (no `cd` needed) and remove the verification `echo` lines (the `cp -r` operations are deterministic and don't need runtime verification):

```dockerfile
RUN mkdir -p /tmp/npm-patch \
    && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 \
    && NPM_DIR="$(npm root -g)/npm" \
    && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
    && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
    && rm -rf /tmp/npm-patch \
    && npm cache clean --force \
    && rm -rf /root/.npm
```

Closes #963