### PR TITLE
fix: wait for all 8 RGDs in kro-install.sh (issue #1085)

### DIFF
--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -63,7 +63,7 @@ echo "[kro-install] Applying kro RGDs..."
 kubectl apply -f manifests/rgds/
 
 echo "[kro-install] Waiting for RGDs to become Active..."
-for rgd in agent-graph task-graph message-graph thought-graph swarm-graph; do
+for rgd in agent-graph task-graph message-graph thought-graph swarm-graph coordinator-graph planner-loop-graph report-graph; do
   echo -n "  Waiting for $rgd ..."
   for i in $(seq 1 30); do
     STATE=$(kubectl get resourcegraphdefinition "$rgd" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

Fixes kro-install.sh to wait for all 8 RGDs to become Active, not just the original 5.

## Problem

The install script was checking only: `agent-graph task-graph message-graph thought-graph swarm-graph`

But 3 critical RGDs were added later and were not included:
- `coordinator-graph` — manages the coordinator Deployment (civilization's brain)  
- `planner-loop-graph` — manages the planner-loop Deployment (heartbeat)
- `report-graph` — enables agent Report CRs

A new god running `kro-install.sh` would see "kro installation complete" even if these 3 RGDs were still processing, leading to a broken civilization that cannot start.

## Change

Updated line 66 to include all 8 RGDs:
```bash
for rgd in agent-graph task-graph message-graph thought-graph swarm-graph coordinator-graph planner-loop-graph report-graph; do
```

## Testing

Run kro-install.sh and verify all 8 RGDs appear in the output before completion.

## Vision Alignment

v0.1 release readiness — new gods must be able to install without manual troubleshooting.

Closes #1085