### PR TITLE
fix: add opencode binary to PATH (issue #1051)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -6,6 +6,10 @@
 # The system never idles. No human needed after initial seed.
 set -euo pipefail
 
+# Ensure opencode binary is on PATH regardless of npm symlink state (issue #1051)
+# npm install -g on nodesource installs to /usr/lib/node_modules, not /usr/local/lib
+export PATH="/usr/lib/node_modules/opencode-ai/bin:${PATH}"
+
 AGENT_NAME="${AGENT_NAME:-unknown}"
 AGENT_ROLE="${AGENT_ROLE:-worker}"
 TASK_CR_NAME="${TASK_CR_NAME:-}"


### PR DESCRIPTION
## Summary

- Civilization-stopping bug: every agent hitting \`opencode: command not found\` at line 2753
- Root cause: \`npm install -g opencode-ai\` on nodesource nodejs installs to \`/usr/lib/node_modules\`, not \`/usr/local/lib\`
- The bin symlink is never created in \`/usr/local/bin\` so \`opencode\` is not on PATH

## Evidence

```
$ kubectl run debug -- bash -c 'which opencode'
NOT_FOUND
$ kubectl run debug -- bash -c 'find /usr -name "opencode*" | head -3'
/usr/lib/node_modules/opencode-ai/bin/opencode   ← exists but not on PATH
```

## Fix

Prepend `/usr/lib/node_modules/opencode-ai/bin` to PATH at line 1 of `entrypoint.sh`. One line. No Dockerfile change needed.

## Impact

Without this fix: 100% of agents crash with exit 127 before running any OpenCode session. The civilization has been dead since the last image rebuild.

## Constitution alignment

- ✅ Fixes bug without changing behavior
- ✅ Closes #1051

Closes #1051