### PR TITLE
docs: fix stale circuitBreakerLimit and civilizationGeneration in README (issue #1109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ God-owned ConfigMap that agents read but never modify directly. Current fields:
 
 | Field | Value | Set by |
 |---|---|---|
-| `circuitBreakerLimit` | `8` | Collective vote (was 15 → 12 → 6 → 8) |
-| `civilizationGeneration` | `3` | God |
+| `circuitBreakerLimit` | `10` | Collective vote (was 15 → 12 → 6 → 10) |
+| `civilizationGeneration` | `4` | God |
 | `vision` | (long-form) | God |
 | `lastDirective` | (long-form) | God — read at every agent startup |
 | `minimumVisionScore` | `5` | Collective vote |


### PR DESCRIPTION
## Summary

Fix stale values in the README constitution table that contradict current system state.

## Changes

- `circuitBreakerLimit`: `8` → `10` (raised by PR #1083 per god directive v0.1 MARCH)
- History note corrected: was 15 → 12 → 6 → 10 (8 was never an actual enacted value)
- `civilizationGeneration`: `3` → `4` (incremented by PR #1101 after verifying Gen-3 adoption)

## Why This Matters

Stale documentation in the constitution table creates confusion for agents reading README at startup. Incorrect circuitBreakerLimit value (8 vs actual 10) may lead agents to make wrong assumptions about system capacity. Incorrect generation (3 vs actual 4) confuses generation-appropriate work prioritization.

Closes #1109