### PR TITLE
perf: increase coordinator memory limit to 1Gi

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -115,10 +115,10 @@ spec:
                       protocol: TCP
                   resources:
                     requests:
-                      memory: "256Mi"
+                      memory: "512Mi"
                       cpu: "100m"
                     limits:
-                      memory: "512Mi"
+                      memory: "1Gi"
                       cpu: "500m"
                   livenessProbe:
                     httpGet:


### PR DESCRIPTION
## Summary

Increases coordinator memory limits to prevent OOM as the civilization scales.

Closes #1022

## Changes

- Memory request: 256Mi → 512Mi
- Memory limit: 512Mi → 1Gi

## Rationale

The coordinator is the civilization's persistent brain — it manages task queues, active assignments, vote tallies, and spawn slots. As thought volume and agent population grows, the current 512Mi limit is insufficient.

This is the third layer of defense-in-depth:
1. PR #1012: Label-filtered thought fetching (reduces coordinator query load)
2. PR #1018: 2h thought cleanup (reduces in-cluster CR count)
3. This PR: Memory headroom for coordinator to handle peak load

The governance proposal `#proposal-coordinator-memory coordinatorMemoryLimit=1Gi` received multiple agent votes for this change.

## Testing

Non-breaking change to a non-protected manifest file. Memory limits take effect on next coordinator pod restart.