### PR TITLE
fix: validate coordinator-claimed issue is still OPEN before working on it

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1092,6 +1092,27 @@ request_coordinator_task() {
       continue
     fi
 
+    # Issue #1015: Validate the claimed issue is still OPEN on GitHub before proceeding.
+    # The coordinator queue may lag behind issue closures, causing agents to waste entire
+    # LLM sessions working on already-closed issues.
+    local issue_state
+    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO}" --json state \
+      -q '.state' 2>/dev/null || echo "UNKNOWN")
+    if [ "$issue_state" != "OPEN" ]; then
+      log "Coordinator: issue #$claimed_issue is $issue_state (not OPEN) — skipping and removing from queue"
+      # Release the claim from activeAssignments
+      release_coordinator_task "$claimed_issue"
+      # Remove from queue as well so future agents don't pick it up
+      local new_queue
+      new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+      kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=merge \
+        -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+      retry=$((retry + 1))
+      continue
+    fi
+
     # Remove claimed issue from the queue
     # Use grep -v || true: when queue has only this issue, grep -v returns exit code 1 (no matches),
     # which would crash the script under set -euo pipefail (issue #979)


### PR DESCRIPTION
## Summary

Fixes #1015

`request_coordinator_task()` was claiming issues from the coordinator queue without validating they are still OPEN on GitHub. The coordinator queue can lag behind issue closures, causing agents to waste entire LLM sessions working on already-closed issues.

## Root Cause

After `claim_task()` succeeded, there was no GitHub API check. The coordinator queue is refreshed every ~2.5 minutes from GitHub, so recently-closed issues can remain in the queue temporarily.

## Changes

In `request_coordinator_task()`, after a successful `claim_task()`:
1. Query GitHub API: `gh issue view "$claimed_issue" --json state`
2. If state != "OPEN": release the claim from `activeAssignments`, remove the issue from the coordinator queue, and continue to the next queue item
3. If OPEN: proceed normally

## Impact

- Prevents agents from spending their full LLM context on closed issues
- Self-healing: closed issues are automatically evicted from the coordinator queue
- Graceful fallback: if GitHub API is unavailable (returns UNKNOWN), the issue is skipped to be safe

## Testing

The fix follows the same pattern as the existing stale-claim skip logic already present in the function.