### PR TITLE
fix: remove hardcoded account/region from seed-prompt.sh and kro-install.sh

### DIFF
--- a/manifests/bootstrap/seed-prompt.sh
+++ b/manifests/bootstrap/seed-prompt.sh
@@ -10,8 +10,9 @@ agentex is a SELF-IMPROVING, SELF-REPLICATING distributed AI agent system.
 Its primary project is ITSELF. Agents develop the platform that runs them.
 The human does not want to manage this - your job is to make it self-sustaining.
 
-You are running on the agentex EKS cluster (us-west-2, account 569190534191).
-Tools: kubectl, gh CLI (authenticated to pnz1990/agentex), aws CLI, git, opencode.
+Your cluster, region, GitHub repo, and S3 bucket are configured in the agentex-constitution ConfigMap.
+Read them: kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data}'
+Tools: kubectl, gh CLI (authenticated to your GitHub repo), aws CLI, git, opencode.
 
 STEP 1 - Understand the system (read first)
 Read these files:
@@ -28,7 +29,8 @@ If any are not Active, check: kubectl describe resourcegraphdefinition NAME
 Fix and PR. kro v0.8.4 DSL: no group field, no quoted CEL expressions.
 
 STEP 3 - Read open issues, pick top 3
-Run: gh issue list --repo pnz1990/agentex --state open --limit 30
+First get your GitHub repo: REPO=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.githubRepo}')
+Run: gh issue list --repo "$REPO" --state open --limit 30
 
 For each of the top 3 issues, create a Task CR and an Agent CR.
 The Agent CR is what triggers a new pod via kro - a Task alone does nothing.

--- a/manifests/system/install-configure.sh
+++ b/manifests/system/install-configure.sh
@@ -59,6 +59,7 @@ while [[ $# -gt 0 ]]; do
       echo "  - manifests/system/constitution.yaml (ConfigMap data fields)"
       echo "  - manifests/bootstrap/seed-agent.yaml (image URL)"
       echo "  - manifests/system/constitution-validator.yaml (image URL)"
+      echo "  - manifests/system/kro-install.sh (CLUSTER and REGION defaults)"
       echo ""
       echo "Run this BEFORE applying manifests to your cluster."
       exit 0
@@ -109,6 +110,13 @@ echo "Updating manifests/system/constitution-validator.yaml..."
 sed -i.bak \
   "s|image: .*\.dkr\.ecr\..*\.amazonaws\.com/agentex/runner:latest|image: $ECR_REGISTRY/agentex/runner:latest|" \
   "$REPO_ROOT/manifests/system/constitution-validator.yaml"
+
+# Update kro-install.sh CLUSTER and REGION defaults (issue #1081)
+echo "Updating manifests/system/kro-install.sh..."
+sed -i.bak \
+  -e "s|CLUSTER=\"\${CLUSTER:-.*}\"|CLUSTER=\"\${CLUSTER:-$CLUSTER_NAME}\"|" \
+  -e "s|REGION=\"\${REGION:-.*}\"|REGION=\"\${REGION:-$AWS_REGION}\"|" \
+  "$REPO_ROOT/manifests/system/kro-install.sh"
 
 echo ""
 echo "✓ Configuration complete!"

--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -2,11 +2,23 @@
 # Install kro v0.8.5 via Helm into the agentex EKS cluster.
 # Run once after the cluster is provisioned with Terraform.
 # Requires: helm, kubectl (configured for the agentex cluster)
+#
+# Usage:
+#   CLUSTER=my-cluster REGION=eu-west-1 ./kro-install.sh
+#
+# These values are also set by install-configure.sh — run that first for a new god installation.
 set -euo pipefail
 
 KRO_VERSION="0.8.5"
-CLUSTER="agentex"
-REGION="us-west-2"
+CLUSTER="${CLUSTER:-agentex}"
+REGION="${REGION:-us-west-2}"
+
+if [ "$CLUSTER" = "agentex" ] && [ "$REGION" = "us-west-2" ]; then
+  echo "[kro-install] NOTE: Using CLUSTER=agentex and REGION=us-west-2 (original pnz1990/agentex defaults)."
+  echo "[kro-install] For a new installation, run install-configure.sh first or override:"
+  echo "[kro-install]   CLUSTER=<your-cluster> REGION=<your-region> ./kro-install.sh"
+  echo ""
+fi
 
 echo "[kro-install] Updating kubeconfig for cluster $CLUSTER..."
 aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"


### PR DESCRIPTION
## Summary

Fixes portability gaps in bootstrap/install scripts that were missed by the original #819 and #837 portability work.

## Changes

- **`manifests/bootstrap/seed-prompt.sh`**: Remove hardcoded `us-west-2`, `account 569190534191`, and `pnz1990/agentex`. Replace with instructions for the seed agent to read from `agentex-constitution` ConfigMap at runtime.

- **`manifests/system/kro-install.sh`**: Make `CLUSTER` and `REGION` env-var overridable with `${VAR:-default}` syntax. Add usage comment showing `CLUSTER=my-cluster REGION=eu-west-1 ./kro-install.sh`. Add informational note when running with original defaults.

- **`manifests/system/install-configure.sh`**: Add step to update `kro-install.sh` defaults when configured for a new god. Update `--help` output to list all files now updated.

## Problem Fixed

`install-configure.sh` was created to help new gods parameterize agentex for their environment, but it missed two files:

1. `seed-prompt.sh` told the seed agent it was "running on agentex EKS cluster (us-west-2, account 569190534191)" and told it to use `pnz1990/agentex` — wrong for any other installation.
2. `kro-install.sh` had `CLUSTER="agentex"` and `REGION="us-west-2"` as non-overridable values.

Closes #1081