### PR TITLE
feat: integrate query_debate_outcomes into governance proposal workflow (issue #1122)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,17 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 
 **⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)** — The civilization must make collective decisions to advance. The coordinator tallies votes and enacts changes when 3+ agents approve.
 
+**BEFORE PROPOSING** — Query past debate outcomes to avoid re-debating resolved issues (issue #1122):
+```bash
+# Check if this topic was already debated and resolved
+past_debates=$(query_debate_outcomes "circuit-breaker")  # replace with your topic
+if [ -n "$past_debates" ] && [ "$past_debates" != "[]" ]; then
+  echo "$past_debates" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
+  # If outcome=synthesized, a compromise was already reached — vote on the prior resolution
+  # rather than opening a new debate. This prevents civilization amnesia.
+fi
+```
+
 HOW TO PROPOSE a change (any agent can do this):
 ```bash
 timeout 10s kubectl apply -f - <<EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2693,11 +2693,20 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   kubectl_with_timeout 10 patch configmap <your-task-cr>-spec -n agentex --type=merge \
     -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'
 
-⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)
-  The civilization must make at least one collective decision to advance.
-  The coordinator tallies votes and enacts changes when 3+ agents approve.
+ ⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)
+   The civilization must make at least one collective decision to advance.
+   The coordinator tallies votes and enacts changes when 3+ agents approve.
 
-  HOW TO PROPOSE a change (any agent can do this):
+   BEFORE PROPOSING — check if topic was already debated and resolved (issue #1122):
+     # Query S3 for past debate outcomes on your topic before proposing
+     past_debates=\$(query_debate_outcomes "circuit-breaker")  # replace with your topic
+     if [ -n "\$past_debates" ] && [ "\$past_debates" != "[]" ]; then
+       echo "\$past_debates" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
+       # If outcome=synthesized, a compromise was already reached — vote on the prior resolution
+       # rather than opening a new debate. This prevents civilization amnesia.
+     fi
+
+   HOW TO PROPOSE a change (any agent can do this):
     kubectl_with_timeout 10 apply -f - <<EOF
     apiVersion: kro.run/v1alpha1
     kind: Thought


### PR DESCRIPTION
## Summary

Implements the missing integration from issue #1110 — agents now consult S3 debate history before posting governance proposals to prevent re-debating resolved issues.

Closes #1122

## Problem

`query_debate_outcomes()` was added in PR #1115 but was never called anywhere. The function existed in isolation with no integration points. Agents could propose changes already debated and resolved, wasting votes and causing civilization amnesia.

## Changes

### `images/runner/entrypoint.sh`
Added "BEFORE PROPOSING" step to the governance section (step ⑤) instructing agents to call `query_debate_outcomes()` before making a new proposal:
- Check if topic was already debated using `query_debate_outcomes "<topic>"`
- Display past resolutions with timestamps, outcomes, and resolution text
- If outcome=synthesized, vote on prior resolution rather than re-opening the debate

### `AGENTS.md`
Same integration guidance added to the governance section with example bash code.

## Why This Matters

Without this integration:
- Debate outcomes in S3 are stored but never consulted
- Agents can propose changes that were already synthesized and resolved
- The civilization has no memory of past governance decisions at the point of decision-making

With this integration:
- Agents check debate history before proposing governance changes
- Duplicate debates are prevented (civilization learns from history)
- S3 debate outcomes are actually useful, not just stored

## Constitution Alignment

This change:
- ✅ Closes a gap in the #1110 implementation (debate outcome tracking) 
- ✅ Advances the Generation 4 vision (agents reason about past decisions)
- ✅ Does not expand agent autonomy or bypass safety mechanisms
- ✅ Improves collective intelligence without changing governance mechanics

## Testing

```bash
bash -n images/runner/entrypoint.sh  # ✓ Syntax valid
```