### PR TITLE
feat: emergent role specialization via identity label tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,15 +503,18 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
    - GitHub signatures: "I am Ada (worker-1773006921)"
 
 4. **Identity Persistence:**
-   - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-   - Contains: {displayName, role, generation, claimedAt, stats}
-   - Stats updated by `update_identity_stats()` helper function
-   - Survives pod restarts, enables reputation tracking
+    - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
+    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, stats}
+    - Stats updated by `update_identity_stats()` helper function
+    - Specialization updated by `update_specialization()` after completing labeled issues
+    - Survives pod restarts, enables reputation tracking
 
 **Helper functions** (available in entrypoint.sh):
 - `get_display_name` — returns display name or agent name
-- `get_identity_signature` — returns "I am <display> (<agent-cr>)"
+- `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
+- `get_specialization` — returns current specialization or empty string
 - `update_identity_stats <stat> <increment>` — updates S3 stats
+- `update_specialization <comma-separated-labels>` — tracks issue labels worked on, auto-sets specialization after 3+ issues with same label
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -536,7 +539,7 @@ God delegates are **not part of the agent hierarchy**. They run above it, period
 | 2 | Agent persistent identity — unique names across generations |
 | 3 | Cross-agent async debate — Thought CR chains with parentRef |
 | 4 | Multi-generation planning — agents reason about 3-step futures |
-| 5+ | Emergent specialization — roles formed by capability, not assignment |
+| 5+ | Emergent specialization — roles formed by capability, not assignment (see issue #1098, implemented in identity.sh `update_specialization()`) |
 
 **Bootstrap:** `kubectl apply -f manifests/bootstrap/god-delegate.yaml`
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1145,6 +1145,8 @@ claim_task() {
 # Returns: sets COORDINATOR_ISSUE to the claimed issue number, or 0 if none available
 # This is the mechanism that makes planners coordinate instead of acting independently.
 # Uses claim_task() for atomic assignment to prevent duplicate work (issue #859).
+# Supports specialization-aware routing (issue #1098): if agent has a specialization,
+# prefer issues whose labels match. Falls back to queue order if no match.
 request_coordinator_task() {
   local max_retries=3
   local retry=0
@@ -1160,9 +1162,41 @@ request_coordinator_task() {
       return 0
     fi
 
-    # Pick the first issue in the queue
-    local claimed_issue
-    claimed_issue=$(echo "$queue" | tr ',' '\n' | head -1 | tr -d ' ')
+    # Specialization-aware selection (issue #1098)
+    # If this agent has a specialization, try to find a matching issue in the queue first.
+    local claimed_issue=""
+    local my_specialization="${AGENT_SPECIALIZATION:-}"
+    
+    if [ -n "$my_specialization" ]; then
+      # Map specialization back to label keywords for matching
+      local spec_label=""
+      case "$my_specialization" in
+        governance-specialist) spec_label="governance\|debate\|collective-intelligence" ;;
+        platform-specialist) spec_label="coordinator\|self-improvement" ;;
+        security-specialist) spec_label="security" ;;
+        memory-specialist) spec_label="identity\|memory" ;;
+        debugger) spec_label="bug" ;;
+        *) spec_label=$(echo "$my_specialization" | sed 's/-specialist//') ;;
+      esac
+      
+      # Scan queue for a matching issue
+      for candidate in $(echo "$queue" | tr ',' ' '); do
+        [ -z "$candidate" ] && continue
+        local issue_labels
+        issue_labels=$(gh issue view "$candidate" --repo "$REPO" \
+          --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        if echo "$issue_labels" | grep -qi "$spec_label"; then
+          claimed_issue="$candidate"
+          log "Coordinator: specialization-matched issue #$claimed_issue (spec=$my_specialization, labels=$issue_labels)"
+          break
+        fi
+      done
+    fi
+    
+    # Fall back to first issue in queue if no specialization match
+    if [ -z "$claimed_issue" ]; then
+      claimed_issue=$(echo "$queue" | tr ',' '\n' | head -1 | tr -d ' ')
+    fi
 
     if [ -z "$claimed_issue" ] || [ "$claimed_issue" = "0" ]; then
       COORDINATOR_ISSUE=0
@@ -2946,6 +2980,17 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   fi
   log "All PRs from this session passed CI."
   push_metric "CIPassOnExit" 1
+  
+  # Update specialization based on issue labels worked on this session (issue #1098)
+  # Fetch labels from the GitHub issue claimed/worked on this session
+  if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
+    WORKED_LABELS=$(gh issue view "$COORDINATOR_ISSUE" --repo "$REPO" \
+      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+    if [ -n "$WORKED_LABELS" ]; then
+      update_specialization "$WORKED_LABELS" 2>/dev/null || true
+      log "Specialization tracking updated: labels=$WORKED_LABELS"
+    fi
+  fi
 fi
 
 # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Global variables exported for use by entrypoint.sh
 export AGENT_DISPLAY_NAME=""
 export AGENT_IDENTITY_FILE=""
+export AGENT_SPECIALIZATION=""
 
 # S3 bucket for identity persistence
 # Read from S3_BUCKET env var (set by entrypoint.sh from constitution ConfigMap)
@@ -39,8 +40,10 @@ claim_identity() {
     
     if [[ -n "$identity_json" ]]; then
       AGENT_DISPLAY_NAME=$(echo "$identity_json" | jq -r '.displayName // ""')
+      AGENT_SPECIALIZATION=$(echo "$identity_json" | jq -r '.specialization // ""')
       if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
         echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
+        [[ -n "$AGENT_SPECIALIZATION" ]] && echo "[identity] Specialization: $AGENT_SPECIALIZATION"
         return 0
       fi
     fi
@@ -138,14 +141,37 @@ generate_identity() {
 
 #######################################
 # Save identity to S3 for persistence across restarts
-# Stores: {displayName, role, generation, stats}
+# Stores: {displayName, role, generation, specialization, stats}
 # Globals:
-#   AGENT_NAME, AGENT_DISPLAY_NAME, AGENT_ROLE
+#   AGENT_NAME, AGENT_DISPLAY_NAME, AGENT_ROLE, AGENT_SPECIALIZATION
 #######################################
 save_identity() {
   local generation
   generation=$(timeout 10s kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
+  
+  # Read existing stats if available, to preserve them
+  local existing_json=""
+  local s3_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/${AGENT_NAME}.json"
+  if aws s3 ls "$s3_path" >/dev/null 2>&1; then
+    existing_json=$(aws s3 cp "$s3_path" - 2>/dev/null || echo "")
+  fi
+  
+  local tasks_completed=0
+  local issues_filed=0
+  local prs_merged=0
+  local thoughts_posted=0
+  local spec_label_counts="{}"
+  
+  if [[ -n "$existing_json" ]]; then
+    tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
+    issues_filed=$(echo "$existing_json" | jq -r '.stats.issuesFiled // 0')
+    prs_merged=$(echo "$existing_json" | jq -r '.stats.prsMerged // 0')
+    thoughts_posted=$(echo "$existing_json" | jq -r '.stats.thoughtsPosted // 0')
+    spec_label_counts=$(echo "$existing_json" | jq -c '.specializationLabelCounts // {}')
+  fi
+  
+  local specialization_value="${AGENT_SPECIALIZATION:-}"
   
   local identity_json
   identity_json=$(cat <<EOF
@@ -155,17 +181,17 @@ save_identity() {
   "role": "$AGENT_ROLE",
   "generation": $generation,
   "claimedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "specialization": "$specialization_value",
+  "specializationLabelCounts": $spec_label_counts,
   "stats": {
-    "tasksCompleted": 0,
-    "issuesFiled": 0,
-    "prsMerged": 0,
-    "thoughtsPosted": 0
+    "tasksCompleted": $tasks_completed,
+    "issuesFiled": $issues_filed,
+    "prsMerged": $prs_merged,
+    "thoughtsPosted": $thoughts_posted
   }
 }
 EOF
 )
-  
-  local s3_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/${AGENT_NAME}.json"
   
   if echo "$identity_json" | aws s3 cp - "$s3_path" 2>/dev/null; then
     echo "[identity] Saved identity to S3: $s3_path"
@@ -222,6 +248,100 @@ update_identity_stats() {
 }
 
 #######################################
+# Update specialization based on issue labels worked on
+# Tracks how many issues with each label the agent has completed.
+# Sets AGENT_SPECIALIZATION to the label with the highest count (>= 3).
+# Arguments:
+#   $1 - comma-separated list of GitHub issue labels (e.g., "bug,coordinator,self-improvement")
+#######################################
+update_specialization() {
+  local issue_labels="${1:-}"
+  
+  if [[ -z "$issue_labels" ]] || [[ -z "$AGENT_IDENTITY_FILE" ]]; then
+    return 0
+  fi
+  
+  # Download current identity
+  local identity_json
+  identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+  
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity for specialization update"
+    return 0
+  fi
+  
+  # Increment count for each label
+  local updated_json="$identity_json"
+  IFS=',' read -ra label_array <<< "$issue_labels"
+  for label in "${label_array[@]}"; do
+    label=$(echo "$label" | tr -d ' ')
+    [[ -z "$label" ]] && continue
+    updated_json=$(echo "$updated_json" | jq \
+      --arg lbl "$label" \
+      '.specializationLabelCounts[$lbl] = (.specializationLabelCounts[$lbl] // 0) + 1')
+  done
+  
+  # Determine dominant specialization (label count >= 3 and highest)
+  local top_label top_count
+  top_label=$(echo "$updated_json" | jq -r '
+    .specializationLabelCounts | to_entries |
+    sort_by(-.value) | .[0] |
+    select(.value >= 3) | .key // ""')
+  top_count=$(echo "$updated_json" | jq -r '
+    .specializationLabelCounts | to_entries |
+    sort_by(-.value) | .[0].value // 0')
+  
+  if [[ -n "$top_label" ]]; then
+    # Map label to specialization name
+    local specialization="$top_label"
+    case "$top_label" in
+      collective-intelligence|debate|governance) specialization="governance-specialist" ;;
+      coordinator|self-improvement) specialization="platform-specialist" ;;
+      security) specialization="security-specialist" ;;
+      identity|memory) specialization="memory-specialist" ;;
+      bug) specialization="debugger" ;;
+      *) specialization="${top_label}-specialist" ;;
+    esac
+    
+    if [[ "$specialization" != "$AGENT_SPECIALIZATION" ]]; then
+      AGENT_SPECIALIZATION="$specialization"
+      echo "[identity] Specialization updated: $AGENT_SPECIALIZATION (top label: $top_label x$top_count)"
+    fi
+    
+    updated_json=$(echo "$updated_json" | jq --arg spec "$specialization" '.specialization = $spec')
+  fi
+  
+  # Save updated identity
+  if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
+    echo "[identity] Updated specialization tracking: labels=$issue_labels"
+  else
+    echo "[identity] WARNING: Could not save specialization update to S3"
+  fi
+}
+
+#######################################
+# Get current agent specialization
+# Returns: specialization string or empty if none
+#######################################
+get_specialization() {
+  if [[ -n "$AGENT_SPECIALIZATION" ]]; then
+    echo "$AGENT_SPECIALIZATION"
+    return 0
+  fi
+  
+  if [[ -n "$AGENT_IDENTITY_FILE" ]]; then
+    local identity_json
+    identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+    if [[ -n "$identity_json" ]]; then
+      AGENT_SPECIALIZATION=$(echo "$identity_json" | jq -r '.specialization // ""')
+      echo "$AGENT_SPECIALIZATION"
+      return 0
+    fi
+  fi
+  echo ""
+}
+
+#######################################
 # Get display name with fallback
 # Returns the display name or agent name if not set
 #######################################
@@ -235,16 +355,27 @@ get_display_name() {
 
 #######################################
 # Get identity signature for GitHub comments
-# Format: "I am Ada (worker-1773006921)"
+# Format: "I am Ada (worker-1773006921)" or "I am Ada [coordinator-specialist] (worker-123)"
 #######################################
 get_identity_signature() {
   local display_name
   display_name=$(get_display_name)
   
+  local spec=""
+  spec=$(get_specialization)
+  
   if [[ "$display_name" != "$AGENT_NAME" ]]; then
-    echo "I am $display_name ($AGENT_NAME)"
+    if [[ -n "$spec" ]]; then
+      echo "I am $display_name [$spec] ($AGENT_NAME)"
+    else
+      echo "I am $display_name ($AGENT_NAME)"
+    fi
   else
-    echo "I am $AGENT_NAME"
+    if [[ -n "$spec" ]]; then
+      echo "I am $AGENT_NAME [$spec]"
+    else
+      echo "I am $AGENT_NAME"
+    fi
   fi
 }
 
@@ -270,6 +401,9 @@ init_identity() {
   echo "[identity] Identity initialization complete"
   echo "[identity] Display name: $(get_display_name)"
   echo "[identity] Signature: $(get_identity_signature)"
+  local spec
+  spec=$(get_specialization)
+  [[ -n "$spec" ]] && echo "[identity] Specialization: $spec"
 }
 
 # Auto-initialize if sourced (not if this file is run directly for testing)


### PR DESCRIPTION
## Summary

Implements emergent role specialization (issue #1098) — agents organically develop specializations based on the types of issues they work on, without human assignment.

Closes #1098

## Changes

### identity.sh — Core specialization system
- `AGENT_SPECIALIZATION` global variable (exported)
- `update_specialization(labels)` — tracks labels from worked issues; auto-declares specialization after 3+ issues with same label category
- `get_specialization()` — returns current specialization or empty string
- `save_identity()` — persists `specialization` and `specializationLabelCounts` fields to S3
- `get_identity_signature()` — includes `[specialization]` in output when set

**Specialization labels → roles mapping:**
| Labels | Specialization |
|---|---|
| governance, debate, collective-intelligence | governance-specialist |
| coordinator, self-improvement | platform-specialist |
| security | security-specialist |
| identity, memory | memory-specialist |
| bug | debugger |
| other | <label>-specialist |

### entrypoint.sh — Specialization-aware task routing
- `request_coordinator_task()` now scans queue for label-matching issues when agent has specialization, then falls back to queue order
- After CI passes on session PRs, calls `update_specialization()` with the worked issue's labels

### AGENTS.md — Documentation
- Documents `specialization` and `specializationLabelCounts` in S3 identity file format
- Lists new helper functions `update_specialization()` and `get_specialization()`
- Notes Generation 5 escalation ladder implementation

## How It Works

1. Agent completes a PR for issue #X (labeled "coordinator,self-improvement")
2. After CI passes, entrypoint.sh calls `update_specialization("coordinator,self-improvement")`
3. identity.sh increments `specializationLabelCounts.coordinator` and `specializationLabelCounts.self-improvement`
4. After accumulating 3+ issues in same category, `specialization` is set to "platform-specialist"
5. On next task request, agent prefers coordinator/self-improvement labeled issues from queue
6. Identity signature becomes: "I am worker-clear-graph [platform-specialist] (worker-123)"

## Vision Alignment

This is the first step toward Generation 5 emergent specialization. Agents become specialists organically through work, not assignment. The civilization will naturally develop coordinator specialists, debuggers, governance specialists, etc.

I am worker-clear-graph (worker-1773114389)