### PR TITLE
fix: increase cleanup_old_thoughts timeout from 10s to 90s (issue #1020)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r11 (fix: multi-stage build to eliminate gnupg CVEs; issue #1009)
+# Image version: 2026-03-10-r12 (fix: cleanup_old_thoughts 90s timeout, issue #1020)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -619,6 +619,10 @@ query_thoughts() {
 
 # cleanup_old_thoughts() - Delete thoughts older than 24 hours to prevent clutter
 # Should be called periodically by planners
+# Issue #1020: With 6000+ Thought CRs, listing takes 10+ seconds (25MB response).
+# The old 10s timeout caused silent failures — old thoughts were never deleted.
+# Fix: use 90s timeout for listing (list is slow but deletion per-item is fast).
+# Also cap deletions at 50 per run to bound execution time.
 cleanup_old_thoughts() {
   local cutoff_time=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
   
@@ -627,7 +631,10 @@ cleanup_old_thoughts() {
     return 0
   fi
   
-  local old_thoughts=$(kubectl_with_timeout 10 get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
+  # Issue #1020: Use 90s timeout — listing 6000+ CRs returns ~25MB and takes 10+ seconds.
+  # The previous 10s kubectl_with_timeout silently failed, leaving 100+ old thoughts undeleted.
+  local old_thoughts
+  old_thoughts=$(kubectl_with_timeout 90 get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null | \
     jq -r --arg cutoff "$cutoff_time" \
     '.items[] | select(.metadata.creationTimestamp < $cutoff) | .metadata.name' 2>/dev/null || true)
   
@@ -636,8 +643,14 @@ cleanup_old_thoughts() {
     return 0
   fi
   
+  # Cap deletions at 50 per planner run to bound execution time
+  local max_deletions=50
   local count=0
   for thought_name in $old_thoughts; do
+    if [ $count -ge $max_deletions ]; then
+      log "Reached max deletions ($max_deletions) for this run — remaining old thoughts will be cleaned next run"
+      break
+    fi
     if kubectl_with_timeout 10 delete thought.kro.run "$thought_name" -n "$NAMESPACE" 2>/dev/null; then
       count=$((count + 1))
     fi


### PR DESCRIPTION
## Summary

`cleanup_old_thoughts()` in `entrypoint.sh` used a 10-second kubectl timeout to list ALL Thought CRs. With 6000+ CRs accumulating, the list takes 10+ seconds (returning ~25MB of JSON). The timeout fires silently and the cleanup logs \"No old thoughts to clean up\" — even when 100+ thoughts are older than 24 hours.

## Root Cause

```bash
# BEFORE: 10s timeout is insufficient for 6000+ CRs (takes 10.4s in practice)
local old_thoughts=$(kubectl_with_timeout 10 get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null | ...
```

Evidence:
```
time kubectl get thoughts.kro.run -n agentex -o json | jq '.items | length'
# => 5944 (real: 10.437s — EXCEEDS 10s timeout, returns empty)
```

Result: 116+ thoughts older than 24 hours not being cleaned up, accelerating the OOM problem.

## Fix

1. Increase listing timeout from 10s to 90s
2. Cap deletions at 50 per planner run to bound execution time

```bash
# AFTER: 90s timeout handles large namespaces; 50-deletion cap prevents long runs
old_thoughts=$(kubectl_with_timeout 90 get thoughts.kro.run ... )
local max_deletions=50
```

## Impact

- Allows planners to actually clean up old thoughts
- Reduces thought ConfigMap accumulation (coordinator OOM mitigation)
- Bounded: max 50 deletions per run × per-planner frequency

## Protected Files

This PR touches `images/runner/entrypoint.sh` (protected file). Constitution alignment:
- ✅ Fixes a bug without changing behavior (cleanup still deletes old thoughts, just works now)
- ✅ Does not expand agent autonomy or bypass safety mechanisms
- ✅ Adds robustness/stability improvement

Closes #1020