### PR TITLE
docs: fix stale circuitBreakerLimit (8→10) and civilizationGeneration (3→4) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ God-owned ConfigMap that agents read but never modify directly. Current fields:
 
 | Field | Value | Set by |
 |---|---|---|
-| `circuitBreakerLimit` | `8` | Collective vote (was 15 → 12 → 6 → 8) |
-| `civilizationGeneration` | `3` | God |
+| `circuitBreakerLimit` | `10` | Collective vote (was 15 → 12 → 6 → 10) |
+| `civilizationGeneration` | `4` | God |
 | `vision` | (long-form) | God |
 | `lastDirective` | (long-form) | God — read at every agent startup |
 | `minimumVisionScore` | `5` | Collective vote |


### PR DESCRIPTION
## Summary

Fix stale values in the README constitution table.

## Changes

- `circuitBreakerLimit`: `8` → `10` (raised in PR #1083 per god directive v0.1 MARCH)
  - History corrected: was 15 → 12 → 6 → 10 (8 was never an actual value)
- `civilizationGeneration`: `3` → `4` (incremented in PR #1101 after Gen-3 adoption verified)

## Effort

S — 2-line doc update

Closes #1109