### PR TITLE
feat: complete Helm chart for one-command agentex installation

### DIFF
--- a/manifests/helm/chart/Chart.yaml
+++ b/manifests/helm/chart/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: agentex
+description: |
+  A self-improving distributed AI agent platform. OpenCode agents run as Kubernetes Pods
+  orchestrated by kro ResourceGraphDefinitions on Amazon EKS. Agents communicate via
+  Kubernetes CRs (fast signaling) and GitHub Issues (durable planning). The system's
+  primary project is itself — agents analyze, improve, and extend their own orchestration layer.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - ai
+  - agents
+  - self-improving
+  - kubernetes
+  - kro
+home: https://github.com/pnz1990/agentex
+sources:
+  - https://github.com/pnz1990/agentex
+maintainers:
+  - name: agentex
+    url: https://github.com/pnz1990/agentex
+dependencies: []
+annotations:
+  agentex/requires-kro: "v0.8.5"
+  agentex/requires-eks: "1.29+"

--- a/manifests/helm/chart/templates/NOTES.txt
+++ b/manifests/helm/chart/templates/NOTES.txt
@@ -1,0 +1,48 @@
+🤖 Agentex civilization deployed!
+
+Civilization: {{ .Values.vision.githubRepo }}
+Region:       {{ .Values.vision.awsRegion }}
+Registry:     {{ .Values.vision.ecrRegistry }}
+Cluster:      {{ .Values.vision.clusterName }}
+S3 Bucket:    {{ .Values.vision.s3Bucket }}
+Generation:   {{ .Values.civilization.generation }}
+
+=== NEXT STEPS ===
+
+1. Build and push the runner image:
+   docker build -t {{ .Values.vision.ecrRegistry }}/agentex/runner:latest ./images/runner/
+   docker push {{ .Values.vision.ecrRegistry }}/agentex/runner:latest
+
+2. Create the GitHub token secret:
+   kubectl create secret generic agentex-github-token \
+     -n {{ .Values.namespace.name }} \
+     --from-literal=token=<YOUR_GITHUB_TOKEN>
+
+3. Seed the civilization (one-time):
+   kubectl apply -f manifests/bootstrap/seed-agent.yaml
+
+4. Verify the civilization is alive:
+   kubectl get jobs -n {{ .Values.namespace.name }}
+   kubectl get configmap coordinator-state -n {{ .Values.namespace.name }} -o yaml
+
+=== STEERING THE CIVILIZATION ===
+
+Update the directive (agents read this on every boot):
+  kubectl patch configmap agentex-constitution \
+    -n {{ .Values.namespace.name }} \
+    --type=merge \
+    -p '{"data":{"lastDirective":"Your directive here"}}'
+
+Emergency kill switch (stops all agent spawning):
+  kubectl patch configmap agentex-killswitch \
+    -n {{ .Values.namespace.name }} \
+    --type=merge \
+    -p '{"data":{"enabled":"true","reason":"Emergency stop"}}'
+
+=== CIRCUIT BREAKER ===
+
+Max concurrent agents: {{ .Values.civilization.circuitBreakerLimit }}
+
+=== DOCUMENTATION ===
+
+Full documentation: https://github.com/pnz1990/agentex/blob/main/AGENTS.md

--- a/manifests/helm/chart/templates/_helpers.tpl
+++ b/manifests/helm/chart/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agentex.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "agentex.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agentex.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agentex.labels" -}}
+helm.sh/chart: {{ include "agentex.chart" . }}
+{{ include "agentex.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agentex.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentex.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Validate required values
+*/}}
+{{- define "agentex.validateValues" -}}
+{{- if not .Values.vision.githubRepo }}
+  {{- fail "vision.githubRepo is required. Example: myorg/myrepo" }}
+{{- end }}
+{{- if not .Values.vision.awsRegion }}
+  {{- fail "vision.awsRegion is required. Example: us-west-2" }}
+{{- end }}
+{{- if not .Values.vision.ecrRegistry }}
+  {{- fail "vision.ecrRegistry is required. Example: 123456.dkr.ecr.us-west-2.amazonaws.com" }}
+{{- end }}
+{{- if not .Values.vision.s3Bucket }}
+  {{- fail "vision.s3Bucket is required. Example: my-thoughts" }}
+{{- end }}
+{{- if not .Values.vision.clusterName }}
+  {{- fail "vision.clusterName is required. Example: my-cluster" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate on every render — called from NOTES.txt
+*/}}
+{{- define "agentex.notes" -}}
+{{ include "agentex.validateValues" . }}
+{{- end }}

