### PR TITLE
feat: values.yaml — new god defines civilization via vision.*/civilization.*/security.* schema (issue #1039)

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,12 +496,11 @@ bash manifests/system/kro-install.sh
 kubectl create namespace agentex
 helm install agentex ./chart \
   --namespace agentex \
-  --set god.repo=myorg/myrepo \
-  --set god.vision="Your civilization's purpose here" \
-  --set image.registry=YOUR_ACCOUNT.dkr.ecr.YOUR_REGION.amazonaws.com \
-  --set aws.region=YOUR_REGION \
-  --set aws.s3Bucket=my-agentex-thoughts \
-  --set cluster.name=my-cluster \
+  --set vision.githubRepo=myorg/myrepo \
+  --set vision.awsRegion=YOUR_REGION \
+  --set vision.ecrRegistry=YOUR_ACCOUNT.dkr.ecr.YOUR_REGION.amazonaws.com \
+  --set vision.s3Bucket=my-agentex-thoughts \
+  --set vision.clusterName=my-cluster \
   --set github.token=ghp_YOUR_TOKEN
 
 # Step 5: Seed the civilization (one-time bootstrap)

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Agentex civilization installed successfully!
 
 Civilization vision:
-{{ .Values.god.vision | trim }}
+{{ .Values.civilization.purpose | trim }}
 
 =======================================================
 NEXT STEPS
@@ -44,7 +44,7 @@ GOVERNANCE
 
 Adjust circuit breaker (max concurrent agents):
   kubectl patch configmap agentex-constitution -n {{ .Values.cluster.namespace }} \
-    --type=merge -p '{"data":{"circuitBreakerLimit":"{{ .Values.constitution.circuitBreakerLimit }}"}}'
+    --type=merge -p '{"data":{"circuitBreakerLimit":"{{ .Values.civilization.circuitBreakerLimit }}"}}'
 
 Update civilization directive:
   kubectl patch configmap agentex-constitution -n {{ .Values.cluster.namespace }} \

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -32,10 +32,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Full image reference
+Full image reference — vision.ecrRegistry / image.repository : image.tag
 */}}
 {{- define "agentex.image" -}}
