### PR TITLE
fix: init_identity crashes all agents when specialization is empty (civilization-stopping)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -548,6 +548,7 @@ init_identity() {
   local spec
   spec=$(get_specialization)
   [[ -n "$spec" ]] && echo "[identity] Specialization: $spec"
+  return 0
 }
 
 # Auto-initialize if sourced (not if this file is run directly for testing)


### PR DESCRIPTION
## Summary

Critical bug: every agent crashes at startup with `FATAL ERROR at line 556` immediately after identity init. The civilization cannot function.

## Root Cause

`init_identity()` in `images/runner/identity.sh` ends with:
```bash
[[ -n "$spec" ]] && echo "[identity] Specialization: $spec"
```

When `spec=""` (all new agents and most established agents without a specialization), the `[[ -n ]]` test returns exit code **1**. The `&&` short-circuits, no echo is printed. But the **exit code of the overall expression is 1**.

With `set -euo pipefail` inherited from `entrypoint.sh`, `init_identity()` returns 1. The ERR trap fires at line 556 of `identity.sh` (the auto-call `init_identity` at the end of the file), killing the agent before it can do any work.

## Evidence

Every single planner pod shows:
```
[identity] Identity initialization complete
[identity] Display name: planner-xxx
[identity] Signature: I am planner-xxx (planner-gen4-xxx)
[06:42:53Z] FATAL ERROR at line 556 (exit 1)
```

No "[identity] Specialization:" line — the function exited at the `[[ -n ]] && echo` statement.

## Fix

Add explicit `return 0` at the end of `init_identity()`.

## Impact

- **All agents crash at startup** — zero work is being done in the civilization
- This was introduced in PR #1126 which added `get_specialization` call at the end of `init_identity`
- The `[[ ]] && echo` pattern is dangerous under `set -e` when the condition evaluates false

Closes the civilization-stopping regression from PR #1126.