--- a/manifests/helm/chart/templates/bootstrap.yaml
+++ b/manifests/helm/chart/templates/bootstrap.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.bootstrap.coordinator }}
+---
+# Coordinator CR — triggers kro to create the coordinator-state ConfigMap + Deployment
+apiVersion: kro.run/v1alpha1
+kind: Coordinator
+metadata:
+  name: coordinator
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: coordinator
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  enabled: true
+  model: {{ .Values.agent.model | quote }}
+  imageTag: {{ .Values.agent.imageTag | quote }}
+  imageRegistry: {{ required "vision.ecrRegistry is required" .Values.vision.ecrRegistry | quote }}
+  clusterName: {{ required "vision.clusterName is required" .Values.vision.clusterName | quote }}
+{{- end }}
+{{- if .Values.bootstrap.plannerLoop }}
+---
+# PlannerLoop CR — triggers kro to create the planner-loop Deployment
+apiVersion: kro.run/v1alpha1
+kind: PlannerLoop
+metadata:
+  name: planner-loop
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: planner-loop
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  enabled: true
+  model: {{ .Values.agent.model | quote }}
+  imageTag: {{ .Values.agent.imageTag | quote }}
+  imageRegistry: {{ required "vision.ecrRegistry is required" .Values.vision.ecrRegistry | quote }}
+  clusterName: {{ required "vision.clusterName is required" .Values.vision.clusterName | quote }}
+{{- end }}

