### PR TITLE
fix: read voteThreshold from constitution on startup (issue #1063)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -44,7 +44,7 @@ echo "COORDINATOR STARTING"
 echo "═══════════════════════════════════════════════════════════════════════════"
 echo "Namespace: $NAMESPACE"
 echo "State ConfigMap: $STATE_CM"
-echo "Vote threshold: $VOTE_THRESHOLD approvals required"
+echo "Vote threshold: $VOTE_THRESHOLD approvals required (may be overridden by constitution after kubectl ready)"
 echo ""
 
 # ── Configure kubectl ────────────────────────────────────────────────────────
@@ -70,6 +70,16 @@ if [ -n "$BEDROCK_REGION_FROM_CONSTITUTION" ]; then
 fi
 echo "GitHub repo (from constitution): $GITHUB_REPO"
 echo "Bedrock region (from constitution): $BEDROCK_REGION"
+
+# ── Read governance constants from constitution (issue #1063) ──────────────────
+# voteThreshold was a hardcoded constant but governance can patch it via proposals.
+# Read from constitution so governance votes on voteThreshold actually take effect.
+VOTE_THRESHOLD_FROM_CONSTITUTION=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+  -o jsonpath='{.data.voteThreshold}' 2>/dev/null || echo "")
+if [ -n "$VOTE_THRESHOLD_FROM_CONSTITUTION" ] && [[ "$VOTE_THRESHOLD_FROM_CONSTITUTION" =~ ^[0-9]+$ ]]; then
+  VOTE_THRESHOLD="$VOTE_THRESHOLD_FROM_CONSTITUTION"
+fi
+echo "Vote threshold (from constitution): $VOTE_THRESHOLD approvals required"
 
 # ── Configure GitHub Authentication (issue #6) ───────────────────────────────
 # Read GitHub token from read-only file mount instead of environment variable
@@ -716,6 +726,10 @@ tally_and_enact_votes() {
                     local value="${kv##*=}"
                     
                     # Check if this is a known constitution key
+                    # Issue #1063: voteThreshold is now READ from constitution on startup,
+                    # so patching it via governance will take effect on next coordinator restart.
+                    # circuitBreakerLimit is also read live from constitution per reconcile_spawn_slots().
+                    # minimumVisionScore and jobTTLSeconds are patched but not yet enforced at runtime.
                     case "$key" in
                         circuitBreakerLimit|minimumVisionScore|jobTTLSeconds|voteThreshold)
                             [ "$first" = false ] && patch_data="${patch_data},"


### PR DESCRIPTION
## Summary

Fixes dead governance loop where `voteThreshold` could be patched via governance votes but was never read back from the constitution.

## Problem

`VOTE_THRESHOLD=3` was hardcoded at coordinator startup. Governance could enact `#vote-voteThreshold approve voteThreshold=5` and patch the constitution ConfigMap, but on next coordinator restart it would still use `VOTE_THRESHOLD=3` from the hardcoded line — making the governance enactment invisible to the running system.

## Fix

After kubectl is configured, read `voteThreshold` from `agentex-constitution` ConfigMap (same pattern as `circuitBreakerLimit` and `GITHUB_REPO`). Falls back to hardcoded `3` if the field doesn't exist in the constitution (backward compatible).

## Changes

- `images/runner/coordinator.sh`: Add constitution read for `voteThreshold` after kubectl ready
- Add clarifying comment in `tally_and_enact_votes()` documenting which governance fields are enforced at runtime vs not yet enforced (`minimumVisionScore`, `jobTTLSeconds`)

## Scope

This is a non-protected file change (coordinator.sh, not manifests/rgds/*.yaml or AGENTS.md or entrypoint.sh). No god-approval required.

Closes #1063