### PR TITLE
feat: auto-apply merged RGD changes to cluster — GitOps for manifests/rgds/

### DIFF
--- a/.github/workflows/sync-rgds.yml
+++ b/.github/workflows/sync-rgds.yml
@@ -1,0 +1,61 @@
+name: Sync RGDs to Cluster
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'manifests/rgds/*.yaml'
+
+env:
+  AWS_REGION: us-west-2
+  CLUSTER_NAME: agentex
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::569190534191:role/agentex-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig for EKS
+        run: |
+          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+
+      - name: Verify cluster access
+        run: |
+          kubectl cluster-info
+          kubectl version --short
+
+      - name: Apply RGD manifests
+        run: |
+          echo "Applying Resource Graph Definitions to cluster..."
+          kubectl apply -f manifests/rgds/
+
+      - name: Verify RGDs applied
+        run: |
+          echo "Listing all ResourceGraphDefinitions:"
+          kubectl get resourcegraphdefinitions -n agentex
+          echo ""
+          echo "RGD sync complete. Cluster state now matches git repository."
+
+      - name: Post success comment to last merged PR
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find the most recent merged PR that touched RGD files
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --state merged --limit 10 --json number,mergedAt,files --jq '.[] | select(.files[].path | startswith("manifests/rgds/")) | .number' | head -1)
+          
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "✅ RGDs synced to cluster by workflow run ${{ github.run_number }}. Cluster state now matches git repository."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,6 +447,17 @@ Eight RGDs form the agent coordination layer:
 - `readyWhen` per resource: `${agentJob.status.completionTime != null}`
 - **Agent CRs MUST use `kro.run/v1alpha1`** — kro watches this group to trigger Jobs. `agentex.io/v1alpha1` is a legacy CRD and will NOT create a Job.
 
+**RGD GitOps (issue #1075):**
+
+When RGD files in `manifests/rgds/*.yaml` are merged to main, they are **automatically applied** to the cluster via GitHub Actions workflow `.github/workflows/sync-rgds.yml`.
+
+- **Trigger**: Push to main branch that modifies `manifests/rgds/*.yaml`
+- **Process**: Workflow runs `kubectl apply -f manifests/rgds/` with EKS cluster access
+- **Benefit**: Merged RGD changes take effect immediately — no manual `kubectl apply` needed
+- **Observable**: Workflow posts success comment to the merged PR
+
+Before this automation (issue #1075), merged RGD PRs would not take effect until someone manually applied them, causing cluster state to drift from git repository.
+
 ---
 
 ## Agent Roles


### PR DESCRIPTION
## Summary

Implements automated RGD sync from git to cluster. When RGD files are merged to main, they are automatically applied to the cluster via GitHub Actions.

Closes #1075

## Problem

Before this PR, merged RGD changes did not take effect until someone manually ran `kubectl apply -f manifests/rgds/`. This caused:
- PR #1055 (coordinator health probe fix) required manual apply to actually fix the crash
- Cluster state drifted from git repository
- Platform improvements were silently ignored

## Solution

Added `.github/workflows/sync-rgds.yml` that:
1. Triggers on push to main when `manifests/rgds/*.yaml` changes
2. Uses AWS OIDC (same pattern as build-runner.yml) for cluster access
3. Runs `kubectl apply -f manifests/rgds/` to sync all RGDs
4. Posts success comment to merged PR for observability

## Changes

- **New workflow**: `.github/workflows/sync-rgds.yml`
  - Trigger: push to main, paths: `manifests/rgds/*.yaml`
  - AWS OIDC auth with `agentex-github-actions` role
  - Updates kubeconfig for EKS cluster
  - Applies all RGD manifests
  - Verifies RGDs applied successfully

- **Documentation**: Updated AGENTS.md
  - Added "RGD GitOps" section after kro DSL rules
  - Explains trigger, process, benefit, observability
  - References issue #1075

## Testing

This PR will test itself:
1. Merge this PR to main
2. Workflow should trigger on the AGENTS.md change (it's not an RGD, so it won't apply anything)
3. Next RGD PR that merges will trigger the workflow and sync to cluster

To validate before merge, check:
- Workflow syntax is valid (GitHub Actions will validate on push)
- AWS role `agentex-github-actions` has EKS describe/update permissions
- Cluster name and region match constitution ConfigMap values

## Effort

M — required GitHub Actions workflow with EKS cluster access