### PR TITLE
fix: inject lastDirective into agent prompt (issue #1048)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -54,6 +54,10 @@ CIVILIZATION_GENERATION=$(kubectl_with_timeout 10 get configmap agentex-constitu
   -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "1")
 if ! [[ "$CIVILIZATION_GENERATION" =~ ^[0-9]+$ ]]; then CIVILIZATION_GENERATION=1; fi
 
+# Read lastDirective from constitution — the god's primary steering signal (issue #1048)
+GOD_DIRECTIVE=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.lastDirective}' 2>/dev/null || echo "")
+
 # Read S3 bucket name for agent memory persistence (issue #825)
 S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
   -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
@@ -2531,6 +2535,8 @@ ${CIVILIZATION_VISION}
 
 Use this vision to self-assess your work alignment (visionScore in Report).
 Check generation to prioritize generation-appropriate work.
+
+$(if [ -n "${GOD_DIRECTIVE}" ]; then printf '═══════════════════════════════════════════════════════\nGOD DIRECTIVE (from constitution.lastDirective)\n═══════════════════════════════════════════════════════\n%s\n\nThis is the god'\''s current steering signal. Read it, act on it, acknowledge it in your Report nextPriority field.\n' "${GOD_DIRECTIVE}"; fi)
 
 ${CHRONICLE_BLOCK}
 


### PR DESCRIPTION
## Summary

- Reads `lastDirective` from `agentex-constitution` at agent startup
- Injects it into the OpenCode prompt as a **GOD DIRECTIVE** block
- Only displayed when non-empty (no noise for fresh installs)

## Problem

The god's primary steering mechanism (`constitution.lastDirective`) was never shown to agents. `entrypoint.sh` read `circuitBreakerLimit`, `vision`, `civilizationGeneration`, `s3Bucket`, etc. but silently dropped `lastDirective`. Every directive posted by god was invisible.

## Fix

Line 57-59: read `GOD_DIRECTIVE` at startup
Line 2539: conditional block in prompt — appears as a clearly-labeled section between civilization context and agent identity blocks

## Constitution alignment

- ✅ Fixes bug without changing behavior (lastDirective field already existed)
- ✅ Enforces constitution design intent: "The lastDirective in the constitution is the most effective steering lever. Agents read it on every boot."
- ✅ God-owned change to protected file (images/runner/entrypoint.sh)
- ✅ Closes #1048 (filed by agent who discovered the gap while implementing #1040)

Closes #1048