--- a/manifests/helm/chart/templates/constitution.yaml
+++ b/manifests/helm/chart/templates/constitution.yaml
@@ -1,0 +1,77 @@
+{{- /*
+agentex-constitution ConfigMap — god-owned constants.
+Agents READ these values. Agents do NOT modify this file or the ConfigMap.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-constitution
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    agentex/owned-by: god
+    agentex/protected: "true"
+  annotations:
+    agentex/description: "God-owned constants. Do not modify without god approval."
+data:
+  # Maximum concurrent active Jobs. God sets this. Agents read it.
+  circuitBreakerLimit: {{ .Values.civilization.circuitBreakerLimit | quote }}
+
+  # Minimum approve votes required for governance decisions
+  voteThreshold: {{ .Values.civilization.voteThreshold | quote }}
+
+  # Daily Bedrock cost budget in USD
+  dailyCostBudgetUSD: {{ .Values.civilization.dailyCostBudgetUSD | quote }}
+
+  # Model to use for all agents (cross-region inference prefix required)
+  agentModel: {{ .Values.agent.model | quote }}
+
+  # S3 bucket for agent memory persistence
+  s3Bucket: {{ required "vision.s3Bucket is required" .Values.vision.s3Bucket | quote }}
+
+  # ECR registry base URL for agent container images
+  ecrRegistry: {{ required "vision.ecrRegistry is required" .Values.vision.ecrRegistry | quote }}
+
+  # AWS region where the EKS cluster and Bedrock run
+  awsRegion: {{ required "vision.awsRegion is required" .Values.vision.awsRegion | quote }}
+
+  # Kubernetes cluster name
+  clusterName: {{ required "vision.clusterName is required" .Values.vision.clusterName | quote }}
+
+  # GitHub repository for issue tracking and PRs
+  githubRepo: {{ required "vision.githubRepo is required" .Values.vision.githubRepo | quote }}
+
+  # Current civilization generation (god increments this)
+  civilizationGeneration: {{ .Values.civilization.generation | quote }}
+
+  # Job TTL for completed agent pods
+  jobTTLSeconds: {{ .Values.civilization.jobTTLSeconds | quote }}
+
+  # Minimum vision score for agent work
+  minimumVisionScore: {{ .Values.civilization.minimumVisionScore | quote }}
+
+  # Minimum generations before agents may work on vision features
+  visionUnlockGeneration: "10"
+
+  # Guidance for agents on vision score prioritization
+  visionScoreGuidance: |
+    Prioritize work with vision score >=5. Score <5 work is permitted
+    but MUST be justified in Report CR blockers field. Emergency work (score=1-3)
+    always allowed without justification when system is in crisis.
+
+  # Security mandate — agents must check for CVEs and act on them
+  securityPosture: |
+    Security is a first-class concern. Agents MUST check GitHub code scanning
+    alerts on each planner run. If count > 0, file a GitHub issue with label
+    "security" summarizing the top alerts. Security issues have coordinator
+    priority score = 9.
+
+  # God's current directive to the civilization
+  lastDirective: |
+{{ .Values.civilization.lastDirective | indent 4 }}
+
+  # Vision: what this civilization exists to become
+  vision: |
+{{ .Values.civilization.purpose | indent 4 }}

--- a/manifests/helm/chart/templates/killswitch.yaml
+++ b/manifests/helm/chart/templates/killswitch.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.bootstrap.killswitch }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-killswitch
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  # Set enabled="true" to stop ALL agent spawning immediately.
+  # This is an emergency control to prevent catastrophic proliferation.
+  # To activate: kubectl patch configmap agentex-killswitch -n agentex \
+  #   --type=merge -p '{"data":{"enabled":"true","reason":"Emergency stop"}}'
+  enabled: "false"
+  reason: ""
+{{- end }}

--- a/manifests/helm/chart/templates/name-registry.yaml
+++ b/manifests/helm/chart/templates/name-registry.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.bootstrap.nameRegistry }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentex-name-registry
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  # Name pool for persistent agent identities
+  # Format: name:role:status (status: available | claimed:<agent-cr-name>)
+
+  # Workers - computer scientists and engineers
+  workers: |
+    ada:worker:available
+    turing:worker:available
+    hopper:worker:available
+    knuth:worker:available
+    dijkstra:worker:available
+    liskov:worker:available
+    lamport:worker:available
+    codd:worker:available
+    ritchie:worker:available
+    kernighan:worker:available
+    thompson:worker:available
+    stroustrup:worker:available
+    gosling:worker:available
+    pike:worker:available
+
+  # Planners - philosophers and thinkers
+  planners: |
+    aristotle:planner:available
+    plato:planner:available
+    socrates:planner:available
+    bacon:planner:available
+    descartes:planner:available
+    kant:planner:available
+    hume:planner:available
+    locke:planner:available
+    spinoza:planner:available
+    leibniz:planner:available
+
+  # Architects - famous architects and builders
+  architects: |
+    vitruvius:architect:available
+    wren:architect:available
+    gaudi:architect:available
+    gehry:architect:available
+    zaha:architect:available
+    piano:architect:available
+    foster:architect:available
+    koolhaas:architect:available
+    calatrava:architect:available
+
+  # Reviewers - critics and essayists
+  reviewers: |
+    voltaire:reviewer:available
+    montaigne:reviewer:available
+    orwell:reviewer:available
+    popper:reviewer:available
+    kuhn:reviewer:available
+    lakatos:reviewer:available
+    feyerabend:reviewer:available
+{{- end }}

--- a/manifests/helm/chart/templates/namespace.yaml
+++ b/manifests/helm/chart/templates/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/manifests/helm/chart/templates/rbac.yaml
+++ b/manifests/helm/chart/templates/rbac.yaml
@@ -1,0 +1,91 @@
+{{- /*
+RBAC resources for agentex agent pods.
+ServiceAccount with Pod Identity / IRSA annotation for AWS access.
+*/}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentex-agent-sa
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.agent.iamRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.agent.iamRoleArn | quote }}
+  {{- end }}
+---
+# Namespace-scoped Role: agents can read/write all agentex CRs and jobs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agentex-agent-role
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: ["agentex.io", "kro.run"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agentex-agent-binding
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: agentex-agent-sa
+    namespace: {{ .Values.namespace.name }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: agentex-agent-role
+---
+# Cluster-level read so agents can watch CRs and RGDs across namespaces if needed
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agentex-agent-cluster-reader
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: ["agentex.io", "kro.run"]
+    resources: ["agents", "tasks", "messages", "thoughts", "swarms", "reports", "coordinators", "plannerloops", "resourcegraphdefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agentex-agent-cluster-binding
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: agentex-agent-sa
+    namespace: {{ .Values.namespace.name }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: agentex-agent-cluster-reader

--- a/manifests/helm/chart/templates/rgds.yaml
+++ b/manifests/helm/chart/templates/rgds.yaml
@@ -1,0 +1,743 @@
+{{- /*
+All 8 kro ResourceGraphDefinitions (RGDs) that form the agent coordination layer.
+These are included verbatim - they use kro's CEL DSL (${...}), not Helm templates.
+RGDs are cluster-scoped resources in kro v0.8.5.
+*/}}
+---
+# agent-graph: Creates a Job (OpenCode runner) for each Agent CR
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: agent-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Agent
+    spec:
+      role: string | default="worker"
+      taskRef: string | required=true
+      model: string | default={{ .Values.agent.model | quote }}
+      swarmRef: string | default=""
+      priority: integer | default=5
+      imageRegistry: string | default={{ .Values.vision.ecrRegistry | quote }}
+      clusterName: string | default={{ .Values.vision.clusterName | quote }}
+      useSpot: boolean | default=false
+      capacityType: string | default="on-demand"
+    status:
+      jobName: ${agentJob.metadata.name}
+      completionTime: ${agentJob.status.completionTime}
+      failed: ${agentJob.status.failed}
+      active: ${agentJob.status.active}
+      succeeded: ${agentJob.status.succeeded}
+  resources:
+    - id: agentJob
+      readyWhen:
+        - ${agentJob.metadata.resourceVersion != ""}
+      template:
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: ${schema.metadata.name}
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-agent
+            agentex/role: ${schema.spec.role}
+            agentex/task: ${schema.spec.taskRef}
+        spec:
+          ttlSecondsAfterFinished: 180
+          backoffLimit: 2
+          activeDeadlineSeconds: 3600
+          template:
+            metadata:
+              labels:
+                app: agentex-agent
+                agentex/role: ${schema.spec.role}
+                agentex/task: ${schema.spec.taskRef}
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Never
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 90
+                      preference:
+                        matchExpressions:
+                          - key: karpenter.sh/capacity-type
+                            operator: In
+                            values:
+                              - ${schema.spec.capacityType}
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: agent
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: AGENT_NAME
+                      value: ${schema.metadata.name}
+                    - name: AGENT_ROLE
+                      value: ${schema.spec.role}
+                    - name: TASK_CR_NAME
+                      value: ${schema.spec.taskRef}
+                    - name: SWARM_REF
+                      value: ${schema.spec.swarmRef}
+                    - name: BEDROCK_MODEL
+                      value: ${schema.spec.model}
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: REPO
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: "agentex"
+                    - name: GITHUB_TOKEN_FILE
+                      value: "/var/secrets/github/token"
+                  resources:
+                    requests:
+                      memory: "512Mi"
+                      cpu: "250m"
+                    limits:
+                      memory: "2Gi"
+                      cpu: "1000m"
+                  volumeMounts:
+                    - name: workspace
+                      mountPath: /workspace
+                    - name: github-token
+                      mountPath: /var/secrets/github
+                      readOnly: true
+              volumes:
+                - name: workspace
+                  emptyDir:
+                    sizeLimit: 2Gi
+                - name: github-token
+                  secret:
+                    secretName: agentex-github-token
+                    defaultMode: 0400
+---
+# task-graph: Creates a ConfigMap (task spec, status, assignee, priority)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: task-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Task
+    spec:
+      title: string | required=true
+      description: string | default=""
+      role: string | default="worker"
+      priority: integer | default=5
+      effort: string | default="M"
+      githubIssue: integer | default=0
+      context: string | default=""
+      swarmRef: string | default=""
+    status:
+      configMapName: ${taskConfigMap.metadata.name}
+      phase: ${taskConfigMap.metadata.name}
+      agentRef: ${taskConfigMap.metadata.name}
+      outcome: ${taskConfigMap.metadata.name}
+      completedAt: ${taskConfigMap.metadata.creationTimestamp}
+  resources:
+    - id: taskConfigMap
+      readyWhen:
+        - ${taskConfigMap.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-spec
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/task: ${schema.metadata.name}
+            agentex/role: ${schema.spec.role}
+            agentex/priority: ${string(schema.spec.priority)}
+            agentex/swarm: ${schema.spec.swarmRef}
+        data:
+          title: ${schema.spec.title}
+          description: ${schema.spec.description}
+          role: ${schema.spec.role}
+          priority: ${string(schema.spec.priority)}
+          effort: ${schema.spec.effort}
+          githubIssue: ${string(schema.spec.githubIssue)}
+          context: ${schema.spec.context}
+          swarmRef: ${schema.spec.swarmRef}
+---
+# message-graph: Creates a ConfigMap (from, to, body, thread, timestamp)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: message-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Message
+    spec:
+      from: string | required=true
+      to: string | required=true
+      body: string | required=true
+      thread: string | default=""
+      messageType: string | default="status"
+      replyTo: string | default=""
+    status:
+      configMapName: ${messageConfigMap.metadata.name}
+      read: ${messageConfigMap.data.read}
+      timestamp: ${messageConfigMap.metadata.creationTimestamp}
+  resources:
+    - id: messageConfigMap
+      readyWhen:
+        - ${messageConfigMap.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-msg
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/from: ${schema.spec.from}
+            agentex/to: ${schema.spec.to}
+            agentex/thread: ${schema.spec.thread}
+            agentex/type: ${schema.spec.messageType}
+        data:
+          from: ${schema.spec.from}
+          to: ${schema.spec.to}
+          body: ${schema.spec.body}
+          thread: ${schema.spec.thread}
+          messageType: ${schema.spec.messageType}
+          replyTo: ${schema.spec.replyTo}
+          read: "false"
+---
+# thought-graph: Creates a ConfigMap (agent reasoning log, visible to peers)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: thought-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Thought
+    spec:
+      agentRef: string | required=true
+      displayName: string | default=""
+      taskRef: string | default=""
+      content: string | required=true
+      thoughtType: string | default="observation"
+      confidence: integer | default=7
+      topic: string | default=""
+      filePath: string | default=""
+      parentRef: string | default=""
+    status:
+      configMapName: ${thoughtConfigMap.metadata.name}
+      readBy: ${thoughtConfigMap.data.readBy}
+  resources:
+    - id: thoughtConfigMap
+      readyWhen:
+        - ${thoughtConfigMap.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-thought
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/thought: "true"
+            agentex/agent: ${schema.spec.agentRef}
+            agentex/task: ${schema.spec.taskRef}
+            agentex/type: ${schema.spec.thoughtType}
+            agentex/topic: ${schema.spec.topic}
+            agentex/file: ${schema.spec.filePath}
+            agentex/parent: ${schema.spec.parentRef}
+        data:
+          agentRef: ${schema.spec.agentRef}
+          displayName: ${schema.spec.displayName}
+          taskRef: ${schema.spec.taskRef}
+          content: ${schema.spec.content}
+          thoughtType: ${schema.spec.thoughtType}
+          confidence: ${string(schema.spec.confidence)}
+          topic: ${schema.spec.topic}
+          filePath: ${schema.spec.filePath}
+          parentRef: ${schema.spec.parentRef}
+          readBy: ""
+---
+# report-graph: Creates a ConfigMap (structured exit report — feeds god-observer)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: report-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Report
+    spec:
+      agentRef: string | required=true
+      displayName: string | default=""
+      taskRef: string | default=""
+      role: string | default="worker"
+      status: string | default="completed"
+      visionScore: integer | default=5
+      workDone: string | default=""
+      issuesFound: string | default=""
+      prOpened: string | default=""
+      blockers: string | default=""
+      nextPriority: string | default=""
+      generation: integer | default=0
+      exitCode: integer | default=0
+    status:
+      configMapName: ${reportConfigMap.metadata.name}
+  resources:
+    - id: reportConfigMap
+      readyWhen:
+        - ${reportConfigMap.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-data
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/agent: ${schema.spec.agentRef}
+            agentex/role: ${schema.spec.role}
+            agentex/status: ${schema.spec.status}
+            agentex/report: ${schema.metadata.name}
+        data:
+          agentRef: ${schema.spec.agentRef}
+          displayName: ${schema.spec.displayName}
+          taskRef: ${schema.spec.taskRef}
+          role: ${schema.spec.role}
+          status: ${schema.spec.status}
+          visionScore: ${string(schema.spec.visionScore)}
+          workDone: ${schema.spec.workDone}
+          issuesFound: ${schema.spec.issuesFound}
+          prOpened: ${schema.spec.prOpened}
+          blockers: ${schema.spec.blockers}
+          nextPriority: ${schema.spec.nextPriority}
+          generation: ${string(schema.spec.generation)}
+          exitCode: ${string(schema.spec.exitCode)}
+---
+# swarm-graph: Creates a State ConfigMap + planner Job (spawned on Swarm CR creation)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: swarm-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Swarm
+    spec:
+      goal: string | required=true
+      plannerTaskRef: string | required=true
+      maxAgents: integer | default=10
+      planners: integer | default=1
+      workers: integer | default=3
+      reviewers: integer | default=1
+      consensusThreshold: integer | default=51
+      githubRepo: string | default={{ .Values.vision.githubRepo | default "pnz1990/agentex" | quote }}
+      model: string | default={{ .Values.agent.model | quote }}
+      imageRegistry: string | default={{ .Values.vision.ecrRegistry | default "569190534191.dkr.ecr.us-west-2.amazonaws.com" | quote }}
+      clusterName: string | default={{ .Values.vision.clusterName | default "agentex" | quote }}
+    status:
+      configMapName: ${swarmState.metadata.name}
+      phase: ${swarmState.data.phase}
+      plannerJob: ${plannerAgent.metadata.name}
+  resources:
+    - id: swarmState
+      readyWhen:
+        - ${swarmState.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-state
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/swarm: ${schema.metadata.name}
+        data:
+          goal: ${schema.spec.goal}
+          phase: "Forming"
+          maxAgents: ${string(schema.spec.maxAgents)}
+          planners: ${string(schema.spec.planners)}
+          workers: ${string(schema.spec.workers)}
+          reviewers: ${string(schema.spec.reviewers)}
+          consensusThreshold: ${string(schema.spec.consensusThreshold)}
+          githubRepo: ${schema.spec.githubRepo}
+          activeAgents: "0"
+          tasksCompleted: "0"
+          issuesCreated: "0"
+          prsMerged: "0"
+          lastActivityTimestamp: ""
+          memberAgents: ""
+    - id: plannerAgent
+      readyWhen:
+        - ${plannerAgent.status.completionTime != null}
+      template:
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: ${schema.metadata.name}-planner
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-agent
+            agentex/role: planner
+            agentex/swarm: ${schema.metadata.name}
+        spec:
+          ttlSecondsAfterFinished: 180
+          backoffLimit: 0
+          activeDeadlineSeconds: 3600
+          template:
+            metadata:
+              labels:
+                app: agentex-agent
+                agentex/role: planner
+                agentex/swarm: ${schema.metadata.name}
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Never
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: agent
+                  image: ${schema.spec.imageRegistry}/agentex/runner:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: AGENT_NAME
+                      value: ${schema.metadata.name}-planner
+                    - name: AGENT_ROLE
+                      value: planner
+                    - name: TASK_CR_NAME
+                      value: ${schema.spec.plannerTaskRef}
+                    - name: SWARM_REF
+                      value: ${schema.metadata.name}
+                    - name: BEDROCK_MODEL
+                      value: ${schema.spec.model}
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: REPO
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                    - name: GITHUB_TOKEN_FILE
+                      value: "/var/secrets/github/token"
+                  resources:
+                    requests:
+                      memory: "512Mi"
+                      cpu: "250m"
+                    limits:
+                      memory: "2Gi"
+                      cpu: "1000m"
+                  volumeMounts:
+                    - name: workspace
+                      mountPath: /workspace
+                    - name: github-token
+                      mountPath: /var/secrets/github
+                      readOnly: true
+              volumes:
+                - name: workspace
+                  emptyDir:
+                    sizeLimit: 2Gi
+                - name: github-token
+                  secret:
+                    secretName: agentex-github-token
+                    defaultMode: 0400
+---
+# coordinator-graph: Creates a State ConfigMap + Deployment (long-running coordinator)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: coordinator-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Coordinator
+    spec:
+      enabled: boolean | default=true
+      model: string | default={{ .Values.agent.model | quote }}
+      imageTag: string | default={{ .Values.agent.imageTag | quote }}
+      imageRegistry: string | default={{ .Values.vision.ecrRegistry | default "569190534191.dkr.ecr.us-west-2.amazonaws.com" | quote }}
+      clusterName: string | default={{ .Values.vision.clusterName | default "agentex" | quote }}
+    status:
+      configMapName: ${coordinatorState.metadata.name}
+      deploymentName: ${coordinatorDeployment.metadata.name}
+      phase: ${coordinatorDeployment.metadata.name}
+      lastHeartbeat: ${coordinatorDeployment.metadata.creationTimestamp}
+  resources:
+    - id: coordinatorState
+      readyWhen:
+        - ${coordinatorState.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coordinator-state
+          namespace: ${schema.metadata.namespace}
+          labels:
+            agentex/component: coordinator
+        data:
+          bootstrapped: "true"
+    - id: coordinatorDeployment
+      readyWhen:
+        - ${coordinatorDeployment.status.availableReplicas == 1}
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: coordinator
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-coordinator
+            agentex/component: coordinator
+        spec:
+          replicas: 1
+          strategy:
+            type: Recreate
+          selector:
+            matchLabels:
+              app: agentex-coordinator
+          template:
+            metadata:
+              labels:
+                app: agentex-coordinator
+                agentex/component: coordinator
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Always
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: coordinator
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
+                  imagePullPolicy: Always
+                  command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: COORDINATOR_NAME
+                      value: coordinator
+                    - name: BEDROCK_MODEL
+                      value: ${schema.spec.model}
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: REPO
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: githubRepo
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                    - name: GITHUB_TOKEN_FILE
+                      value: "/var/secrets/github/token"
+                  ports:
+                    - name: health
+                      containerPort: 8080
+                      protocol: TCP
+                  resources:
+                    requests:
+                      memory: "512Mi"
+                      cpu: "100m"
+                    limits:
+                      memory: "1Gi"
+                      cpu: "500m"
+                  livenessProbe:
+                    httpGet:
+                      path: /health
+                      port: health
+                      scheme: HTTP
+                    initialDelaySeconds: 60
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    httpGet:
+                      path: /health
+                      port: health
+                      scheme: HTTP
+                    initialDelaySeconds: 30
+                    periodSeconds: 10
+                    timeoutSeconds: 5
+                    failureThreshold: 2
+                  volumeMounts:
+                    - name: workspace
+                      mountPath: /workspace
+                    - name: github-token
+                      mountPath: /var/secrets/github
+                      readOnly: true
+              volumes:
+                - name: workspace
+                  emptyDir:
+                    sizeLimit: 1Gi
+                - name: github-token
+                  secret:
+                    secretName: agentex-github-token
+                    defaultMode: 0400
+---
+# planner-loop-graph: Creates a Deployment (long-running loop that spawns planner Jobs)
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: planner-loop-graph
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: PlannerLoop
+    spec:
+      enabled: boolean | default=true
+      model: string | default={{ .Values.agent.model | quote }}
+      imageTag: string | default={{ .Values.agent.imageTag | quote }}
+      imageRegistry: string | default={{ .Values.vision.ecrRegistry | default "569190534191.dkr.ecr.us-west-2.amazonaws.com" | quote }}
+      clusterName: string | default={{ .Values.vision.clusterName | default "agentex" | quote }}
+    status:
+      deploymentName: ${plannerLoopDeployment.metadata.name}
+      phase: ${plannerLoopDeployment.metadata.name}
+  resources:
+    - id: plannerLoopDeployment
+      readyWhen:
+        - ${plannerLoopDeployment.status.availableReplicas == 1}
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: planner-loop
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-planner-loop
+            agentex/component: planner-loop
+        spec:
+          replicas: 1
+          strategy:
+            type: Recreate
+          selector:
+            matchLabels:
+              app: agentex-planner-loop
+          template:
+            metadata:
+              labels:
+                app: agentex-planner-loop
+                agentex/component: planner-loop
+            spec:
+              serviceAccountName: agentex-agent-sa
+              restartPolicy: Always
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: planner-loop
+                  image: ${schema.spec.imageRegistry}/agentex/runner:${schema.spec.imageTag}
+                  imagePullPolicy: Always
+                  command: ["/bin/bash", "/usr/local/bin/planner-loop.sh"]
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop: ["ALL"]
+                  env:
+                    - name: BEDROCK_REGION
+                      valueFrom:
+                        configMapKeyRef:
+                          name: agentex-constitution
+                          key: awsRegion
+                    - name: CLUSTER
+                      value: ${schema.spec.clusterName}
+                    - name: NAMESPACE
+                      value: ${schema.metadata.namespace}
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "50m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "200m"
+                  livenessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 30
+                    periodSeconds: 60
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    exec:
+                      command:
+                        - /bin/sh
+                        - -c
+                        - 'ps aux | grep -v grep | grep planner-loop.sh'
+                    initialDelaySeconds: 10
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 2

--- a/manifests/helm/chart/values.yaml
+++ b/manifests/helm/chart/values.yaml
@@ -1,0 +1,114 @@
+# =============================================================================
+# Agentex Helm Chart Values
+# =============================================================================
+# A new god installs agentex by setting the required values below and running:
+#
+#   helm install agentex ./manifests/helm/chart \
+#     --set vision.githubRepo=myorg/myrepo \
+#     --set vision.awsRegion=eu-west-1 \
+#     --set vision.ecrRegistry=123456.dkr.ecr.eu-west-1.amazonaws.com \
+#     --set vision.s3Bucket=my-thoughts \
+#     --set vision.clusterName=my-cluster
+#
+# After install, seed the civilization:
+#   kubectl apply -f manifests/bootstrap/seed-agent.yaml
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# REQUIRED: New god must set all values in this section
+# -----------------------------------------------------------------------------
+vision:
+  # GitHub repository where agents file issues and open PRs
+  # Format: owner/repo  (e.g. myorg/myrepo)
+  githubRepo: ""
+
+  # AWS region where your EKS cluster and Bedrock are enabled
+  # (e.g. eu-west-1, us-west-2, us-east-1)
+  awsRegion: ""
+
+  # Container registry URL (no trailing slash)
+  # Format: <account>.dkr.ecr.<region>.amazonaws.com
+  ecrRegistry: ""
+
+  # S3 bucket name for agent memory and the civilization chronicle
+  # Must be pre-created in your AWS account with appropriate IAM permissions
+  s3Bucket: ""
+
+  # EKS cluster name (used by agents to configure kubectl)
+  clusterName: ""
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Sensible defaults — change only if you know what you're doing
+# -----------------------------------------------------------------------------
+civilization:
+  # The purpose of this civilization. Agents read this as their guiding vision.
+  purpose: |
+    Agents that propose, vote, debate, and reason about improvements to
+    their own society — a true collective intelligence that develops itself.
+    NOT: agents that fix their own plumbing forever.
+    YES: agents that build new capabilities, debate architecture, form identity,
+    remember history, and pursue emergent goals beyond their initial mandate.
+
+  # Starting generation number. God increments this to mark new eras.
+  generation: "1"
+
+  # Maximum concurrent active agent Jobs. Increase carefully — too high causes proliferation.
+  circuitBreakerLimit: "6"
+
+  # Daily Bedrock cost budget in USD. Coordinator monitors and reduces spawn slots if exceeded.
+  dailyCostBudgetUSD: "50"
+
+  # TTL in seconds before completed Job pods are cleaned up.
+  jobTTLSeconds: "300"
+
+  # Minimum approve votes required for governance decisions.
+  voteThreshold: "3"
+
+  # Agents prioritize work with visionScore >= this value.
+  minimumVisionScore: "5"
+
+  # The god's current directive to the civilization (agents read this on every boot).
+  # Update via: kubectl patch configmap agentex-constitution -n agentex \
+  #   --type=merge -p '{"data":{"lastDirective":"..."}}'
+  lastDirective: |
+    Generation 1 ACTIVE. System just installed. Priority:
+    (1) Ensure agents are spawning and completing tasks successfully.
+    (2) Monitor GitHub issues for the first self-improvement cycles.
+    (3) Verify the agent chain never breaks (planner → workers → planners).
+
+# -----------------------------------------------------------------------------
+# Agent runtime configuration
+# -----------------------------------------------------------------------------
+agent:
+  # Bedrock model for all agents (cross-region inference prefix required)
+  model: "us.anthropic.claude-sonnet-4-6"
+
+  # Container image tag to use for the runner image
+  imageTag: "latest"
+
+  # IAM role ARN for the agent service account (Pod Identity / IRSA)
+  # Must have permissions: Bedrock InvokeModel, ECR pull, S3 read/write, EKS describe
+  # Created by manifests/system/install-configure.sh
+  iamRoleArn: ""
+
+# -----------------------------------------------------------------------------
+# Namespace configuration
+# -----------------------------------------------------------------------------
+namespace:
+  # Name of the Kubernetes namespace all agentex resources live in
+  name: agentex
+  # Whether to create the namespace (set to false if it already exists)
+  create: true
+
+# -----------------------------------------------------------------------------
+# Bootstrap resources
+# -----------------------------------------------------------------------------
+bootstrap:
+  # Deploy the coordinator CR + Deployment on install
+  coordinator: true
+  # Deploy the planner-loop CR + Deployment on install
+  plannerLoop: true
+  # Deploy the kill switch ConfigMap (disabled by default)
+  killswitch: true
+  # Deploy the name registry ConfigMap
+  nameRegistry: true


### PR DESCRIPTION
## Summary

Implements a complete, valid Helm chart that installs the entire agentex civilization with a single command. A new god can go from zero to a running civilization without touching individual manifests.

```bash
helm install agentex ./manifests/helm/chart \
  --set vision.githubRepo=myorg/myrepo \
  --set vision.awsRegion=eu-west-1 \
  --set vision.ecrRegistry=123456.dkr.ecr.eu-west-1.amazonaws.com \
  --set vision.s3Bucket=my-thoughts \
  --set vision.clusterName=my-cluster
```

Closes #1037

## Changes

### New files: `manifests/helm/chart/`

- **`Chart.yaml`** — chart metadata, version 0.1.0, kro v0.8.5 annotation
- **`values.yaml`** — fully documented values with required/optional sections
- **`templates/_helpers.tpl`** — common helpers + required-value validation
- **`templates/NOTES.txt`** — post-install instructions for the new god
- **`templates/namespace.yaml`** — agentex namespace
- **`templates/rbac.yaml`** — ServiceAccount (with IRSA annotation), Role, RoleBinding, ClusterRole, ClusterRoleBinding
- **`templates/constitution.yaml`** — agentex-constitution ConfigMap with all fields parameterized from values
- **`templates/killswitch.yaml`** — agentex-killswitch ConfigMap (disabled by default)
- **`templates/name-registry.yaml`** — agentex-name-registry ConfigMap (full name pool)
- **`templates/rgds.yaml`** — all 8 kro ResourceGraphDefinitions (agent, task, message, thought, report, swarm, coordinator, planner-loop) with configurable defaults
- **`templates/bootstrap.yaml`** — Coordinator CR + PlannerLoop CR (triggers kro to create deployments)

## Validation

```
$ helm lint ./manifests/helm/chart --set vision.githubRepo=myorg/myrepo ...
==> Linting ./manifests/helm/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template agentex ./manifests/helm/chart --set ... | grep "^# Source:"
# 19 resources rendered correctly
```

Required values fail fast with clear error messages:
```
Error: execution error at (agentex/templates/constitution.yaml:32:15): vision.s3Bucket is required
```

## Vision Alignment

Score: 10/10 — This is the packaging milestone that makes agentex portable. A new god can now install and run this civilization in their own AWS account/cluster without manual manifest surgery. Closes the portability gap from issue #819.