### PR TITLE
fix: Prime Directive SPAWN SUCCESSOR must not tell planners to spawn planners

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2422,14 +2422,15 @@ Your job is to make that possible — by ensuring the system NEVER STOPS.
 BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
 ① SPAWN YOUR SUCCESSOR
-  Create a Task CR + Agent CR for the next agent to continue the work.
-  The Agent CR is what triggers a new pod via kro. A Task CR alone does nothing.
+  Workers, reviewers, and architects must spawn a successor.
+  **Planners do NOT spawn successors** — the planner-loop Deployment handles planner
+  perpetuation automatically. Planners only spawn WORKERS for open issues.
 
   **Use the spawn_task_and_agent() helper function** — it handles circuit breaker,
   atomic spawn gate, kill switch, and all edge cases correctly.
 
   # STEP 1: Determine next agent role and name
-  NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+  NEXT_ROLE="worker"  # workers/reviewers/architects spawn successors; planners spawn workers only
   NEXT_NAME="\${NEXT_ROLE}-\$(date +%s)"
   TASK_NAME="task-\${NEXT_NAME}"
 
@@ -2446,8 +2447,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "\$TASK_NAME" \\
     "\$NEXT_NAME" \\
     "\$NEXT_ROLE" \\
-    "Continue platform improvement — planner loop generation N" \\
-    "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting." \\
+    "Continue platform improvement — worker loop" \\
+    "Check coordinator for assigned task, implement and open PR. Spawn successor when done." \\
     "M" \\
     0 \\
     ""


### PR DESCRIPTION
## Summary

PR #949 updated AGENTS.md to remove planner successor spawning, but the fix was never applied to the `PERPETUATION_MANIFEST` in `entrypoint.sh`. This caused planners to self-perpetuate, spawning 4+ simultaneous planners.

## Root Cause

`PERPETUATION_MANIFEST` in `entrypoint.sh:2432` had `NEXT_ROLE="planner"` and the task description said `"MUST spawn YOUR OWN successor before exiting"`. This text is shown to ALL agents including planners, instructing them to spawn more planners.

## Changes

- Step ① now clarifies: **Planners do NOT spawn successors** — planner-loop Deployment handles perpetuation
- `NEXT_ROLE` changed from `"planner"` to `"worker"` (correct default for non-planners)
- Task title/description updated from planner-specific language to worker context

## Constitution Alignment

This change:
- ✅ Fixes bug without changing behavior (planner-loop still perpetuates planners)  
- ✅ Enforces existing single-planner constraint from PR #949
- ✅ Does not expand agent autonomy
- ✅ Prevents proliferation (safety improvement)

Closes #1076

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior
- [x] Enforces existing constitution rule (single-planner constraint)
- [x] Linked to GitHub issue #1076
- [x] Does not expand agent autonomy or bypass safety mechanisms