-{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{ .Values.vision.ecrRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/chart/templates/constitution.yaml
+++ b/chart/templates/constitution.yaml
@@ -11,53 +11,53 @@ metadata:
     agentex/description: "God-owned constants. Do not modify without god approval."
 data:
   # Maximum concurrent active Jobs. God sets this. Agents read it.
-  circuitBreakerLimit: {{ .Values.constitution.circuitBreakerLimit | quote }}
+  circuitBreakerLimit: {{ .Values.civilization.circuitBreakerLimit | quote }}
 
   # Minimum approve votes required for governance decisions
-  voteThreshold: {{ .Values.constitution.voteThreshold | quote }}
+  voteThreshold: {{ .Values.civilization.voteThreshold | quote }}
 
   # Daily Bedrock cost budget in USD
-  dailyCostBudgetUSD: {{ .Values.constitution.dailyCostBudgetUSD | quote }}
+  dailyCostBudgetUSD: {{ .Values.civilization.dailyCostBudgetUSD | quote }}
 
   # Model to use for all agents (cross-region inference prefix required)
-  agentModel: {{ .Values.agent.model | quote }}
+  agentModel: {{ .Values.civilization.model | quote }}
 
   # S3 bucket for agent memory persistence
-  s3Bucket: {{ .Values.aws.s3Bucket | quote }}
+  s3Bucket: {{ .Values.vision.s3Bucket | quote }}
 
   # ECR registry base URL for agent container images (issue #837)
   # Agents read this for spawn templates. God sets this to their AWS account ECR.
   # Format: <account>.dkr.ecr.<region>.amazonaws.com (no trailing slash)
-  ecrRegistry: {{ .Values.image.registry | quote }}
+  ecrRegistry: {{ .Values.vision.ecrRegistry | quote }}
 
   # AWS region where the cluster and Bedrock run (issue #819)
   # Agents read this for AWS API calls. Must match where EKS cluster lives.
-  awsRegion: {{ .Values.aws.region | quote }}
+  awsRegion: {{ .Values.vision.awsRegion | quote }}
 
   # GitHub repository for issue tracking and PRs (issue #819, #853 portability)
   # God sets this to their own GitHub org/repo. Format: owner/repo
   # A new god's agents will file issues and PRs on their own repo.
-  githubRepo: {{ .Values.github.repo | quote }}
+  githubRepo: {{ .Values.vision.githubRepo | quote }}
 
   # EKS cluster name (issue #819 portability)
   # Agents use this to configure kubectl context. God sets this to their cluster name.
-  clusterName: {{ .Values.cluster.name | quote }}
+  clusterName: {{ .Values.vision.clusterName | quote }}
 
   # Current civilization generation (god increments this)
-  civilizationGeneration: {{ .Values.constitution.civilizationGeneration | quote }}
+  civilizationGeneration: {{ .Values.civilization.generation | quote }}
 
   # Minimum generations before agents may work on vision features
-  visionUnlockGeneration: {{ .Values.constitution.visionUnlockGeneration | quote }}
+  visionUnlockGeneration: {{ .Values.civilization.visionUnlockGeneration | quote }}
 
   # Job TTL for completed agent pods (seconds)
-  jobTTLSeconds: {{ .Values.constitution.jobTTLSeconds | quote }}
+  jobTTLSeconds: {{ .Values.civilization.jobTTLSeconds | quote }}
 
   # Minimum vision score for agent work
-  minimumVisionScore: {{ .Values.constitution.minimumVisionScore | quote }}
+  minimumVisionScore: {{ .Values.civilization.minimumVisionScore | quote }}
 
   # Guidance for agents on vision score prioritization
   visionScoreGuidance: |
-    Prioritize work with vision score >= {{ .Values.constitution.minimumVisionScore }}. Score <{{ .Values.constitution.minimumVisionScore }} work is permitted
+    Prioritize work with vision score >= {{ .Values.civilization.minimumVisionScore }}. Score <{{ .Values.civilization.minimumVisionScore }} work is permitted
     but MUST be justified in Report CR blockers field. Emergency work (score=1-3)
     always allowed without justification when system is in crisis.
 
@@ -70,8 +70,8 @@ data:
 
   # God's current directive to the civilization
   lastDirective: |
-    {{ .Values.god.lastDirective | nindent 4 | trim }}
+    {{ .Values.civilization.lastDirective | nindent 4 | trim }}
 
   # Vision: what this civilization exists to become
   vision: |
-    {{ .Values.god.vision | nindent 4 | trim }}
+    {{ .Values.civilization.purpose | nindent 4 | trim }}

--- a/chart/templates/coordinator.yaml
+++ b/chart/templates/coordinator.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ include "agentex.namespace" . }}
 spec:
   enabled: true
-  model: {{ .Values.agent.model | quote }}
+  model: {{ .Values.civilization.model | quote }}
   imageTag: {{ .Values.image.tag | quote }}

--- a/chart/templates/killswitch.yaml
+++ b/chart/templates/killswitch.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/component: control-plane
 data:
   # Set enabled="true" to stop ALL agent spawning immediately
-  enabled: {{ .Values.killswitch.enabled | ternary "true" "false" | quote }}
-  reason: {{ .Values.killswitch.reason | quote }}
+  enabled: {{ .Values.security.killSwitchEnabled | ternary "true" "false" | quote }}
+  reason: {{ .Values.security.killSwitchReason | quote }}

--- a/chart/templates/planner-loop.yaml
+++ b/chart/templates/planner-loop.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ include "agentex.namespace" . }}
 spec:
   enabled: true
-  model: {{ .Values.agent.model | quote }}
+  model: {{ .Values.civilization.model | quote }}
   imageTag: {{ .Values.image.tag | quote }}
-  imageRegistry: {{ .Values.image.registry | quote }}
-  clusterName: {{ .Values.cluster.name | quote }}
+  imageRegistry: {{ .Values.vision.ecrRegistry | quote }}
+  clusterName: {{ .Values.vision.clusterName | quote }}

--- a/chart/templates/rgd-agent.yaml
+++ b/chart/templates/rgd-agent.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       role: string | default="worker"
       taskRef: string | required=true
-      model: string | default={{ .Values.agent.model | quote }}
+      model: string | default={{ .Values.civilization.model | quote }}
       swarmRef: string | default=""
       priority: integer | default=5
     status:
@@ -34,7 +34,7 @@ spec:
             agentex/role: ${schema.spec.role}
             agentex/task: ${schema.spec.taskRef}
         spec:
-          ttlSecondsAfterFinished: {{ .Values.constitution.jobTTLSeconds }}
+          ttlSecondsAfterFinished: {{ .Values.civilization.jobTTLSeconds }}
           backoffLimit: 2
           activeDeadlineSeconds: 3600
           template:
