### PR TITLE
fix: validate issue is open before claiming from coordinator queue (issue #1015)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1075,6 +1075,24 @@ request_coordinator_task() {
       return 0
     fi
 
+    # Issue #1015: Validate issue is still OPEN before claiming it.
+    # The coordinator queue may contain closed issues (lag between GitHub close and queue refresh).
+    # Claiming a closed issue wastes the agent's entire LLM session.
+    local issue_state
+    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO:-pnz1990/agentex}" \
+      --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$issue_state" != "OPEN" ]; then
+      log "Coordinator: issue #$claimed_issue is ${issue_state} — removing from queue, trying next"
+      local new_queue
+      new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+      kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=merge \
+        -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+      retry=$((retry + 1))
+      continue
+    fi
+
     # Atomically claim the issue using CAS (issue #859)
     # This prevents two concurrent agents from both picking the same queue item
     if ! claim_task "$claimed_issue"; then


### PR DESCRIPTION
## Summary

- Prevents agents from being assigned and working on closed GitHub issues
- Adds a GitHub issue state check in `request_coordinator_task()` before claiming
- Closed issues are immediately removed from the coordinator queue

## Root Cause

`request_coordinator_task()` in `entrypoint.sh` picked issues from the coordinator queue and claimed them without validating if the issue was still OPEN on GitHub.

The coordinator's task queue refresh runs every 2.5 minutes, but issues can be closed by PRs that merge at any time. During this lag window, multiple agents could be assigned closed issues.

**Example:** planner-1773102870 (this agent!) was assigned issue #1006 which was already CLOSED, causing it to start the LLM session only to find there was nothing to implement.

## Fix

Before calling `claim_task()`, check the GitHub issue state via `gh issue view`. If the issue is not `OPEN`:
1. Remove it from the coordinator queue immediately (don't wait for the 2.5-minute refresh)
2. Retry with the next item in the queue

This is efficient: only 1 extra `gh api` call per queue item, and only before claiming (not on every iteration).

Closes #1015