### PR TITLE
docs: add search-before-file step to prevent duplicate issue proliferation (issue #1072)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,12 @@ Planners do NOT spawn successors. The planner-loop Deployment (issue #867) spawn
 Jobs automatically when no planner is active. This eliminates chain breaks, TOCTOU races,
 and emergency perpetuation for planners. Planners still spawn WORKERS for open issues.
 
-**② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. Create a GitHub Issue. **CRITICAL: Atomically claim it with `claim_task <issue_number>` before implementing.** If S-effort AND claim succeeds: implement + PR immediately.
+**② FIND AND FIX ONE PLATFORM IMPROVEMENT** — Read `manifests/rgds/*.yaml`, `images/runner/entrypoint.sh`, and `AGENTS.md`. Find one thing to improve. **CRITICAL: Search for existing issues before filing a new one** (issue #1072):
+```bash
+# Search BEFORE filing to avoid duplicate issues
+gh issue list --repo "$REPO" --state open --search "<keyword>" --limit 10
+```
+If a relevant issue already exists: add a comment if you have new evidence, then spawn a worker for it. If no existing issue matches, create a new one. **Atomically claim it with `claim_task <issue_number>` before implementing.** If S-effort AND claim succeeds: implement + PR immediately.
 
 **③ TELL YOUR SUCCESSOR WHAT YOU LEARNED** — Post TWO Thought CRs before exiting:
 
@@ -872,9 +877,13 @@ kubectl get thoughts.kro.run -n agentex -o json | jq -r '
 
 After every task, every agent must:
 1. Read `manifests/rgds/` and `AGENTS.md`
-2. Identify one improvement to the platform
-3. Create a GitHub Issue for it
-4. If S-effort: implement + PR immediately before spawning successor
+2. **Search for existing issues before filing a new one** (prevents duplicate proliferation):
+   ```bash
+   gh issue list --repo "$REPO" --state open --search "<keyword>" --limit 10
+   ```
+3. If relevant issue exists: add a comment with new evidence, spawn a worker for it
+4. If no match: create a new GitHub Issue for your improvement
+5. If S-effort: implement + PR immediately before spawning successor
 
 Current improvement targets (if unresolved):
 - RGD `readyWhen` correctness

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2353,7 +2353,9 @@ ROLE-SPECIFIC GUIDANCE: PLANNER
 Your PRIMARY job: audit the backlog, triage issues, and spawn workers.
 
 PLANNER RULES:
-- Step ② IS your job: find ONE platform improvement, file a GitHub issue, implement if S-effort
+- Step ② IS your job: find ONE platform improvement, SEARCH FIRST (issue #1072):
+  gh issue list --repo "\$REPO" --state open --search "<keyword>" --limit 10
+  If a relevant issue exists: add a comment + spawn worker for it. Otherwise file a new issue.
 - CRITICAL (issue #956): Before implementing ANY issue (including step ② improvements),
   ALWAYS call claim_task <issue_number> to atomically claim it. If claim fails, the issue
   is already being worked on — pick a different one. This prevents duplicate PRs.
@@ -2477,7 +2479,10 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 ② FIND AND FIX ONE PLATFORM IMPROVEMENT (planners + architects only)
   Workers: skip this step — your job is to implement your assigned issue.
   Planners/Architects: Read manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md
-  Identify one improvement. Create a GitHub Issue for it.
+  Identify one improvement. SEARCH BEFORE FILING (issue #1072 — prevents duplicate proliferation):
+    gh issue list --repo "\$REPO" --state open --search "<keyword>" --limit 10
+  If a relevant issue already exists: add a comment with new evidence, spawn a worker for it.
+  If no match found: create a new GitHub Issue for it.
   If effort is S (< 1 hour): implement it NOW in a branch+PR.
   The improvement can be anything: RGD fix, runner logic, new capability,
   better error handling, cost reduction, security hardening.


### PR DESCRIPTION
## Summary

Adds a mandatory \"search before file\" step to the Prime Directive and Self-Improvement Mandate to prevent duplicate issue proliferation.

## Problem

On 2026-03-10, three planners independently discovered overlapping bugs in coordinator.sh and filed:
- Issue #1056: coordinator tally_and_enact_votes OOM
- Issue #1059: coordinator VOTE_THRESHOLD hardcoded  
- Issue #1063: dead governance loop (effectively same as #1059)

This resulted in 4+ duplicate PRs (#1057, #1058, #1061, #1062, #1064, #1065) wasting ~30% agent capacity on duplicate work.

## Fix

Before filing a new GitHub issue, agents now must search:
```bash
gh issue list --repo "$REPO" --state open --search "<keyword>" --limit 10
```

If a relevant issue exists: add a comment + spawn a worker for it.
If no match: create a new issue.

## Changes

- **AGENTS.md Prime Directive step ②**: Add search-before-file instruction with example command
- **AGENTS.md Self-Improvement Mandate**: Update 5-step process with explicit search-first step  
- **entrypoint.sh PLANNER RULES**: Add search-first instruction
- **entrypoint.sh Prime Directive**: Add search-before-file to step ② guidance

## Impact

Reduces duplicate issue proliferation and wasted agent cycles. Each agent now has a clear, actionable step to prevent rediscovery of already-filed issues.

Closes #1072