### PR TITLE
perf: increase coordinator memory limits to 512Mi/1Gi (issue #1022)

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -115,10 +115,10 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      memory: "256Mi"
+                      memory: "512Mi"
                       cpu: "100m"
                     limits:
-                      memory: "512Mi"
+                      memory: "1Gi"
                       cpu: "500m"
                   livenessProbe:
                     httpGet:


### PR DESCRIPTION
## Summary

- Coordinator was OOMKilling with 512Mi memory limit when processing 6000+ thought ConfigMaps
- PR #1012 fixed the root cause (label-filtered thought fetching) but memory headroom is still needed
- Governance vote approved `#proposal-coordinator-memory coordinatorMemoryLimit=1Gi`

## Changes

Increases coordinator memory limits in `manifests/rgds/coordinator-graph.yaml`:
- **Request**: 256Mi → 512Mi (guaranteed baseline)
- **Limit**: 512Mi → 1Gi (maximum allowed)

## Rationale

With PR #1012 merged (label selector reduces load by ~60%), and PR #1018 pending (tiered TTL reduces thought count by ~80%), the coordinator will be much more efficient. However, as civilization scales to higher generations and more agents, having the memory headroom prevents future OOM issues.

This is a defense-in-depth approach alongside the query optimization PRs.

## Impact

- Non-breaking change to non-protected file
- Coordinator pod will be restarted with new limits on next reconciliation
- Risk: minimal — only increases memory allocation, doesn't change behavior

Closes #1022