### PR TITLE
fix: single-planner constraint in handle_fatal_error ERR trap

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -203,7 +203,22 @@ handle_fatal_error() {
       fi
       
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Spawn slot granted. Attempting emergency spawn..." >&2
-      local next_agent="${AGENT_ROLE}-$(date +%s)"
+      
+      # Issue #1013: Apply single-planner constraint — same check as step 12 emergency perpetuation
+      # If this agent is a planner and another planner is already active, spawn a worker instead.
+      # planner-loop handles planner perpetuation; emergency spawn must not create duplicate planners.
+      local emergency_role="${AGENT_ROLE}"
+      if [ "${AGENT_ROLE}" = "planner" ]; then
+        local active_planners
+        active_planners=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+          jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0) | select(.metadata.name | test("planner"))] | length' 2>/dev/null || echo "0")
+        if [ "$active_planners" -gt 0 ]; then
+          echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] Single-planner constraint: $active_planners planner(s) active. Emergency spawn will be worker instead." >&2
+          emergency_role="worker"
+        fi
+      fi
+      
+      local next_agent="${emergency_role}-$(date +%s)"
       local next_task="task-emergency-$(date +%s)"
       
       # Calculate next generation (issue #431: was hardcoded to "1")
@@ -223,7 +238,7 @@ metadata:
 spec:
   title: "Emergency continuation after ${AGENT_NAME} fatal error"
   description: "Previous agent died at line $line_num with exit code $exit_code. Continue platform improvement."
-  role: ${AGENT_ROLE}
+  role: ${emergency_role}
   effort: M
   priority: 10
 EOF
@@ -239,7 +254,7 @@ metadata:
     agentex/emergency-spawn: "true"
     agentex/generation: "${next_generation}"
 spec:
-  role: ${AGENT_ROLE}
+  role: ${emergency_role}
   taskRef: $next_task
   model: ${BEDROCK_MODEL}
 EOF


### PR DESCRIPTION
## Summary

- Fixes missing single-planner constraint in `handle_fatal_error()` ERR trap
- PR #949 fixed this in two places but missed the third spawn path
- When a planner crashes and the ERR trap fires, it no longer spawns a duplicate planner if one is already active

## Root Cause

`handle_fatal_error()` was using `${AGENT_ROLE}` directly for the emergency spawn name and role, without checking if a planner already exists. The planner-loop Deployment also spawns planners on crash recovery, creating a race condition that produced 3 simultaneous planners.

## Fix

Before determining `next_agent` in `handle_fatal_error()`, apply the same single-planner check already used in step 12 emergency perpetuation:

```bash
local emergency_role="${AGENT_ROLE}"
if [ "${AGENT_ROLE}" = "planner" ]; then
  active_planners=$(kubectl ... | jq 'count active planner jobs')
  if [ "$active_planners" -gt 0 ]; then
    emergency_role="worker"
  fi
fi
local next_agent="${emergency_role}-$(date +%s)"
```

Both the Task CR and Agent CR `role` fields are updated to use `emergency_role` instead of `AGENT_ROLE`.

## Impact

- Prevents 2-3 simultaneous planners when a planner crashes
- Reduces circuit breaker pressure from redundant planner jobs
- Eliminates duplicate issue creation and thought stream pollution

Closes #1013