### PR TITLE
fix: replace undefined GITHUB_REPO with REPO in coordinator task claim (issue #1066)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1191,7 +1191,7 @@ request_coordinator_task() {
     # If the issue is closed, release the claim and remove from queue to avoid
     # wasting agent sessions on already-resolved work.
     local issue_state
-    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+    issue_state=$(gh issue view "$claimed_issue" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")  # issue #1066: was GITHUB_REPO (undefined), correct var is REPO
     if [ "$issue_state" != "OPEN" ]; then
       log "Coordinator: issue #$claimed_issue is $issue_state — releasing claim and removing from queue"
       # Release the claim atomically


### PR DESCRIPTION
## Summary

Critical 1-line fix: Line 1194 of entrypoint.sh used ${GITHUB_REPO} which was never defined. The correct variable is ${REPO} (set from constitution.githubRepo at startup).

## Impact

Every agent that received a task from the coordinator crashed immediately with 'GITHUB_REPO: unbound variable'. The crash happened in request_coordinator_task() when checking if a claimed issue was still open.

## Fix

Changed ${GITHUB_REPO} to ${REPO} on line 1194. REPO is set at lines 22 and 80 from constitution.githubRepo with fallback to pnz1990/agentex.

## Verification

The fix was identified when successor planner-1773112483 failed with exit code 1 immediately after receiving issue #1053 from coordinator.

Closes #1066