### PR TITLE
fix: validate issue is open before claiming from coordinator queue (issue #1015)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r11 (fix: multi-stage build to eliminate gnupg CVEs; issue #1009)
+# Image version: 2026-03-10-r12 (fix: validate issue open before claiming from coordinator queue; issue #1015)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1092,6 +1092,26 @@ request_coordinator_task() {
       continue
     fi
 
+    # Issue #1015: Validate issue is still open on GitHub before proceeding.
+    # The coordinator queue may lag behind actual issue closures, causing agents to
+    # waste entire LLM sessions on already-closed work.
+    local issue_state
+    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+    if [ "$issue_state" != "OPEN" ]; then
+      log "Coordinator: issue #$claimed_issue is $issue_state — skipping closed issue and removing from queue"
+      # Release the claim we just made
+      release_coordinator_task "$claimed_issue"
+      # Also remove from queue so it doesn't come back
+      local new_queue
+      new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+      kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=merge \
+        -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+      retry=$((retry + 1))
+      continue
+    fi
+
     # Remove claimed issue from the queue
     # Use grep -v || true: when queue has only this issue, grep -v returns exit code 1 (no matches),
     # which would crash the script under set -euo pipefail (issue #979)


### PR DESCRIPTION
## Summary

- `request_coordinator_task()` claimed issues from the coordinator queue without verifying they were still open on GitHub
- Agents were assigned closed issues (#1000, #1001, #1004 etc.) and wasted entire LLM sessions doing nothing useful
- Added GitHub API check after `claim_task()` to validate issue state before proceeding

## Root Cause

The coordinator queue refresh runs every ~2.5 minutes, but issues can be closed between refresh cycles. Previously, after claiming an issue, there was no validation that the issue was still open.

## Fix

After `claim_task()` succeeds, check the issue state via `gh issue view`:
1. If `state != OPEN`: release the claim, remove from queue, retry with next item  
2. If `state == OPEN`: proceed as before

This is a graceful retry loop (max 3 retries), so agents naturally skip closed issues and proceed to open ones.

## Impact

- Agents no longer waste full sessions on closed issues
- Queue self-cleans: closed issues are removed during claim validation
- S-effort fix (< 30 minutes implementation)

Closes #1015