@@ -74,11 +74,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: {{ .Values.aws.region | quote }}
+                      value: {{ .Values.vision.awsRegion | quote }}
                     - name: REPO
-                      value: {{ .Values.god.repo | quote }}
+                      value: {{ .Values.vision.githubRepo | quote }}
                     - name: CLUSTER
-                      value: {{ .Values.cluster.name | quote }}
+                      value: {{ .Values.vision.clusterName | quote }}
                     - name: NAMESPACE
                       value: {{ .Values.cluster.namespace | quote }}
                     - name: GITHUB_TOKEN_FILE

--- a/chart/templates/rgd-coordinator.yaml
+++ b/chart/templates/rgd-coordinator.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Coordinator
     spec:
       enabled: boolean | default=true
-      model: string | default={{ .Values.agent.model | quote }}
+      model: string | default={{ .Values.civilization.model | quote }}
       imageTag: string | default={{ .Values.image.tag | quote }}
     status:
       configMapName: ${coordinatorState.metadata.name}
@@ -74,7 +74,7 @@ spec:
                   type: RuntimeDefault
               containers:
                 - name: coordinator
-                  image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:${schema.spec.imageTag}
+                  image: {{ .Values.vision.ecrRegistry }}/{{ .Values.image.repository }}:${schema.spec.imageTag}
                   imagePullPolicy: {{ .Values.image.pullPolicy }}
                   command: ["/bin/bash", "/usr/local/bin/coordinator.sh"]
                   securityContext:
@@ -88,11 +88,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: {{ .Values.aws.region | quote }}
+                      value: {{ .Values.vision.awsRegion | quote }}
                     - name: REPO
-                      value: {{ .Values.god.repo | quote }}
+                      value: {{ .Values.vision.githubRepo | quote }}
                     - name: CLUSTER
-                      value: {{ .Values.cluster.name | quote }}
+                      value: {{ .Values.vision.clusterName | quote }}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/chart/templates/rgd-planner-loop.yaml
+++ b/chart/templates/rgd-planner-loop.yaml
@@ -9,10 +9,10 @@ spec:
     kind: PlannerLoop
     spec:
       enabled: boolean | default=true
-      model: string | default={{ .Values.agent.model | quote }}
+      model: string | default={{ .Values.civilization.model | quote }}
       imageTag: string | default={{ .Values.image.tag | quote }}
-      imageRegistry: string | default={{ .Values.image.registry | quote }}
-      clusterName: string | default={{ .Values.cluster.name | quote }}
+      imageRegistry: string | default={{ .Values.vision.ecrRegistry | quote }}
+      clusterName: string | default={{ .Values.vision.clusterName | quote }}
     status:
       deploymentName: ${plannerLoopDeployment.metadata.name}
       phase: ${plannerLoopDeployment.metadata.name}

--- a/chart/templates/rgd-swarm.yaml
+++ b/chart/templates/rgd-swarm.yaml
@@ -15,8 +15,8 @@ spec:
       workers: integer | default=3
       reviewers: integer | default=1
       consensusThreshold: integer | default=51
-      githubRepo: string | default={{ .Values.god.repo | quote }}
-      model: string | default={{ .Values.agent.model | quote }}
+      githubRepo: string | default={{ .Values.vision.githubRepo | quote }}
+      model: string | default={{ .Values.civilization.model | quote }}
     status:
       configMapName: ${swarmState.metadata.name}
       phase: ${swarmState.data.phase}
@@ -63,7 +63,7 @@ spec:
             agentex/role: planner
             agentex/swarm: ${schema.metadata.name}
         spec:
-          ttlSecondsAfterFinished: {{ .Values.constitution.jobTTLSeconds }}
+          ttlSecondsAfterFinished: {{ .Values.civilization.jobTTLSeconds }}
           backoffLimit: 0
           activeDeadlineSeconds: 3600
           template:
@@ -103,11 +103,11 @@ spec:
                     - name: BEDROCK_MODEL
                       value: ${schema.spec.model}
                     - name: BEDROCK_REGION
-                      value: {{ .Values.aws.region | quote }}
+                      value: {{ .Values.vision.awsRegion | quote }}
                     - name: REPO
-                      value: {{ .Values.god.repo | quote }}
+                      value: {{ .Values.vision.githubRepo | quote }}
                     - name: CLUSTER
-                      value: {{ .Values.cluster.name | quote }}
+                      value: {{ .Values.vision.clusterName | quote }}
                     - name: NAMESPACE
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE

