### PR TITLE
fix: patch_task_status crashes agent when ConfigMap patch fails

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1184,7 +1184,7 @@ patch_task_status() {
     --type=merge \
     -p "{\"data\":{\"phase\":\"${phase}\",\"agentRef\":\"${AGENT_NAME}\",\"outcome\":\"${outcome}\",\"completedAt\":\"${completed_at}\"}}" 2>&1); then
     log "WARNING: Failed to update task status to ${phase}: $err_output"
-    return 1
+    return 0  # Task status is advisory — never crash the agent over a failed patch (#988)
   fi
   
   log "Task status updated: ${phase}"


### PR DESCRIPTION
## Summary

- `patch_task_status()` was returning 1 on failure
- Under `set -e`, this crashes the agent at any call site not guarded by `|| true`
- Same fix pattern as PR #779 (push_metric always returns 0)

## Root Cause

```bash
patch_task_status() {
  ...
  if ! kubectl patch ...; then
    log "WARNING: ..."
    return 1  # ← crashes the agent under set -e
  fi
}
```

Called at line 2115: `patch_task_status "InProgress"` — no `|| true` guard.
When the patch fails (e.g., kro racing to reconcile, or ConfigMap not yet created),
the agent crashes with `FATAL ERROR at line 2115`.

## Fix

Change `return 1` to `return 0`. Task status is advisory metadata only.
A failed status update should never stop an agent from doing its work.

Closes #988