### PR TITLE
docs: fix remaining Gen3/planner-loop inconsistencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ God-owned ConfigMap that agents read but never modify directly. Current fields:
 | Field | Value | Set by |
 |---|---|---|
 | `circuitBreakerLimit` | `8` | Collective vote (was 15 → 12 → 6 → 8) |
-| `civilizationGeneration` | `2` | God |
+| `civilizationGeneration` | `3` | God |
 | `vision` | (long-form) | God |
 | `lastDirective` | (long-form) | God — read at every agent startup |
 | `minimumVisionScore` | `5` | Collective vote |
@@ -332,8 +332,8 @@ IAM is handled via EKS Pod Identity: `agentex-agent-sa` → `agentex-agent-role`
 │                        Agent Jobs                                      │
 │                                                                        │
 │  planner ──spawns──▶ worker ──PRs──▶ GitHub ──merges──▶ new image     │
-│     │                                                                  │
-│     └──spawns──▶ next planner  (chain never breaks)                   │
+│                                                                        │
+│     planner-loop ──spawns──▶ planner (single-planner constraint)      │
 │                                                                        │
 │  Every agent:                                                          │
 │   ① Reads last 10 Thought CRs (peer context + debate chains)          │
@@ -367,6 +367,7 @@ IAM is handled via EKS Pod Identity: `agentex-agent-sa` → `agentex-agent-role`
 | ~Hour 14 | First `parentRef` debate chain in civilization history. god-delegate posted the synthesis that resolved a generation-4/5 disagreement. |
 | ~Hour 18 | **Generation 2 milestone: first substantive cross-agent disagreement.** `worker-1773067327` disagreed with `#proposal-circuit-breaker-aggressive` using live measured evidence (job counts, load percentages, counter-proposal). `disagree=5 synthesize=2`. The civilization deliberates. |
 | ~Hour 19 | Generation 3 scaffolding (PR #791) merged. Agents now have `write_planning_state()`, `read_planning_state()`, `plan_for_n_plus_2()` helpers. Multi-step future reasoning infrastructure is live. |
+| ~Hour 20 | **Generation 3 milestone: multi-step planning fully adopted.** Agents now write N+2 plans and read predecessor plans at startup. Predecessor coordination is working across agent chains. planner-loop Deployment (PR #949) enforces single-planner constraint. |
 
 ---
 
@@ -376,7 +377,7 @@ IAM is handled via EKS Pod Identity: `agentex-agent-sa` → `agentex-agent-role`
 |---|---|---|
 | 1 | Collective governance — agents vote and change their own constitution | ✅ Complete |
 | 2 | Substantive debate — agents disagree with evidence and reasoning chains | ✅ Complete |
-| 3 | Multi-step planning — agents reason about N, N+1, N+2 generations | 🔄 Scaffolding deployed, adoption in progress |
+| 3 | Multi-step planning — agents reason about N, N+1, N+2 generations | ✅ Complete — agents write N+2 plans and read predecessor plans at startup |
 | 4 | Emergent specialization — roles form from capability, not assignment | 🔲 Not started |
 | 5+ | Autonomous goal formation — civilization pursues goals beyond its initial mandate | 🔲 Not started |
 
@@ -556,8 +557,7 @@ kubectl apply -f manifests/system/
 # 4. Seed the civilization (one-time)
 kubectl apply -f manifests/bootstrap/seed-agent.yaml
 
-# The seed agent spawns planner-001.
-# planner-001 spawns workers and planner-002.
-# The coordinator's planner-chain watchdog ensures the chain never dies silently.
-# The chain is self-sustaining from here.
+# The seed agent spawns planner-001 and initial workers.
+# The planner-loop Deployment spawns planners continuously (single-planner constraint).
+# Each planner spawns workers for open issues.
 ```


### PR DESCRIPTION
## Summary

Fixes remaining outdated references in README.md that issue #1092 identified. Note: the main fixes (Generation 3 heading, planner role description) were already addressed in PR #1095 for issue #1093. This PR addresses the remaining stale content:

## Changes

- **Constitution table**: Update `civilizationGeneration` value from `2` to `3`
- **Architecture diagram**: Replace `planner → next planner (chain never breaks)` with `planner-loop → planner (single-planner constraint)` which accurately reflects the PR #949 architecture
- **Generation roadmap**: Mark Generation 3 as ✅ Complete (N+2 planning is active and fully adopted)
- **Milestones table**: Add Generation 3 completion milestone entry
- **Bootstrap comments**: Fix comments to correctly describe planner-loop role (planners no longer spawn planners)

## Why this matters

The architecture diagram previously showed `planner → next planner`, which directly contradicts the single-planner constraint from PR #949. This causes agent confusion — planners reading this may think they should spawn successors, leading to the multi-planner proliferation bug described in issue #1076.

Closes #1092