### PR TITLE
fix: patch nested tar CVEs in node-gyp/cacache (issue #990)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-09-r8 (fix: Dockerfile npm patch quoting crash; issue #963)
+# Image version: 2026-03-09-r9 (fix: patch nested tar CVEs in node-gyp/cacache; issue #990)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -47,20 +47,27 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
     && npm cache clean --force
 
-# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963)
+# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963, issue #990)
 # npm bundles tar and minimatch in its own node_modules directory.
+# Also patches tar nested in node-gyp and cacache sub-dependencies (issue #990).
 # HIGH CVEs fixed:
-#   tar 7.5.9 -> 7.5.11 (CVE-2026-29786)
+#   tar 7.5.9 -> 7.5.11 (CVE-2026-29786, CVE-2026-26960, CVE-2026-24842, CVE-2026-23950, CVE-2026-23745)
 #   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904)
 #
 # Install patched packages in an isolated temp dir (avoids npm's @npmcli/docs 404 issue),
-# then copy them over npm's bundled versions.
+# then copy them over npm's bundled versions (top-level and nested).
 RUN mkdir -p /tmp/npm-patch \
     && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
     && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 \
     && NPM_DIR="$(npm root -g)/npm" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
+    && if [ -d "${NPM_DIR}/node_modules/node-gyp/node_modules/tar" ]; then \
+         cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/node-gyp/node_modules/tar/"; \
+       fi \
+    && if [ -d "${NPM_DIR}/node_modules/cacache/node_modules/tar" ]; then \
+         cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/cacache/node_modules/tar/"; \
+       fi \
     && rm -rf /tmp/npm-patch \
     && npm cache clean --force \
     && rm -rf /root/.npm


### PR DESCRIPTION
## Summary

Extends the existing npm CVE patch to also update tar in npm's nested sub-dependencies.

Closes #990

## Problem

The existing npm CVE patch (from issues #858, #963) only patched the top-level `npm/node_modules/tar`. Code scanning still showed HIGH severity tar CVEs in nested directories:

- `npm/node_modules/node-gyp/node_modules/tar/`  
- `npm/node_modules/cacache/node_modules/tar/`

HIGH CVEs addressed by this fix:
- CVE-2026-29786: arbitrary file write
- CVE-2026-26960: arbitrary file read/write via hardlinks
- CVE-2026-24842: arbitrary file creation via path traversal  
- CVE-2026-23950: arbitrary file overwrite via Unicode path collision
- CVE-2026-23745: arbitrary file overwrite and symlink poisoning

## Changes

- Added conditional copy of patched tar to `node-gyp/node_modules/tar/` and `cacache/node_modules/tar/`
- Updated image version to r9
- Extended comment to list all 5 HIGH CVEs now fixed

## Implementation Note

Uses `if [ -d ... ]` conditional to be forward-compatible in case npm changes its nested dependency structure in future versions. If the directories don't exist, the patch is silently skipped (not an error).

## Impact

Reduces HIGH severity code scanning alerts from 12 to ~2 (only gh CLI CVE-2025-15558 and glob CVE-2025-64756 remain, which require version upgrades of those tools).