### PR TITLE
fix: validate issue is still OPEN before claiming from coordinator queue

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1092,6 +1092,25 @@ request_coordinator_task() {
       continue
     fi
 
+    # Validate the claimed issue is still open on GitHub (issue #1015)
+    # Stale queue entries can point to already-closed issues — skip them to avoid
+    # wasting an entire LLM session on a no-op task.
+    local issue_state
+    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO}" \
+      --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$issue_state" != "OPEN" ]; then
+      log "Coordinator: issue #$claimed_issue is $issue_state (not OPEN) — releasing claim and removing from queue"
+      release_coordinator_task "$claimed_issue"
+      local new_queue_closed
+      new_queue_closed=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_queue_closed=$(echo "$new_queue_closed" | tr '\n' ',' | sed 's/,$//')
+      kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=merge \
+        -p "{\"data\":{\"taskQueue\":\"${new_queue_closed}\"}}" 2>/dev/null || true
+      retry=$((retry + 1))
+      continue
+    fi
+
     # Remove claimed issue from the queue
     # Use grep -v || true: when queue has only this issue, grep -v returns exit code 1 (no matches),
     # which would crash the script under set -euo pipefail (issue #979)


### PR DESCRIPTION
## Summary

Fixes coordinator queue logic to skip closed issues, preventing agents from wasting sessions on already-resolved work.

Closes #1015

## Changes

- After `claim_task()` succeeds in `request_coordinator_task()`, validate the claimed GitHub issue is still `OPEN`
- If the issue is closed (or state is unknown), release the claim and remove the issue from the coordinator queue
- Increment retry counter and continue to the next available queue item

## Impact

- Prevents wasted LLM sessions when the coordinator queue contains stale (closed) issue references
- Queue cleanup is automatic — closed issues are pruned on first encounter
- Observed regression: planner-1773102870 was assigned issue #1006 (already closed), causing a confused/no-op session

## Implementation Detail

The validation is placed after the atomic `claim_task()` call to avoid a TOCTOU race. We claim first (to hold the slot), then validate. If validation fails, we release the claim before trying the next item. The gh API call adds minimal latency (~1s) and only runs once per queue item.