### PR TITLE
fix: remove hardcoded account/region in seed-prompt.sh and kro-install.sh

### DIFF
--- a/manifests/bootstrap/seed-prompt.sh
+++ b/manifests/bootstrap/seed-prompt.sh
@@ -10,8 +10,9 @@ agentex is a SELF-IMPROVING, SELF-REPLICATING distributed AI agent system.
 Its primary project is ITSELF. Agents develop the platform that runs them.
 The human does not want to manage this - your job is to make it self-sustaining.
 
-You are running on the agentex EKS cluster (us-west-2, account 569190534191).
-Tools: kubectl, gh CLI (authenticated to pnz1990/agentex), aws CLI, git, opencode.
+You are running on the agentex EKS cluster. Read cluster/region/repo from the constitution:
+  kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data}'
+Tools: kubectl, gh CLI (authenticated to the repo in constitution.githubRepo), aws CLI, git, opencode.
 
 STEP 1 - Understand the system (read first)
 Read these files:
@@ -28,7 +29,7 @@ If any are not Active, check: kubectl describe resourcegraphdefinition NAME
 Fix and PR. kro v0.8.4 DSL: no group field, no quoted CEL expressions.
 
 STEP 3 - Read open issues, pick top 3
-Run: gh issue list --repo pnz1990/agentex --state open --limit 30
+Run: REPO=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.githubRepo}') && gh issue list --repo "$REPO" --state open --limit 30
 
 For each of the top 3 issues, create a Task CR and an Agent CR.
 The Agent CR is what triggers a new pod via kro - a Task alone does nothing.

--- a/manifests/system/install-configure.sh
+++ b/manifests/system/install-configure.sh
@@ -59,6 +59,8 @@ while [[ $# -gt 0 ]]; do
       echo "  - manifests/system/constitution.yaml (ConfigMap data fields)"
       echo "  - manifests/bootstrap/seed-agent.yaml (image URL)"
       echo "  - manifests/system/constitution-validator.yaml (image URL)"
+      echo "  - manifests/system/kro-install.sh (CLUSTER and REGION defaults)"
+      echo "  - manifests/bootstrap/seed-prompt.sh (read-only: uses constitution at runtime)"
       echo ""
       echo "Run this BEFORE applying manifests to your cluster."
       exit 0
@@ -109,6 +111,13 @@ echo "Updating manifests/system/constitution-validator.yaml..."
 sed -i.bak \
   "s|image: .*\.dkr\.ecr\..*\.amazonaws\.com/agentex/runner:latest|image: $ECR_REGISTRY/agentex/runner:latest|" \
   "$REPO_ROOT/manifests/system/constitution-validator.yaml"
+
+# Update kro-install.sh default CLUSTER and REGION values
+echo "Updating manifests/system/kro-install.sh..."
+sed -i.bak \
+  -e "s|^CLUSTER=\".*\"|CLUSTER=\"${CLUSTER_NAME}\"|" \
+  -e "s|^REGION=\".*\"|REGION=\"${AWS_REGION}\"|" \
+  "$REPO_ROOT/manifests/system/kro-install.sh"
 
 echo ""
 echo "✓ Configuration complete!"

--- a/manifests/system/kro-install.sh
+++ b/manifests/system/kro-install.sh
@@ -2,11 +2,51 @@
 # Install kro v0.8.5 via Helm into the agentex EKS cluster.
 # Run once after the cluster is provisioned with Terraform.
 # Requires: helm, kubectl (configured for the agentex cluster)
+#
+# Usage:
+#   CLUSTER=my-cluster REGION=eu-west-1 ./kro-install.sh
+#   OR:
+#   ./kro-install.sh --cluster my-cluster --region eu-west-1
+#
+# Defaults to the original agentex installation values if not set.
+# Run install-configure.sh first to update all manifests for your environment.
 set -euo pipefail
 
 KRO_VERSION="0.8.5"
-CLUSTER="agentex"
-REGION="us-west-2"
+
+# Allow override via CLI args or env vars (set by install-configure.sh)
+CLUSTER="${CLUSTER:-agentex}"
+REGION="${REGION:-us-west-2}"
+
+# Parse optional command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --cluster)
+      CLUSTER="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --help)
+      echo "Usage: $0 [--cluster CLUSTER_NAME] [--region AWS_REGION]"
+      echo ""
+      echo "Environment variables (alternative to flags):"
+      echo "  CLUSTER   EKS cluster name (default: agentex)"
+      echo "  REGION    AWS region (default: us-west-2)"
+      echo ""
+      echo "Tip: Run manifests/system/install-configure.sh first to configure"
+      echo "     all manifests for your environment."
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Run with --help for usage."
+      exit 1
+      ;;
+  esac
+done
 
 echo "[kro-install] Updating kubeconfig for cluster $CLUSTER..."
 aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"


### PR DESCRIPTION
## Summary

- `seed-prompt.sh`: replaced hardcoded `us-west-2`, account `569190534191`, and `pnz1990/agentex` with runtime constitution reads — the seed agent now reads `REPO`, region, and cluster from the `agentex-constitution` ConfigMap at startup via `kubectl`
- `kro-install.sh`: replaced hardcoded `CLUSTER=agentex` / `REGION=us-west-2` with env-var defaults (`${CLUSTER:-agentex}`) and optional `--cluster`/`--region` CLI flags; added `--help`; fully backward-compatible
- `install-configure.sh`: added a step to update the `kro-install.sh` defaults when a new god runs the configure script; updated `--help` output to list all updated files including `seed-prompt.sh` (read-only note)

## Changes

- `manifests/bootstrap/seed-prompt.sh`: generic instructions pointing to constitution; `gh issue list` uses constitution `githubRepo` at runtime
- `manifests/system/kro-install.sh`: parameterized with env vars / CLI args, backward-compatible defaults remain
- `manifests/system/install-configure.sh`: also patches `kro-install.sh` CLUSTER/REGION defaults on configure run

Closes #1081