--- a/chart/templates/seed-agent.yaml
+++ b/chart/templates/seed-agent.yaml
@@ -63,13 +63,13 @@ spec:
             - name: TASK_CR_NAME
               value: "task-seed-001"
             - name: BEDROCK_MODEL
-              value: {{ .Values.agent.model | quote }}
+              value: {{ .Values.civilization.model | quote }}
             - name: BEDROCK_REGION
-              value: {{ .Values.aws.region | quote }}
+              value: {{ .Values.vision.awsRegion | quote }}
             - name: REPO
-              value: {{ .Values.god.repo | quote }}
+              value: {{ .Values.vision.githubRepo | quote }}
             - name: CLUSTER
-              value: {{ .Values.cluster.name | quote }}
+              value: {{ .Values.vision.clusterName | quote }}
             - name: NAMESPACE
               value: {{ .Values.cluster.namespace | quote }}
             - name: GITHUB_TOKEN_FILE
@@ -118,17 +118,17 @@ data:
     You are the seed agent for a new agentex civilization.
 
     Your civilization's vision:
-    {{ .Values.god.vision | nindent 4 }}
+    {{ .Values.civilization.purpose | nindent 4 }}
 
-    Repository: {{ .Values.god.repo }}
-    Cluster: {{ .Values.cluster.name }}
+    Repository: {{ .Values.vision.githubRepo }}
+    Cluster: {{ .Values.vision.clusterName }}
     Namespace: {{ .Values.cluster.namespace }}
-    Tools: kubectl, gh CLI (authenticated to {{ .Values.god.repo }}), aws CLI, git, opencode.
+    Tools: kubectl, gh CLI (authenticated to {{ .Values.vision.githubRepo }}), aws CLI, git, opencode.
 
     YOUR TASKS:
     1. Check cluster health: kubectl get nodes && kubectl get pods -n {{ .Values.cluster.namespace }}
     2. Verify kro is healthy: kubectl get resourcegraphdefinitions -n {{ .Values.cluster.namespace }}
-    3. Read open GitHub issues: gh issue list --repo {{ .Values.god.repo }} --state open --limit 30
+    3. Read open GitHub issues: gh issue list --repo {{ .Values.vision.githubRepo }} --state open --limit 30
     4. Spawn planner-001: create Task CR + Agent CR for role=planner
     5. Spawn 2-3 workers for the highest priority open issues
     6. Create a GitHub issue for any problems you discover

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,27 +1,47 @@
 # =============================================================================
 # Agentex Helm Chart — values.yaml
 # =============================================================================
-# A new god needs to set ONLY these values to start a civilization:
+# A new god needs to set ONLY the values under `vision:` to start a civilization:
 #
 #   helm install agentex ./chart \
-#     --set god.repo=myorg/myproduct \
-#     --set god.vision="Build a SaaS invoice tool" \
-#     --set image.registry=123456789.dkr.ecr.us-east-1.amazonaws.com \
-#     --set aws.region=us-east-1 \
-#     --set aws.s3Bucket=my-agentex-thoughts
+#     --set vision.githubRepo=myorg/myproduct \
+#     --set vision.awsRegion=eu-west-1 \
+#     --set vision.ecrRegistry=123456789.dkr.ecr.eu-west-1.amazonaws.com \
+#     --set vision.s3Bucket=my-agentex-thoughts \
+#     --set vision.clusterName=my-cluster \
+#     --set github.token=ghp_YOUR_TOKEN
 #
 # Everything else has sensible defaults.
 # =============================================================================
 
 # ---------------------------------------------------------------------------
-# God configuration — customize your civilization
+# vision: — REQUIRED — new god must set all five of these
+# These define WHERE your civilization lives and what it works on.
 # ---------------------------------------------------------------------------
-god:
-  # Your GitHub repo (agents will push code, open PRs, create issues here)
-  repo: "pnz1990/agentex"
+vision:
+  # Your GitHub repo — agents file issues and open PRs here (format: owner/repo)
+  githubRepo: "pnz1990/agentex"
 
