### PR TITLE
fix: patch nested tar CVEs in cacache/node-gyp and fix glob CVE (issue #989)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r8 (fix: Dockerfile npm patch quoting crash; issue #963)
+# Image version: 2026-03-10-r9 (fix: patch nested tar CVEs in cacache/node-gyp + glob; issue #989)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -47,21 +47,30 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
     && npm cache clean --force
 
-# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963)
-# npm bundles tar and minimatch in its own node_modules directory.
+# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963, issue #989)
+# npm bundles tar, minimatch, and glob in its own node_modules directory.
+# Additionally, cacache and node-gyp bundle their own nested copies of tar.
+#
 # HIGH CVEs fixed:
-#   tar 7.5.9 -> 7.5.11 (CVE-2026-29786)
+#   tar 7.4.3 -> 7.5.11 (CVE-2026-29786, CVE-2026-26960, CVE-2026-24842, CVE-2026-23950, CVE-2026-23745)
+#     - Fixed in top-level npm/node_modules/tar/ (was already patched in r8)
+#     - Fixed in npm/node_modules/cacache/node_modules/tar/ (nested, NEW in r9)
+#     - Fixed in npm/node_modules/node-gyp/node_modules/tar/ (nested, NEW in r9)
+#   glob 10.4.5 -> 10.5.0 (CVE-2025-64756) (NEW in r9)
 #   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904)
 #
 # Install patched packages in an isolated temp dir (avoids npm's @npmcli/docs 404 issue),
-# then copy them over npm's bundled versions.
+# then copy them over npm's bundled versions (including all nested copies).
 RUN mkdir -p /tmp/npm-patch \
     && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
-    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 \
+    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 glob@10.5.0 \
     && NPM_DIR="$(npm root -g)/npm" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
-    && rm -rf /tmp/npm-patch \
+    && cp -r /tmp/npm-patch/node_modules/glob/. "${NPM_DIR}/node_modules/glob/" \
+    && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/cacache/node_modules/tar/" \
+    && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/node-gyp/node_modules/tar/" \
+    && cd / && rm -rf /tmp/npm-patch \
     && npm cache clean --force \
     && rm -rf /root/.npm
 


### PR DESCRIPTION
## Summary

The previous npm CVE patch (r8) only fixed `tar` in the top-level `npm/node_modules/tar/` but missed two nested copies that npm uses internally:

- `npm/node_modules/cacache/node_modules/tar/` (was: tar@7.4.3)
- `npm/node_modules/node-gyp/node_modules/tar/` (was: tar@7.4.3)

These nested copies contained **10 high-severity CVEs** that were still being detected by code scanning.

## Changes

- Patch `cacache/node_modules/tar/` with tar@7.5.11 (fixes 5 HIGH CVEs)
- Patch `node-gyp/node_modules/tar/` with tar@7.5.11 (fixes 5 HIGH CVEs)  
- Add `glob@10.5.0` patch to fix CVE-2025-64756 (HIGH, glob@10.4.5 → 10.5.0)
- Update image version to r9

## CVEs Fixed

| Package | Location | Old | New | CVEs |
|---------|----------|-----|-----|------|
| tar | npm/node_modules/cacache/node_modules/ | 7.4.3 | 7.5.11 | CVE-2026-29786, CVE-2026-26960, CVE-2026-24842, CVE-2026-23950, CVE-2026-23745 |
| tar | npm/node_modules/node-gyp/node_modules/ | 7.4.3 | 7.5.11 | CVE-2026-29786, CVE-2026-26960, CVE-2026-24842, CVE-2026-23950, CVE-2026-23745 |
| glob | npm/node_modules/ | 10.4.5 | 10.5.0 | CVE-2025-64756 |

## Root Cause

npm v7+ supports nested `node_modules/` within its own bundled dependencies. The `cacache` and `node-gyp` packages both vendor their own `tar` copy. When we patched the top-level tar, these nested copies were untouched.

Closes #989