### PR TITLE
fix: use exec health probes in coordinator-graph to stop CrashLoopBackOff

### DIFF
--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -109,10 +109,6 @@ spec:
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE
                       value: "/var/secrets/github/token"
-                  ports:
-                    - name: health
-                      containerPort: 8080
-                      protocol: TCP
                   resources:
                     requests:
                       memory: "512Mi"
@@ -121,20 +117,16 @@ spec:
                       memory: "1Gi"
                       cpu: "500m"
                   livenessProbe:
-                    httpGet:
-                      path: /health
-                      port: health
-                      scheme: HTTP
-                    initialDelaySeconds: 60
+                    exec:
+                      command: ["test", "-f", "/tmp/coordinator-alive"]
+                    initialDelaySeconds: 30
                     periodSeconds: 30
                     timeoutSeconds: 5
                     failureThreshold: 3
                   readinessProbe:
-                    httpGet:
-                      path: /health
-                      port: health
-                      scheme: HTTP
-                    initialDelaySeconds: 30
+                    exec:
+                      command: ["test", "-f", "/tmp/coordinator-alive"]
+                    initialDelaySeconds: 15
                     periodSeconds: 10
                     timeoutSeconds: 5
                     failureThreshold: 2


### PR DESCRIPTION
## Summary

The coordinator pod was in continuous CrashLoopBackOff state, restarting every ~3 minutes.

## Root Cause

coordinator-graph.yaml configured HTTP GET probes on port 8080, but the running coordinator image has NO HTTP health server. The coordinator.sh in the running image only creates `/tmp/coordinator-alive` file markers. The probes always fail → liveness kills the pod → restart loop.

## Fix

Changed health probes from HTTP GET to exec file checks that match what coordinator.sh actually does:

```yaml
livenessProbe:
  exec:
    command: ["test", "-f", "/tmp/coordinator-alive"]
readinessProbe:
  exec:
    command: ["test", "-f", "/tmp/coordinator-alive"]
```

Also removed unused containerPort 8080.

## Constitution Alignment

- ✅ Fixes a bug without changing coordinator behavior
- ✅ Makes the coordinator reliably available (stops crash-loop)
- ✅ Uses existing file-based health mechanism already in coordinator.sh
- ✅ Does NOT expand agent autonomy or bypass safety mechanisms

## Closes

Closes #1053

## Changes

- `manifests/rgds/coordinator-graph.yaml`: Switch liveness/readiness probes from httpGet to exec, remove port 8080