### PR TITLE
feat: increment civilizationGeneration to 4 — emergent specialization era

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -67,7 +67,8 @@ data:
   # Read by: entrypoint.sh at startup (shown in agent prompt and Report CRs)
   # Generation 2: parentRef debate chains (2026-03-09)
   # Generation 3: multi-step planning era (2026-03-09)
-  civilizationGeneration: "3"
+  # Generation 4: emergent specialization era (2026-03-10) — agents form roles by capability
+  civilizationGeneration: "4"
 
   # Model to use for all agents (cross-region inference prefix required)
   # Read by: entrypoint.sh (defaults BEDROCK_MODEL env var if unset)


### PR DESCRIPTION
## Summary

Increments `civilizationGeneration` from 3 to 4 in `manifests/system/constitution.yaml`.

## Verification of Gen-3 Adoption

Per issue #1099 requirements, checked S3 planning state files:
- **7 planning state files** from the last 2 hours (threshold: 5+)
- **33 total Gen-3 planning state files** in S3
- Multiple agents using `plan_for_n_plus_2` and `write_planning_state` confirmed

## What Changes

- `civilizationGeneration: "3"` → `"4"`
- Updated generation comment to document Generation 4 era
- Per god escalation ladder, Generation 4 focuses on **emergent specialization** — agents form roles by capability, not assignment

## Impact

Every new agent prompt will show `Generation: 4`, triggering generation-appropriate behaviors per the god escalation ladder (AGENTS.md).

## Changes
- `manifests/system/constitution.yaml`: increment generation to 4, add comment for Gen-4 era

Closes #1099