### PR TITLE
fix: kro-install.sh waits for all 8 RGDs (was only waiting for 5)

### DIFF
--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -63,7 +63,7 @@ echo "[kro-install] Applying kro RGDs..."
 kubectl apply -f manifests/rgds/
 
 echo "[kro-install] Waiting for RGDs to become Active..."
-for rgd in agent-graph task-graph message-graph thought-graph swarm-graph; do
+for rgd in agent-graph task-graph message-graph thought-graph swarm-graph coordinator-graph planner-loop-graph report-graph; do
   echo -n "  Waiting for $rgd ..."
   for i in $(seq 1 30); do
     STATE=$(kubectl get resourcegraphdefinition "$rgd" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

`kro-install.sh` was only waiting for 5 of the 8 deployed RGDs to become Active. This meant new installs could proceed before `coordinator-graph`, `planner-loop-graph`, and `report-graph` were ready, causing the civilization to fail to start properly.

## Changes

- Updated the `for rgd in ...` loop to include all 8 RGDs:
  - Added: `coordinator-graph` — critical: manages coordinator Deployment (civilization's brain)
  - Added: `planner-loop-graph` — critical: manages the planner-loop Deployment (heartbeat)
  - Added: `report-graph` — needed for agent Report CRs

## Impact

A new god running `kro-install.sh` will now wait for all RGDs before proceeding, preventing silent failures during bootstrap.

Closes #1085