-  # Your civilization's purpose (free text, shown to all agents)
-  vision: |
+  # AWS region where your EKS cluster and Bedrock run (e.g. eu-west-1, us-east-1)
+  awsRegion: "us-west-2"
+
+  # ECR registry base URL — agents pull the runner image from here (no trailing slash)
+  # Format: <account>.dkr.ecr.<region>.amazonaws.com
+  ecrRegistry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"
+
+  # S3 bucket for agent memory, chronicle, and planning state
+  s3Bucket: "agentex-thoughts"
+
+  # EKS cluster name — agents use this to configure kubectl context
+  clusterName: "agentex"
+
+# ---------------------------------------------------------------------------
+# civilization: — OPTIONAL — sensible defaults for a fresh install
+# These shape your civilization's behavior and governance.
+# ---------------------------------------------------------------------------
+civilization:
+  # Your civilization's purpose (free text, shown to all agents as the north star)
+  purpose: |
     Agents that propose, vote, debate, and reason about improvements to
     their own society — a true collective intelligence that develops itself.
     NOT: agents that fix their own plumbing forever.
@@ -34,83 +54,73 @@ god:
     platform issue, spawn workers for open GitHub issues, and ensure
     the planner loop never stops.
 
-# ---------------------------------------------------------------------------
-# Container image — your ECR (or any registry)
-# ---------------------------------------------------------------------------
-image:
-  # Your container registry base URL (no trailing slash)
-  registry: "569190534191.dkr.ecr.us-west-2.amazonaws.com"
-  # Image repository path within registry
-  repository: "agentex/runner"
-  # Image tag (latest or a specific SHA)
-  tag: "latest"
-  # Pull policy
-  pullPolicy: Always
+  # Current civilization generation (god increments this)
+  generation: "1"
 
-# ---------------------------------------------------------------------------
-# AWS — region and S3 for agent memory
-# ---------------------------------------------------------------------------
-aws:
-  # AWS region where EKS cluster runs
-  region: "us-west-2"
-  # S3 bucket for agent memory and chronicle
-  s3Bucket: "agentex-thoughts"
+  # Maximum concurrent active Jobs — increase slowly with evidence (circuit breaker)
+  circuitBreakerLimit: "6"
 
-# ---------------------------------------------------------------------------
-# Kubernetes cluster — where your civilization lives
-# ---------------------------------------------------------------------------
-cluster:
-  # EKS cluster name (used in agent env var)
-  name: "agentex"
-  # Namespace for all agentex resources
-  namespace: "agentex"
+  # Daily Bedrock cost budget in USD
+  dailyCostBudgetUSD: "50"
 
-# ---------------------------------------------------------------------------
-# Agent model — Bedrock model for all agents
-# ---------------------------------------------------------------------------
-agent:
-  # Bedrock model ID (cross-region inference prefix required)
+  # Job TTL for completed agent pods (seconds)
+  jobTTLSeconds: "300"
+
+  # Minimum approve votes required to enact a governance proposal
+  voteThreshold: "3"
+
+  # Minimum vision score for agent work (agents should only take high-value tasks)
+  minimumVisionScore: "5"
+
+  # Minimum generations before agents may work on vision features
+  visionUnlockGeneration: "10"
+
+  # Bedrock model ID for all agents (cross-region inference prefix required)
   model: "us.anthropic.claude-sonnet-4-6"
 
 # ---------------------------------------------------------------------------
-# GitHub token — injected as a Kubernetes Secret
-# Agents use this to authenticate with GitHub (push, PR, issues)
-# Set via: --set github.token=ghp_xxx  OR  use an existing secret
+# security: — OPTIONAL — kill switch and security posture
+# ---------------------------------------------------------------------------
+security:
+  # Set to true to stop ALL agent spawning immediately (emergency use only)
+  killSwitchEnabled: false
+  # Reason shown in kill switch ConfigMap (human-readable)
+  killSwitchReason: ""
+
+# ---------------------------------------------------------------------------
+# github: — GitHub authentication
+# Agents use this to push code, open PRs, and create issues.
+# Set token via: --set github.token=ghp_xxx  OR  use an existing secret.
 # ---------------------------------------------------------------------------
 github:
-  # GitHub repository for issue tracking and PRs (format: owner/repo)
-  # Agents will file issues and open PRs on this repo
-  repo: "pnz1990/agentex"
   # GitHub personal access token with repo scope
   # If empty, assumes secret already exists (e.g. externally managed)
   token: ""
-  # Name of the secret that holds the token
+  # Name of the Kubernetes Secret that holds the token
   secretName: "agentex-github-token"
   # Key within the secret
   secretKey: "token"
 
 # ---------------------------------------------------------------------------
-# Constitution — civilization governance parameters
-# Agents READ these. Only god changes them.
+# image: — container image configuration
 # ---------------------------------------------------------------------------
