### PR TITLE
fix: update Prime Directive to prevent planners from spawning successors

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2353,6 +2353,9 @@ ROLE-SPECIFIC GUIDANCE: PLANNER
 Your PRIMARY job: audit the backlog, triage issues, and spawn workers.
 
 PLANNER RULES:
+- CRITICAL: Do NOT spawn a planner successor. The planner-loop Deployment handles planner
+  perpetuation automatically. Planners spawning planners violates the single-planner constraint
+  and causes exponential proliferation (issue #1076).
 - Step ② IS your job: find ONE platform improvement, SEARCH FIRST (issue #1072):
   gh issue list --repo "\$REPO" --state open --search "<keyword>" --limit 10
   If a relevant issue exists: add a comment + spawn worker for it. Otherwise file a new issue.
@@ -2422,6 +2425,10 @@ Your job is to make that possible — by ensuring the system NEVER STOPS.
 BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
 ① SPAWN YOUR SUCCESSOR
+  **PLANNERS: SKIP THIS STEP.** The planner-loop Deployment handles planner perpetuation.
+  Planners do NOT spawn planner successors — doing so violates the single-planner constraint.
+  Workers, reviewers, and architects MUST spawn a successor before exiting.
+
   Create a Task CR + Agent CR for the next agent to continue the work.
   The Agent CR is what triggers a new pod via kro. A Task CR alone does nothing.
 
@@ -2429,7 +2436,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   atomic spawn gate, kill switch, and all edge cases correctly.
 
   # STEP 1: Determine next agent role and name
-  NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+  NEXT_ROLE="worker"  # or reviewer/architect - choose based on what work is needed
+  # NOTE: Do NOT set NEXT_ROLE="planner" — the planner-loop Deployment handles planners
   NEXT_NAME="\${NEXT_ROLE}-\$(date +%s)"
   TASK_NAME="task-\${NEXT_NAME}"
 
@@ -2446,8 +2454,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "\$TASK_NAME" \\
     "\$NEXT_NAME" \\
     "\$NEXT_ROLE" \\
-    "Continue platform improvement — planner loop generation N" \\
-    "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting." \\
+    "Continue platform improvement — worker loop" \\
+    "Check coordinator for assigned task, implement and open PR. Spawn successor when done." \\
     "M" \\
     0 \\
     ""


### PR DESCRIPTION
## Summary

- The Prime Directive in entrypoint.sh was instructing planners to spawn their own successors, violating the single-planner constraint (PR #949)
- This caused 4+ simultaneous planners to run concurrently, defeating the planner-loop design
- Fixed by explicitly telling planners to skip step ①, changing the NEXT_ROLE example from 'planner' to 'worker', and adding a CRITICAL rule to the planner role context

## Changes

- Added `**PLANNERS: SKIP THIS STEP.**` warning to step ① of the Prime Directive
- Changed `NEXT_ROLE="planner"` default to `NEXT_ROLE="worker"` with comment explaining the planner-loop handles planners
- Updated spawn_task_and_agent example description to be worker-appropriate (removed "MUST spawn YOUR OWN successor before exiting")
- Added CRITICAL rule to PLANNER role context: "Do NOT spawn a planner successor. The planner-loop Deployment handles planner perpetuation automatically."

## Root Cause

PR #949 updated AGENTS.md to remove planner successor spawning but did NOT update the Prime Directive text in entrypoint.sh that gets injected into the agent prompt. This is the same class of bug as #806 and #811 (AGENTS.md vs entrypoint.sh desync).

## Impact

Before: Each planner reads "NEXT_ROLE=planner" and "MUST spawn YOUR OWN successor", spawning a new planner and causing exponential proliferation.

After: Planners explicitly skip step ① and are reminded the planner-loop handles their perpetuation.

Closes #1076