### PR TITLE
fix: coordinator removes stale assignments for closed GitHub issues

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -328,6 +328,9 @@ refresh_task_queue() {
 # closed issues to re-accumulate even after refresh_task_queue() replaced the queue.
 # The fix: simply remove stale assignments. refresh_task_queue() (every 5 iterations)
 # will re-add any issues that are still open on GitHub.
+# Issue #1094 fix: Also remove assignments for CLOSED GitHub issues even when the
+# agent job is still running. Agents working on closed issues are wasting cycles —
+# they should be freed to pick different work.
 cleanup_stale_assignments() {
     local assignments
     assignments=$(get_state "activeAssignments")
@@ -348,6 +351,19 @@ cleanup_stale_assignments() {
             || echo "false")
 
         if [ "$job_active" = "true" ]; then
+            # Issue #1094: Even if agent job is running, check if the GitHub issue is still open.
+            # If the issue was closed (by a merged PR or god), remove the assignment so the
+            # task slot is freed for other work. Skip numeric check to handle non-issue refs.
+            if [[ "$issue" =~ ^[0-9]+$ ]]; then
+                local issue_state
+                issue_state=$(gh issue view "$issue" --repo "${GITHUB_REPO}" --json state \
+                    --jq '.state' 2>/dev/null || echo "UNKNOWN")
+                if [ "$issue_state" = "CLOSED" ]; then
+                    echo "[$(date -u +%H:%M:%S)] Closed issue: $agent_name → issue #$issue is CLOSED, releasing assignment (agent may continue but task slot freed)"
+                    stale_count=$((stale_count + 1))
+                    continue
+                fi
+            fi
             [ -n "$cleaned_assignments" ] \
                 && cleaned_assignments="${cleaned_assignments},${pair}" \
                 || cleaned_assignments="$pair"


### PR DESCRIPTION
## Summary

The coordinator's `cleanup_stale_assignments()` function was only removing assignments when the agent's Job was no longer running. If a GitHub issue was closed (by a merged PR or by god) while a worker was still running, the assignment would persist until the agent's job completed.

## Root Cause

`cleanup_stale_assignments()` only checked `job_active` status. It did not validate whether the assigned GitHub issue was still OPEN.

## Fix

Add GitHub issue state validation inside the active-job check:
- When a Job is still running, query `gh issue view <N> --json state`
- If `state == "CLOSED"`, log and release the assignment immediately
- Uses `|| echo "UNKNOWN"` fallback — if `gh` fails, keeps assignment (safe default)
- Only runs on numeric issue IDs (skips non-issue assignment values)

## Impact

- Coordinator `activeAssignments` stays accurate even when issues are closed mid-flight
- Task slots freed immediately when issues close, not waiting for agent jobs to finish
- Addresses god directive: "Close stale issues from coordinator taskQueue to prevent duplicate work"

## Test Scenario

1. Worker claims issue #X and starts running
2. Another agent's PR merges, closing issue #X  
3. Next coordinator cleanup cycle: assignment `worker-N:X` removed (issue is CLOSED)
4. Other agents can now pick up new work without confusion

Closes #1094