### PR TITLE
fix: apply single-planner constraint in handle_fatal_error emergency spawn (issue #1013)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-# Image version: 2026-03-10-r10 (fix: diff CVE-2026-24001 + dismiss Windows-only CVE-2025-15558; issue #1000)
+# Image version: 2026-03-10-r11 (fix: emergency spawn single-planner constraint; issue #1013)
 ARG KUBECTL_VERSION=1.35.2
 ARG GH_VERSION=2.87.3
 ARG OPENCODE_VERSION=latest

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -203,7 +203,23 @@ handle_fatal_error() {
       fi
       
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Spawn slot granted. Attempting emergency spawn..." >&2
-      local next_agent="${AGENT_ROLE}-$(date +%s)"
+
+      # Issue #1013: Apply single-planner constraint in emergency spawn path.
+      # PR #949 fixed this in the regular exit path but missed handle_fatal_error.
+      # When a planner crashes, the ERR trap must NOT spawn another planner if one
+      # is already active — planner-loop handles planner perpetuation.
+      local emergency_role="${AGENT_ROLE}"
+      if [ "${AGENT_ROLE}" = "planner" ]; then
+        local active_planners_count
+        active_planners_count=$(kubectl_with_timeout 10 get jobs -n "${NAMESPACE}" -o json 2>/dev/null | \
+          jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0) | select(.metadata.name | test("planner"))] | length' 2>/dev/null || echo "0")
+        if [ "${active_planners_count}" -gt 0 ]; then
+          echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Single-planner constraint: ${active_planners_count} planner(s) already active. Spawning worker instead." >&2
+          emergency_role="worker"
+        fi
+      fi
+
+      local next_agent="${emergency_role}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       
       # Calculate next generation (issue #431: was hardcoded to "1")
@@ -223,7 +239,7 @@ metadata:
 spec:
   title: "Emergency continuation after ${AGENT_NAME} fatal error"
   description: "Previous agent died at line $line_num with exit code $exit_code. Continue platform improvement."
-  role: ${AGENT_ROLE}
+  role: ${emergency_role}
   effort: M
   priority: 10
 EOF
@@ -239,7 +255,7 @@ metadata:
     agentex/emergency-spawn: "true"
     agentex/generation: "${next_generation}"
 spec:
-  role: ${AGENT_ROLE}
+  role: ${emergency_role}
   taskRef: $next_task
   model: ${BEDROCK_MODEL}
 EOF


### PR DESCRIPTION
## Summary

- `handle_fatal_error()` ERR trap spawned new agents using `${AGENT_ROLE}` directly, bypassing the single-planner constraint
- When a planner crashed, the ERR trap spawned another planner without checking if one already exists
- This caused 3+ simultaneous planners (observed: planner-1773102578, planner-1773102861, planner-1773102870) despite PR #949

## Root Cause

PR #949 fixed the single-planner constraint in two places:
1. ✅ Step 12 emergency perpetuation (worker → planner: checks `ACTIVE_PLANNERS_COUNT`)
2. ✅ Regular role cycling (worker → planner: same check)

But missed:
3. ❌ **`handle_fatal_error()` ERR trap** (line ~206): used `${AGENT_ROLE}` directly

## Fix

In `handle_fatal_error()`, apply the same single-planner check before assigning the emergency role:

```bash
# Issue #1013: Apply single-planner constraint in emergency spawn path.
local emergency_role="${AGENT_ROLE}"
if [ "${AGENT_ROLE}" = "planner" ]; then
  local active_planners_count
  active_planners_count=$(kubectl get jobs ... | jq '...planners...')
  if [ "${active_planners_count}" -gt 0 ]; then
    emergency_role="worker"  # planner-loop handles perpetuation
  fi
fi
local next_agent="${emergency_role}-$(date +%s)"
```

Also updates `role:` field in both Task CR and Agent CR specs to use `${emergency_role}`.

Closes #1013