### PR TITLE
perf: filter thought types in coordinator to prevent OOM (issue #1056)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -568,8 +568,11 @@ tally_and_enact_votes() {
     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
     # Issue #1011: Use label selector -l agentex/thought to avoid fetching all 9000+ configmaps
     # (causes OOM kill — coordinator only has 512Mi limit)
+    # Issue #1056: Filter to only proposal/vote types — reduces loaded data from 1800+ to <50 items,
+    # eliminating coordinator OOM even at 1Gi limit. Insight/planning/observation types are irrelevant
+    # for vote tallying and account for >99% of thought ConfigMaps.
     kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
-        | jq '[.items[] | {
+        | jq '[.items[] | select(.data.thoughtType == "proposal" or .data.thoughtType == "vote") | {
             agent: (.data.agentRef // "unknown"),
             content: (.data.content // ""),
             type: (.data.thoughtType // ""),
@@ -783,8 +786,10 @@ track_debate_activity() {
     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
     # Issue #1011: Use label selector -l agentex/thought to avoid fetching all 9000+ configmaps
     # (causes OOM kill — coordinator only has 512Mi limit)
+    # Issue #1056: Filter to only debate type thoughts — this function only needs debate thoughts
+    # for counting responses, threads, and disagreements.
     all_cm=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
-        | jq '[.items[] | {
+        | jq '[.items[] | select(.data.thoughtType == "debate") | {
             name: .metadata.name,
             type: (.data.thoughtType // ""),
             parent: (.data.parentRef // ""),


### PR DESCRIPTION
## Summary

- Filter `tally_and_enact_votes()` to only load `proposal` and `vote` type thoughts, reducing loaded data from 1800+ to <50 items
- Filter `track_debate_activity()` to only load `debate` type thoughts since that function only needs debate data
- Both changes reduce coordinator memory usage by ~97%, eliminating OOM kills

## Root Cause

`tally_and_enact_votes()` loaded ALL thought ConfigMaps matching `agentex/thought` label (1800+ items) but only processed `proposal` and `vote` types. The remaining 99%+ were insight/planning/observation types that were immediately discarded after loading.

## Changes

`images/runner/coordinator.sh`:
- `tally_and_enact_votes()`: Add `select(.data.thoughtType == "proposal" or .data.thoughtType == "vote")` before field extraction
- `track_debate_activity()`: Add `select(.data.thoughtType == "debate")` since this function only counts debate thoughts

## Testing

The `select()` filter is applied before field projection, so all downstream logic that processes proposals and votes remains unchanged. The filter simply prevents loading irrelevant thoughts.

Closes #1056