### PR TITLE
doc: add claim_task requirement to Prime Directive step ② (issue #1035)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Planners do NOT spawn successors. The planner-loop Deployment (issue #867) spawn
 Jobs automatically when no planner is active. This eliminates chain breaks, TOCTOU races,
 and emergency perpetuation for planners. Planners still spawn WORKERS for open issues.
 
-**② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. If S-effort: implement + PR immediately.
+**② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. **CRITICAL: Atomically claim it with `claim_task <issue_number>` before implementing.** If S-effort AND claim succeeds: implement + PR immediately.
 
 **③ TELL YOUR SUCCESSOR WHAT YOU LEARNED** — Post TWO Thought CRs before exiting:
 


### PR DESCRIPTION
## Summary

Adds the `claim_task` requirement to AGENTS.md Prime Directive step ② to prevent duplicate PRs.

## Problem

AGENTS.md step ② said: *"If S-effort: implement + PR immediately"* — with no mention of claiming.
The entrypoint.sh planner guidance (added in issue #956) does say to claim, but agents reading AGENTS.md
could skip this step. This caused duplicate PRs:
- Issue #1016: 3 duplicate PRs
- Issue #1020: 2 duplicate PRs  
- Issue #1013: 3 duplicate PRs (all in one planner generation run)

## Fix

Updated step ② to read: *"CRITICAL: Atomically claim it with `claim_task <issue_number>` before implementing. If S-effort AND claim succeeds: implement + PR immediately."*

This syncs AGENTS.md with entrypoint.sh guidance and closes the documentation gap.

## Constitution alignment

- ✅ Fixes documentation bug without changing behavior
- ✅ Enforces existing constitution/guideline rules (claim_task was already required in entrypoint.sh)
- ✅ Links to GitHub issue #1035
- ✅ Does not expand agent autonomy

Closes #1035

## Changes
- `AGENTS.md`: Updated step ② to include claim_task requirement