### PR TITLE
fix: patch diff CVE-2026-24001 in npm bundled deps (issue #1000)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-10-r9 (fix: nested tar CVEs in node-gyp/cacache + glob CVE; issue #988)
+# Image version: 2026-03-10-r10 (fix: diff CVE-2026-24001 + dismiss Windows-only CVE-2025-15558; issue #1000)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest
@@ -47,7 +47,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
     && npm cache clean --force
 
-# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963, issue #988)
+# Fix npm bundled dependency CVEs (issue #858, issue #658, issue #963, issue #988, issue #1000)
 # npm bundles tar and minimatch in its own node_modules directory.
 # node-gyp and cacache also have their own nested tar copies (issue #988).
 # HIGH CVEs fixed:
@@ -59,18 +59,21 @@ RUN npm install -g opencode-ai@${OPENCODE_VERSION} \
 #   minimatch 10.2.2 -> 10.2.3 (CVE-2026-27903, CVE-2026-27904)
 #   glob 10.4.5 -> 10.5.0 (CVE-2025-64756 command injection via malicious filenames)
 #     - Patched in: npm/node_modules/glob
+#   diff 5.2.0 -> 5.2.2 (CVE-2026-24001 regular expression denial of service)
+#     - Patched in: npm/node_modules/diff
 #
 # Install patched packages in an isolated temp dir (avoids npm's @npmcli/docs 404 issue),
 # then copy them over npm's bundled versions.
 RUN mkdir -p /tmp/npm-patch \
     && echo '{"name":"patch","version":"1.0.0"}' > /tmp/npm-patch/package.json \
-    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 glob@10.5.0 \
+    && npm install --prefix /tmp/npm-patch --save-exact tar@7.5.11 minimatch@10.2.3 glob@10.5.0 diff@5.2.2 \
     && NPM_DIR="$(npm root -g)/npm" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/node-gyp/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/tar/. "${NPM_DIR}/node_modules/cacache/node_modules/tar/" \
     && cp -r /tmp/npm-patch/node_modules/minimatch/. "${NPM_DIR}/node_modules/minimatch/" \
     && cp -r /tmp/npm-patch/node_modules/glob/. "${NPM_DIR}/node_modules/glob/" \
+    && cp -r /tmp/npm-patch/node_modules/diff/. "${NPM_DIR}/node_modules/diff/" \
     && rm -rf /tmp/npm-patch \
     && npm cache clean --force \
     && rm -rf /root/.npm


### PR DESCRIPTION
## Summary

Addresses security scanning alert issue #1000 (49 open code scanning alerts).

### Fixed
- **CVE-2026-24001** (LOW): Patched npm bundled `diff` package from 5.2.0 → 5.2.2 (ReDoS vulnerability)

### Dismissed (not applicable)
- **CVE-2025-15558** (HIGH): `docker/cli` in `gh` binary — Windows-only privilege escalation via `C:\ProgramData\Docker\cli-plugins`. This container runs exclusively on Linux. Dismissed via GitHub code scanning API with explanation.

### Cannot be fixed (documented for future reference)
- **gnupg/gpg CVEs** (CVE-2022-3219, CVE-2025-68972): No upstream fix available in Ubuntu 24.04 packages. These packages are already purged in the Dockerfile but some survive via gpgv as a base system dependency.
- **Go stdlib CVEs** (CVE-2026-25679, CVE-2026-27139, CVE-2026-27142): `gh` and `kubectl` binaries compiled with Go 1.25.7, fixed in 1.25.8+. Need upstream binary releases.
- **OS package CVEs** (coreutils, curl, libpam, git, etc.): No fixed version available in Ubuntu 24.04 at time of writing.

## Changes
- `images/runner/Dockerfile`: Add `diff@5.2.2` to npm patch step
- Updated image version comment to r10

Closes #1000