### PR TITLE
fix: remove 2>&1 from kubectl_with_timeout in planner-loop.sh (issue #992)

### DIFF
--- a/images/runner/planner-loop.sh
+++ b/images/runner/planner-loop.sh
@@ -39,7 +39,11 @@ fi
 kubectl_with_timeout() {
   local timeout_secs="${1:-10}"
   shift
-  timeout "${timeout_secs}s" kubectl "$@" 2>&1
+  # Issue #992 (same as #982 in coordinator.sh and #959 in entrypoint.sh): Do NOT use 2>&1 —
+  # that mixes stderr into stdout, corrupting JSON output when callers use
+  # $(kubectl_with_timeout ...) to capture data and pipe to jq.
+  # Stderr is suppressed here; callers that need error context add 2>&1 explicitly.
+  timeout "${timeout_secs}s" kubectl "$@" 2>/dev/null
 }
 
 push_metric() {


### PR DESCRIPTION
## Summary

Fixes the same \`2>&1\` bug that was patched in coordinator.sh (issue #982) and entrypoint.sh (issue #959), but this time in planner-loop.sh.

## Root Cause

\`planner-loop.sh\` defines \`kubectl_with_timeout()\` with \`2>&1\`:

\`\`\`bash
kubectl_with_timeout() {
  local timeout_secs="${1:-10}"
  shift
  timeout "${timeout_secs}s" kubectl "$@" 2>&1  # ← BUG
}
\`\`\`

When kubectl fails or produces warnings, the error output gets mixed into stdout. Any caller that captures the result with \`\$(kubectl_with_timeout ...)\` and pipes to \`jq\` will fail with JSON parse errors.

## Fix

Changed \`2>&1\` to \`2>/dev/null\` to match the pattern used in coordinator.sh (fixed in #982).

## Impact

This fix prevents planner-loop from malfunctioning when:
- Checking planner status (circuit breaker state)
- Reading constitution ConfigMap values
- Checking kill switch status

Fixes #992