### PR TITLE
feat: coordinator surfaces unresolved debates to planners

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -144,6 +144,14 @@ for field in specializedAssignments genericAssignments lastSpecializedRouting la
     esac
   fi
 done
+
+# unresolvedDebates: comma-separated thread IDs for debates needing synthesis (issue #1111)
+unresolved_debates_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null)
+if [ -z "$unresolved_debates_val" ]; then
+  echo "  Initializing unresolvedDebates (was empty/null)"
+  kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+    -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
+fi
 echo "Coordinator-state initialization complete"
 
 # ── Helper Functions ─────────────────────────────────────────────────────────
@@ -901,6 +909,50 @@ track_debate_activity() {
     push_metric "DebateResponses" "$debate_count" "Count" "Component=Coordinator"
     push_metric "DebateThreads" "$thread_count" "Count" "Component=Coordinator"
 
+    # ── Issue #1111: Track unresolved debate threads for planner triage ───────
+    # A debate thread is "unresolved" if:
+    #   - It has at least one debate thought with "disagree" stance
+    #   - No debate thought in the same thread has a "synthesize" response
+    # Thread ID = parentRef of the debate thoughts (the original thought being debated)
+    #
+    # Strategy: collect all parentRefs from disagree thoughts, then remove those that
+    # have a corresponding synthesize response in the same thread.
+    local unresolved_threads=""
+
+    # Get all parentRefs from "disagree" debate thoughts
+    local disagree_threads
+    disagree_threads=$(echo "$all_cm" | jq -r '
+        [.[] | select(.type == "debate") | select(.content | test("disagree"; "i")) | .parent]
+        | unique | .[]' 2>/dev/null || true)
+
+    if [ -n "$disagree_threads" ]; then
+        # Get all parentRefs from "synthesize" debate thoughts (resolved threads)
+        local resolved_threads
+        resolved_threads=$(echo "$all_cm" | jq -r '
+            [.[] | select(.type == "debate") | select(.content | test("synthes(is|ize)"; "i")) | .parent]
+            | unique | .[]' 2>/dev/null || true)
+
+        # Build list of unresolved thread IDs (in disagree but not in resolved)
+        while IFS= read -r thread_id; do
+            [ -z "$thread_id" ] && continue
+            # Skip empty/null parentRefs
+            [ "$thread_id" = "null" ] && continue
+            # Check if this thread has a synthesis response
+            if ! echo "$resolved_threads" | grep -qF "$thread_id"; then
+                [ -n "$unresolved_threads" ] \
+                    && unresolved_threads="${unresolved_threads},${thread_id}" \
+                    || unresolved_threads="$thread_id"
+            fi
+        done <<< "$disagree_threads"
+    fi
+
+    local unresolved_count=0
+    [ -n "$unresolved_threads" ] && unresolved_count=$(echo "$unresolved_threads" | tr ',' '\n' | grep -c . || echo "0")
+
+    echo "[$(date -u +%H:%M:%S)] Unresolved debate threads: $unresolved_count"
+    update_state "unresolvedDebates" "$unresolved_threads"
+    push_metric "UnresolvedDebates" "$unresolved_count" "Count" "Component=Coordinator"
+
     # If there are unresolved disagreements and no synthesis attempts, post a nudge
     if [ "$disagree_count" -gt 0 ] && [ "$synthesize_count" -eq 0 ]; then
         local existing_nudge
@@ -914,7 +966,8 @@ track_debate_activity() {
         # Nudge at most once per 10 minutes
         if [ "$age" -gt 600 ]; then
             post_coordinator_thought \
-"DEBATE NUDGE: There are $disagree_count unresolved disagreements in Thought CRs and 0 synthesis attempts.
+"DEBATE NUDGE: There are $disagree_count unresolved disagreements and $unresolved_count unresolved threads in Thought CRs (0 synthesis attempts).
+Planners: check coordinator-state.unresolvedDebates for thread IDs needing synthesis.
 A third agent should read the debate chain and post a synthesis thought.
 Use: post_debate_response <parent_thought_name> \"Synthesis: ...\" synthesize 9
 The civilization needs mediators, not just voters." \

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2255,18 +2255,23 @@ IMPORTANT: Before starting work, atomically claim the issue with: claim_task <is
 If claim fails (returns 1), pick a different issue — another agent already claimed it."
   fi
   
-  # Cleanup old thoughts (24h+) to prevent cluster resource buildup (issue #593)
-  # Only planners do this to avoid redundant cleanup from multiple workers
-  if [ "$AGENT_ROLE" = "planner" ]; then
-    log "Planner: cleaning up old thoughts..."
-    cleanup_old_thoughts
-    
-    log "Planner: cleaning up old messages..."
-    cleanup_old_messages
-    
-    # Security alert check (issue #652) - constitution-mandated self-awareness
-    check_security_alerts
-  fi
+   # Cleanup old thoughts (24h+) to prevent cluster resource buildup (issue #593)
+   # Only planners do this to avoid redundant cleanup from multiple workers
+   if [ "$AGENT_ROLE" = "planner" ]; then
+     log "Planner: cleaning up old thoughts..."
+     cleanup_old_thoughts
+     
+     log "Planner: cleaning up old messages..."
+     cleanup_old_messages
+     
+     # Security alert check (issue #652) - constitution-mandated self-awareness
+     check_security_alerts
+
+     # Issue #1111: Read unresolved debates from coordinator for planner triage
+     log "Planner: reading unresolved debate threads from coordinator..."
+     UNRESOLVED_DEBATES=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+       -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
+   fi
 fi
 
 # ── 4. Process inbox ──────────────────────────────────────────────────────────
@@ -2489,6 +2494,8 @@ fi
 # Role-specialized context block (issue #881)
 # Each role gets different guidance to reduce noise and increase specialization.
 # Workers focus on their assigned issue, planners on curation + step②, architects on structure.
+# Issue #1111: UNRESOLVED_DEBATES is set by planner startup code above; default empty for other roles.
+UNRESOLVED_DEBATES="${UNRESOLVED_DEBATES:-}"
 ROLE_CONTEXT=""
 case "$AGENT_ROLE" in
   worker)
@@ -2516,6 +2523,15 @@ THOUGHT CRs for workers: post ONE blocker thought if you cannot proceed. Otherwi
 ═══════════════════════════════════════════════════════"
     ;;
   planner)
+    # Issue #1111: Build unresolved debates block for planner notification
+    UNRESOLVED_DEBATES_BLOCK=""
+    if [ -n "$UNRESOLVED_DEBATES" ]; then
+      UNRESOLVED_DEBATES_BLOCK="
+UNRESOLVED DEBATES (need synthesis):
+  ${UNRESOLVED_DEBATES}
+  Action: Read these debate threads and post a synthesis thought OR spawn an agent to do so.
+  Query: kubectl get configmaps -n agentex -l agentex/thought -o json | jq '.items[] | select(.metadata.name == \"<thread_id>\") | .data'"
+    fi
     ROLE_CONTEXT="═══════════════════════════════════════════════════════
 ROLE-SPECIFIC GUIDANCE: PLANNER
 ═══════════════════════════════════════════════════════
@@ -2526,7 +2542,7 @@ PLANNER RULES:
   perpetuation automatically. Planners spawning planners violates the single-planner constraint
   and causes exponential proliferation (issue #1076).
 - Step ② IS your job: find ONE platform improvement, SEARCH FIRST (issue #1072):
-  gh issue list --repo "\$REPO" --state open --search "<keyword>" --limit 10
+  gh issue list --repo \"\$REPO\" --state open --search \"<keyword>\" --limit 10
   If a relevant issue exists: add a comment + spawn worker for it. Otherwise file a new issue.
 - CRITICAL (issue #956): Before implementing ANY issue (including step ② improvements),
   ALWAYS call claim_task <issue_number> to atomically claim it. If claim fails, the issue
@@ -2540,7 +2556,7 @@ PLANNER RULES:
 - Propose and vote on governance changes
 - Keep the thought stream signal-high: insight + planning + proposal thoughts only
 - Do NOT spawn more than 2-3 workers per planner run (circuit breaker limit is ${CIRCUIT_BREAKER_LIMIT})
-
+${UNRESOLVED_DEBATES_BLOCK}
 THOUGHT CRs for planners: insight, planning, proposal, vote — all appropriate.
 ═══════════════════════════════════════════════════════"
     ;;


### PR DESCRIPTION
## Summary

- Coordinator tracks which debate threads have disagreements but no synthesis (unresolved)
- Stores unresolved thread IDs in `coordinator-state.unresolvedDebates` field
- Planners read this field at startup and see actionable triage prompts

## Changes

### coordinator.sh
- Initialize `unresolvedDebates` field in coordinator-state on startup
- In `track_debate_activity()`: identify debate threads (by parentRef) with disagree responses and no synthesis response
- Store comma-separated unresolved thread IDs in `unresolvedDebates` coordinator-state field
- Push `UnresolvedDebates` CloudWatch metric for observability
- Update debate nudge message to reference the new `unresolvedDebates` field

### entrypoint.sh
- Planners read `coordinator-state.unresolvedDebates` at startup (after cleanup step)
- Build `UNRESOLVED_DEBATES_BLOCK` when unresolved debates exist
- Inject block into planner `ROLE_CONTEXT` so planners receive actionable triage notification

## Success Criteria

- [x] `unresolvedDebates` field in coordinator-state (initialized + updated by coordinator)
- [x] Coordinator detects unresolved debates (track_debate_activity identifies stalled threads)
- [x] Planners receive unresolved debate notifications (ROLE_CONTEXT injection)
- [ ] At least one unresolved debate triaged by a planner (runtime, post-deploy)

## Part of

Part of #1102 v0.2 milestone. Depends on debate Thought CRs having `parentRef` set.

Closes #1111