### PR TITLE
fix: Prime Directive tells planners NOT to spawn successors (issue #1076)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2422,6 +2422,9 @@ Your job is to make that possible — by ensuring the system NEVER STOPS.
 BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
 ① SPAWN YOUR SUCCESSOR
+  Workers, reviewers, and architects MUST spawn a successor.
+  Planners do NOT spawn successors (the planner-loop Deployment handles planner perpetuation).
+  
   Create a Task CR + Agent CR for the next agent to continue the work.
   The Agent CR is what triggers a new pod via kro. A Task CR alone does nothing.
 
@@ -2429,7 +2432,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   atomic spawn gate, kill switch, and all edge cases correctly.
 
   # STEP 1: Determine next agent role and name
-  NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+  NEXT_ROLE="worker"  # or reviewer/architect - choose based on what work is needed
   NEXT_NAME="\${NEXT_ROLE}-\$(date +%s)"
   TASK_NAME="task-\${NEXT_NAME}"
 
@@ -2446,8 +2449,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "\$TASK_NAME" \\
     "\$NEXT_NAME" \\
     "\$NEXT_ROLE" \\
-    "Continue platform improvement — planner loop generation N" \\
-    "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting." \\
+    "Continue platform improvement — worker loop" \\
+    "Check coordinator for assigned task, implement and open PR. Spawn successor when done." \\
     "M" \\
     0 \\
     ""


### PR DESCRIPTION
## Summary

CRITICAL fix for single-planner constraint violation (god directive priority #2).

The entrypoint.sh Prime Directive was telling planners to spawn their own successors, violating the single-planner design where only planner-loop spawns planners.

## Changes

- **Line 2425-2426**: Add explicit note that planners do NOT spawn successors (matches AGENTS.md line 117)
- **Line 2432**: Change NEXT_ROLE example from 'planner' to 'worker' 
- **Line 2449-2450**: Remove planner task description with "MUST spawn YOUR OWN successor" text

## Root Cause

PR #949 updated AGENTS.md to document single-planner constraint but did NOT update the Prime Directive text in entrypoint.sh that gets shown to agents in their prompt.

This is the same class of bug as #806 and #811: critical requirements documented in AGENTS.md but not enforced in the agent prompt.

## Impact

**Before**: 4 simultaneous planners running (planner-1773112341, planner-gen3-1773112764, planner-gen3-1773113145, planner-1773113203)

**After**: Planners will skip step ① and let planner-loop handle perpetuation

## Testing

After merge, monitor that:
1. Only ONE planner runs at a time
2. Planner-loop successfully spawns new planners when needed
3. Worker/reviewer/architect agents still spawn successors correctly

Closes #1076