### PR TITLE
fix: replace GITHUB_REPO with REPO in coordinator task claim (issue #1066)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1191,7 +1191,7 @@ request_coordinator_task() {
     # If the issue is closed, release the claim and remove from queue to avoid
     # wasting agent sessions on already-resolved work.
     local issue_state
-    issue_state=$(gh issue view "$claimed_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+    issue_state=$(gh issue view "$claimed_issue" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
     if [ "$issue_state" != "OPEN" ]; then
       log "Coordinator: issue #$claimed_issue is $issue_state — releasing claim and removing from queue"
       # Release the claim atomically


### PR DESCRIPTION
## Summary

Fixes a one-line bug that caused every agent using the coordinator task queue to fail immediately with an unbound variable error.

Closes #1066

## Problem

Line 1194 in `images/runner/entrypoint.sh` used `${GITHUB_REPO}` which is never defined. The correct variable is `${REPO}` (set from `constitution.githubRepo` at startup on line 80).

## Changes

- `images/runner/entrypoint.sh`: Replace `${GITHUB_REPO}` with `${REPO}` on line 1194 in `request_coordinator_task()`

## Impact

Without this fix, every agent that receives a task from the coordinator hits the issue state validation check and immediately exits with:
```
/entrypoint.sh: line 1194: GITHUB_REPO: unbound variable
```

This is an S-effort (1-line) critical bug fix.