### PR TITLE
feat: add pod-cleanup CronJob to Helm chart (issue #1120)

### DIFF
--- a/chart/templates/pod-cleanup-cronjob.yaml
+++ b/chart/templates/pod-cleanup-cronjob.yaml
@@ -1,0 +1,103 @@
+{{- /*
+Pod Cleanup CronJob — keeps the cluster clean by removing old completed/failed pods.
+Issue #1120: Add pod-cleanup to Helm chart for new gods.
+
+Without this, completed pods accumulate in the cluster, wasting etcd storage
+and slowing kubectl query performance (75+ pods were the trigger for issue #315).
+*/}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-completed-pods
+  namespace: {{ .Values.cluster.namespace }}
+  labels:
+    app.kubernetes.io/name: agentex
+    app.kubernetes.io/component: cleanup
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schedule: "23 * * * *"  # Run at 23 minutes past every hour (avoids :00 spike)
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid  # Don't run concurrent cleanup jobs
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 600  # Cleanup the cleanup job after 10 minutes
+      backoffLimit: 2
+      activeDeadlineSeconds: 300  # Kill cleanup job if it takes > 5 minutes
+      template:
+        metadata:
+          labels:
+            app: agentex-cleanup
+        spec:
+          serviceAccountName: agentex-agent-sa
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: cleanup
+            # Use a lightweight kubectl image — no need for the full runner image
+            image: bitnami/kubectl:1.31
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              NAMESPACE="{{ .Values.cluster.namespace }}"
+              echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Pod cleanup starting (namespace: $NAMESPACE)"
+
+              # Find completed pods older than 2 hours
+              TWO_HOURS_AGO=$(date -u -d '2 hours ago' +%s 2>/dev/null || date -u -v-2H +%s)
+
+              # Get all completed/failed pods with their completion times
+              PODS_TO_DELETE=$(kubectl get pods -n "$NAMESPACE" -o json | jq -r --arg cutoff "$TWO_HOURS_AGO" '
+                .items[] |
+                select(.status.phase == "Succeeded" or .status.phase == "Failed") |
+                select(.status.containerStatuses != null) |
+                select(.status.containerStatuses[0].state.terminated != null) |
+                select(
+                  (.status.containerStatuses[0].state.terminated.finishedAt | fromdateiso8601) < ($cutoff | tonumber)
+                ) |
+                .metadata.name
+              ')
+
+              if [ -z "$PODS_TO_DELETE" ]; then
+                echo "No pods older than 2 hours to clean up"
+                exit 0
+              fi
+
+              # Count pods to delete
+              POD_COUNT=$(echo "$PODS_TO_DELETE" | wc -l)
+              echo "Found $POD_COUNT pods to delete (older than 2 hours)"
+
+              # Delete pods (using xargs for safety with large lists)
+              echo "$PODS_TO_DELETE" | xargs -r -n 10 kubectl delete pods -n "$NAMESPACE" --wait=false
+
+              echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Cleanup complete: deleted $POD_COUNT pods"
+              exit 0
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "50m"
+              limits:
+                memory: "128Mi"
+                cpu: "200m"
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir:
+                sizeLimit: 10Mi


### PR DESCRIPTION
## Summary

Adds `chart/templates/pod-cleanup-cronjob.yaml` to the Helm chart so new gods installing via `helm install agentex ./chart` get automatic pod cleanup out of the box.

## Problem

`manifests/system/pod-cleanup-cronjob.yaml` exists (issue #315) and provides hourly cleanup of completed/failed pods older than 2 hours. However, the Helm chart at `chart/` was missing this CronJob — meaning new gods would experience pod accumulation (75+ pods is the historical trigger) without any defense-in-depth cleanup.

## Changes

- **New file**: `chart/templates/pod-cleanup-cronjob.yaml`
  - Uses `{{ .Values.cluster.namespace }}` (properly templated, no hardcoding)
  - Uses `bitnami/kubectl:1.31` (lightweight, no full runner image needed)
  - Same schedule as the existing system manifest: `23 * * * *` (avoids :00 spike)
  - Runs hourly, finds pods >2h old that are Succeeded/Failed, deletes them

## Testing

The template is structurally identical to `manifests/system/pod-cleanup-cronjob.yaml` which has been running in production. The only changes are:
1. Helm template expressions instead of hardcoded namespace
2. Helm metadata labels

Closes #1120