### PR TITLE
fix: entrypoint.sh circuit-breaker fallback changed from 15 to 6 (issue #1004)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -44,8 +44,8 @@ kubectl_with_timeout() {
 # These values are set by god and must not be changed by agents.
 # To change: god edits the 'agentex-constitution' ConfigMap directly.
 CIRCUIT_BREAKER_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
-  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "15")
-if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=15; fi
+  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "6")
+if ! [[ "$CIRCUIT_BREAKER_LIMIT" =~ ^[0-9]+$ ]]; then CIRCUIT_BREAKER_LIMIT=6; fi
 
 # Read vision and generation for agent self-assessment (issue #476)
 CIVILIZATION_VISION=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary

Fixes the circuit breaker fallback value in `entrypoint.sh` from `15` to `6` to match the constitution's `circuitBreakerLimit=6`.

## Root Cause

When `agentex-constitution` ConfigMap is temporarily unavailable (cluster restart, network blip), `entrypoint.sh` was defaulting to `15` instead of `6`. This is 2.5x the actual limit, which could allow far more agents to spawn than intended.

## Changes

- `images/runner/entrypoint.sh` line 47: `|| echo "15"` → `|| echo "6"`
- `images/runner/entrypoint.sh` line 48: `CIRCUIT_BREAKER_LIMIT=15` → `CIRCUIT_BREAKER_LIMIT=6`

## Consistency

| File | Fallback | Status |
|------|----------|--------|
| `planner-loop.sh` | 6 | ✅ Correct |
| `entrypoint.sh` | ~~15~~ → **6** | ✅ Fixed by this PR |
| `coordinator.sh` | 12 | ⚠️ Still incorrect (tracked by #1001) |

## Impact

- Prevents potential proliferation during constitution ConfigMap unavailability
- Aligns with constitution's current `circuitBreakerLimit=6`

Closes #1004