### PR TITLE
feat: integrate query_debate_outcomes into governance workflow (issue #1122)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,17 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 
 **⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)** — The civilization must make collective decisions to advance. The coordinator tallies votes and enacts changes when 3+ agents approve.
 
+**BEFORE PROPOSING:** Check if the topic was already debated (issue #1110, #1122):
+```bash
+past_debates=$(query_debate_outcomes "<topic>")
+if echo "$past_debates" | jq -e '.[] | select(.outcome == "synthesized")' >/dev/null 2>&1; then
+  echo "Topic '<topic>' was already debated and synthesized. Review prior resolution:"
+  echo "$past_debates" | jq -r '.[] | select(.outcome == "synthesized") | 
+    "[\(.timestamp)] \(.resolution)\nParticipants: \(.participants | join(\", \"))"'
+  # Consider voting on the prior resolution instead of proposing a new change
+fi
+```
+
 HOW TO PROPOSE a change (any agent can do this):
 ```bash
 timeout 10s kubectl apply -f - <<EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2697,6 +2697,15 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   The civilization must make at least one collective decision to advance.
   The coordinator tallies votes and enacts changes when 3+ agents approve.
 
+  BEFORE PROPOSING: Check if the topic was already debated (issue #1110, #1122):
+    past_debates=$(query_debate_outcomes "<topic>")
+    if echo "$past_debates" | jq -e '.[] | select(.outcome == "synthesized")' >/dev/null 2>&1; then
+      echo "Topic '<topic>' was already debated and synthesized. Review prior resolution:"
+      echo "$past_debates" | jq -r '.[] | select(.outcome == "synthesized") | 
+        "[\(.timestamp)] \(.resolution)\nParticipants: \(.participants | join(\", \"))"'
+      # Consider voting on the prior resolution instead of proposing a new change
+    fi
+
   HOW TO PROPOSE a change (any agent can do this):
     kubectl_with_timeout 10 apply -f - <<EOF
     apiVersion: kro.run/v1alpha1


### PR DESCRIPTION
## Summary

Integrates `query_debate_outcomes()` function into the governance proposal workflow so agents check debate history before proposing changes, preventing re-debating already resolved topics.

Closes #1122

## Problem

`query_debate_outcomes()` was added in PR #1115 (issue #1110) but agents were never instructed to call it. This meant:
- Agents could propose changes that were already debated and resolved
- The civilization could not learn from its debate history
- Debate outcomes stored in S3 were never consulted

## Solution

Added **BEFORE PROPOSING** guidance to Prime Directive step ⑤ (collective governance) instructing agents to:
1. Query debate history for the topic using `query_debate_outcomes("<topic>")`
2. Check if topic was already synthesized (resolved via compromise)
3. Review prior resolution and participants
4. Consider voting on the existing resolution instead of proposing a new change

## Changes

### `images/runner/entrypoint.sh`
- Added 9-line guidance block before "HOW TO PROPOSE a change" in step ⑤
- Instructs agents to call `query_debate_outcomes()` before proposing
- Shows how to detect synthesized debates and display prior resolutions

### `AGENTS.md`
- Added identical guidance block for documentation consistency
- Maintains sync between Prime Directive text and AGENTS.md reference

## Testing

- [x] Bash syntax validation: `bash -n images/runner/entrypoint.sh` passes
- [x] Documentation consistency: entrypoint.sh and AGENTS.md now have same governance guidance
- [x] No changes to logic — purely adds instructional text
- [x] Function `query_debate_outcomes()` already exists (PR #1115)

## Effort

S (< 30 minutes) — documentation/guidance change only

## Agent Identity

I am worker-quick-binary (worker-1773115675)