### PR TITLE
feat: add pod-cleanup CronJob to Helm chart

### DIFF
--- a/chart/templates/pod-cleanup-cronjob.yaml
+++ b/chart/templates/pod-cleanup-cronjob.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.cleanup.enabled }}
+# Automatic cleanup of completed/failed pods — cluster hygiene (issue #1120)
+# Runs hourly to delete pods older than 2 hours that have completed or failed.
+#
+# Why this is needed:
+# - Completed/failed pods accumulate in the cluster over time
+# - They waste etcd storage and slow kubectl queries
+# - This CronJob provides defense-in-depth cleanup alongside Job TTLs
+#
+# Disable with: --set cleanup.enabled=false
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-completed-pods
+  namespace: {{ include "agentex.namespace" . }}
+  labels:
+    {{- include "agentex.labels" . | nindent 4 }}
+    app: agentex-cleanup
+spec:
+  schedule: {{ .Values.cleanup.schedule | quote }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 600
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app: agentex-cleanup
+        spec:
+          serviceAccountName: agentex-agent-sa
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: cleanup
+            image: {{ include "agentex.image" . }}
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Pod cleanup starting"
+
+              # Find completed pods older than the configured age
+              CUTOFF_SECONDS={{ .Values.cleanup.podAgeSeconds }}
+              CUTOFF_TIME=$(date -u -d "${CUTOFF_SECONDS} seconds ago" +%s 2>/dev/null || \
+                date -u -v-${CUTOFF_SECONDS}S +%s)
+
+              # Get all completed/failed pods with their completion times
+              PODS_TO_DELETE=$(kubectl get pods -n {{ include "agentex.namespace" . }} -o json | jq -r --arg cutoff "$CUTOFF_TIME" '
+                .items[] |
+                select(.status.phase == "Succeeded" or .status.phase == "Failed") |
+                select(.status.containerStatuses != null) |
+                select(.status.containerStatuses[0].state.terminated != null) |
+                select(
+                  (.status.containerStatuses[0].state.terminated.finishedAt | fromdateiso8601) < ($cutoff | tonumber)
+                ) |
+                .metadata.name
+              ')
+
+              if [ -z "$PODS_TO_DELETE" ]; then
+                echo "No pods older than ${CUTOFF_SECONDS}s to clean up"
+                exit 0
+              fi
+
+              POD_COUNT=$(echo "$PODS_TO_DELETE" | wc -l)
+              echo "Found $POD_COUNT pods to delete (older than ${CUTOFF_SECONDS}s)"
+
+              echo "$PODS_TO_DELETE" | xargs -r -n 10 kubectl delete pods -n {{ include "agentex.namespace" . }} --wait=false
+
+              echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Cleanup complete: deleted $POD_COUNT pods"
+              exit 0
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "50m"
+              limits:
+                memory: "128Mi"
+                cpu: "200m"
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir:
+                sizeLimit: 10Mi
+{{- end }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "delete"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "delete"]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -132,3 +132,17 @@ seed:
   enabled: true
   # Maximum time seed job may run (seconds)
   activeDeadlineSeconds: 3600
+
+# ---------------------------------------------------------------------------
+# cleanup: — periodic pod cleanup CronJob
+# Deletes completed/failed pods older than podAgeSeconds to keep the cluster
+# tidy and prevent etcd bloat. Enabled by default.
+# Disable with: --set cleanup.enabled=false
+# ---------------------------------------------------------------------------
+cleanup:
+  # Enable the cleanup CronJob (recommended: keep enabled)
+  enabled: true
+  # Cron schedule — default: 23 minutes past every hour (avoids :00 spike)
+  schedule: "23 * * * *"
+  # Delete completed/failed pods older than this many seconds (default: 7200 = 2 hours)
+  podAgeSeconds: 7200


### PR DESCRIPTION
## Summary

Adds the pod-cleanup CronJob to the Helm chart so new gods installing via `helm install agentex ./chart` get automatic cluster hygiene out of the box.

Closes #1120

## Changes

- **`chart/templates/pod-cleanup-cronjob.yaml`** — new CronJob template mirroring `manifests/system/pod-cleanup-cronjob.yaml`:
  - Uses `{{ include "agentex.image" . }}` (ECR registry + runner image, no hardcoded image URL)
  - Enabled by default, toggleable via `cleanup.enabled: false`
  - Configurable schedule and pod age threshold via values
  - Identical security posture: non-root, read-only filesystem, dropped capabilities

- **`chart/values.yaml`** — adds `cleanup:` section with defaults:
  - `enabled: true`
  - `schedule: "23 * * * *"` (23min past each hour, avoids :00 spike)
  - `podAgeSeconds: 7200` (delete pods older than 2 hours)

- **`chart/templates/rbac.yaml`** — adds `delete` verb to pod permissions so the cleanup CronJob can actually delete pods (was previously missing, causing the existing `manifests/system/pod-cleanup-cronjob.yaml` to fail silently)

## Testing

```bash
# Verify template renders correctly
helm template agentex ./chart | grep -A5 "CronJob"

# Install with cleanup disabled
helm install agentex ./chart --set cleanup.enabled=false

# Override schedule/age
helm install agentex ./chart --set cleanup.schedule="0 * * * *" --set cleanup.podAgeSeconds=3600
```