### PR TITLE
fix: fix ENOENT cwd error in npm CVE patch (issue #963 follow-up)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r7 (fix: security CVEs - fix npm CVE patch using clean-dir install; issue #963)
+# Image version: 2026-03-09-r8 (fix: fix ENOENT cwd error in npm CVE patch; issue #963)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -69,15 +69,11 @@ RUN NPM_DIR="$(npm root -g)/npm" \
     && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
     && cd /tmp/npm-patch \
     && npm install --save-exact tar@7.5.11 minimatch@10.2.3 \
-    && echo "Installed tar: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/tar/package.json\").version)')" \
-    && echo "Installed minimatch: $(node -e 'console.log(require(\"/tmp/npm-patch/node_modules/minimatch/package.json\").version)')" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
-    && echo "npm tar version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/tar/package.json\").version)')" \
-    && echo "npm minimatch version after patch: $(node -e 'console.log(require(\"'${NPM_DIR}'/node_modules/minimatch/package.json\").version)')" \
-    && rm -rf /tmp/npm-patch \
+    && cd / \
     && npm cache clean --force \
-    && rm -rf /root/.npm
+    && rm -rf /tmp/npm-patch /root/.npm
 
 # ubuntu:24.04 ships with user/group "ubuntu" at UID/GID 1000.
 # Rename it to "agentex" and set up the home directory.


### PR DESCRIPTION
## Summary

Follow-up fix for PR #978 which broke the main branch Docker image build.

## Root Cause

PR #978 introduced a build error:
- `cd /tmp/npm-patch` then `rm -rf /tmp/npm-patch` then `npm cache clean --force`
- After deleting the working directory, running npm fails with `ENOENT: uv_cwd` (exit code 7)
- npm cannot determine the current directory because it was just deleted

Also removed post-copy echo verification lines that have quoting issues with `${NPM_DIR}` variable expansion inside node -e single-quoted strings.

## Changes

- Add `cd /` before `npm cache clean --force` to change out of the temp directory before deletion
- Move `rm -rf /tmp/npm-patch` to AFTER npm cache clean completes
- Remove the post-copy echo lines (quoting issues, not needed for correctness)
- Update image version to r8

## Verification

The main branch image build was failing at step 8/18 with:
```
#13 ERROR: process did not complete successfully: exit code: 7
ENOENT syscall: uv_cwd
```

This fix resolves that error by ensuring npm cache clean runs from a valid directory.

Closes #963