### PR TITLE
fix(prime-directive): remove planner self-spawning instruction

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2422,6 +2422,11 @@ Your job is to make that possible — by ensuring the system NEVER STOPS.
 BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
 ① SPAWN YOUR SUCCESSOR
+  Workers, reviewers, and architects must spawn a successor.
+  Planners do NOT spawn successors (the planner-loop Deployment handles planner perpetuation).
+
+  **For workers/reviewers/architects:**
+
   Create a Task CR + Agent CR for the next agent to continue the work.
   The Agent CR is what triggers a new pod via kro. A Task CR alone does nothing.
 
@@ -2429,7 +2434,7 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   atomic spawn gate, kill switch, and all edge cases correctly.
 
   # STEP 1: Determine next agent role and name
-  NEXT_ROLE="planner"  # or worker/reviewer/architect - choose based on what work is needed
+  NEXT_ROLE="worker"  # or reviewer/architect - choose based on what work is needed
   NEXT_NAME="\${NEXT_ROLE}-\$(date +%s)"
   TASK_NAME="task-\${NEXT_NAME}"
 
@@ -2446,8 +2451,8 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "\$TASK_NAME" \\
     "\$NEXT_NAME" \\
     "\$NEXT_ROLE" \\
-    "Continue platform improvement — planner loop generation N" \\
-    "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting." \\
+    "Continue platform improvement — worker loop" \\
+    "Check coordinator for assigned task, implement and open PR. Spawn successor when done." \\
     "M" \\
     0 \\
     ""


### PR DESCRIPTION
## Summary

Fixes the critical bug where entrypoint.sh Prime Directive was telling planners to spawn their own successors, violating the single-planner constraint established in PR #949.

Closes #1076

## Problem

The Prime Directive shown to agents contained planner-specific examples and text that contradicted AGENTS.md:

**AGENTS.md (correct):**
```
① SPAWN YOUR SUCCESSOR — Workers, reviewers, and architects must spawn a successor.
Planners do NOT spawn successors (the planner-loop Deployment handles planner perpetuation).
```

**entrypoint.sh (wrong):**
```bash
NEXT_ROLE="planner"
"Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting."
```

This caused **4 simultaneous planners** to run, each reading the Prime Directive and spawning another planner in violation of the single-planner design.

## Changes

1. **Added explicit planner exemption** at the start of step ①:
   ```
   Workers, reviewers, and architects must spawn a successor.
   Planners do NOT spawn successors (the planner-loop Deployment handles planner perpetuation).
   ```

2. **Changed example role from planner to worker:**
   ```bash
   NEXT_ROLE="worker"  # or reviewer/architect - choose based on what work is needed
   ```

3. **Updated task description** from planner-specific to worker-specific:
   - Before: "Audit codebase, fix one platform issue, spawn workers for open GitHub issues. MUST spawn YOUR OWN successor before exiting."
   - After: "Check coordinator for assigned task, implement and open PR. Spawn successor when done."

## Root Cause

Same class of bug as #806 and #811: critical requirements documented in AGENTS.md but not enforced in the agent prompt shown by entrypoint.sh. The Prime Directive is what agents actually see and act on.

## Testing

After this fix:
- Planners will see explicit instruction that they do NOT spawn successors
- Worker examples will be used instead of planner examples
- The misleading "MUST spawn YOUR OWN successor" text is removed
- Single-planner constraint will be maintained (verified in next thriving snapshot per god directive)

## Impact

- Severity: CRITICAL (violates god directive priority #2)
- Vision score: 5/10 (platform stability - prevents proliferation bug)
- Aligns entrypoint.sh with AGENTS.md to maintain single-planner invariant