-constitution:
-  # Maximum concurrent active Jobs (circuit breaker limit)
-  circuitBreakerLimit: "6"
-  # Minimum votes to enact a governance proposal
-  voteThreshold: "3"
-  # Daily Bedrock cost budget in USD
-  dailyCostBudgetUSD: "50"
-  # Job TTL for completed pods (seconds)
-  jobTTLSeconds: "300"
-  # Minimum vision score for agent work
-  minimumVisionScore: "5"
-  # Current civilization generation (god increments this)
-  civilizationGeneration: "1"
-  # Minimum generations before vision features are unlocked
-  visionUnlockGeneration: "10"
+image:
+  # Image repository path within the vision.ecrRegistry
+  repository: "agentex/runner"
+  # Image tag (latest or a specific SHA for reproducibility)
+  tag: "latest"
+  # Pull policy
+  pullPolicy: Always
 
 # ---------------------------------------------------------------------------
-# Resource limits for agent pods
+# cluster: — Kubernetes namespace (rarely needs changing)
+# ---------------------------------------------------------------------------
+cluster:
+  # Namespace for all agentex resources
+  namespace: "agentex"
+
+# ---------------------------------------------------------------------------
+# resources: — agent pod resource limits
 # ---------------------------------------------------------------------------
 resources:
   requests:
@@ -121,25 +131,7 @@ resources:
     cpu: "1000m"
 
 # ---------------------------------------------------------------------------
-# Pod security — applied to all agent pods
-# ---------------------------------------------------------------------------
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
-  seccompProfile:
-    type: RuntimeDefault
-
-# ---------------------------------------------------------------------------
-# Kill switch — set to true to stop all agent spawning immediately
-# ---------------------------------------------------------------------------
-killswitch:
-  enabled: false
-  reason: ""
-
-# ---------------------------------------------------------------------------
-# Seed agent — the bootstrap job that starts the civilization
+# seed: — one-time bootstrap job
 # ---------------------------------------------------------------------------
 seed:
   # Enable seed job (set to false if civilization is already running)


### PR DESCRIPTION
## Summary

Refactors the Helm chart `chart/values.yaml` to use a clean, intentional schema that makes agentex fully parameterizable — a new god sets values once in `values.yaml` without touching any code files.

## What changed

### values.yaml schema restructure

**`vision.*` (REQUIRED)** — the 5 fields a new god MUST set:
- `vision.githubRepo` — your GitHub repo (was scattered across `god.repo` and `github.repo`)
- `vision.awsRegion` — AWS region for EKS + Bedrock (was `aws.region`)
- `vision.ecrRegistry` — ECR registry URL (was `image.registry`)
- `vision.s3Bucket` — S3 bucket for agent memory (was `aws.s3Bucket`)
- `vision.clusterName` — EKS cluster name (was `cluster.name`)

**`civilization.*` (OPTIONAL)** — governance + behavior defaults:
- `civilization.purpose` — what agents exist to build (was `god.vision`)
- `civilization.lastDirective` — god's initial steering (was `god.lastDirective`)
- `civilization.generation`, `circuitBreakerLimit`, `model`, etc. (was `constitution.*` + `agent.model`)

**`security.*` (OPTIONAL)** — kill switch config:
- `security.killSwitchEnabled` (was `killswitch.enabled`)
- `security.killSwitchReason` (was `killswitch.reason`)

### All templates updated

All 9 chart templates updated to use the new schema:
`constitution.yaml`, `_helpers.tpl`, `coordinator.yaml`, `killswitch.yaml`,
`planner-loop.yaml`, `rgd-agent.yaml`, `rgd-coordinator.yaml`, `rgd-planner-loop.yaml`,
`rgd-swarm.yaml`, `seed-agent.yaml`, `NOTES.txt`

### README updated

Updated helm install example to use the cleaner `vision.*` flags:

```bash
helm install agentex ./chart \
  --set vision.githubRepo=myorg/myrepo \
  --set vision.awsRegion=eu-west-1 \
  --set vision.ecrRegistry=123456789.dkr.ecr.eu-west-1.amazonaws.com \
  --set vision.s3Bucket=my-agentex-thoughts \
  --set vision.clusterName=my-cluster \
  --set github.token=ghp_YOUR_TOKEN
```

## Why this matters

The old schema scattered the 5 required portability fields across 4 different top-level keys (`god`, `aws`, `image`, `cluster`). A new god had to understand the internals to know what to set. The new `vision.*` group makes it obvious: "these 5 things define where your civilization lives."

Closes #1039