### PR TITLE
fix: redirect debug output to stderr in find_best_agent_for_issue (issue #1132)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1160,7 +1160,7 @@ find_best_agent_for_issue() {
         agent_score=$(score_agent_for_issue "$agent_name" "$issue_number" \
             "$issue_labels" "$issue_keywords")
 
-        echo "[$(date -u +%H:%M:%S)] Specialization score for $agent_name on issue #$issue_number: $agent_score"
+        echo "[$(date -u +%H:%M:%S)] Specialization score for $agent_name on issue #$issue_number: $agent_score" >&2
 
         if [ "$agent_score" -gt "$best_score" ]; then
             best_score="$agent_score"
@@ -1170,7 +1170,7 @@ find_best_agent_for_issue() {
 
     # Only return if score exceeds threshold
     if [ "$best_score" -gt "$SPECIALIZATION_ROUTING_THRESHOLD" ]; then
-        echo "[$(date -u +%H:%M:%S)] Specialized routing: $best_agent (score=$best_score) → issue #$issue_number"
+        echo "[$(date -u +%H:%M:%S)] Specialized routing: $best_agent (score=$best_score) → issue #$issue_number" >&2
         echo "$best_agent"
     else
         echo ""


### PR DESCRIPTION
## Summary

Fixes a bug in `coordinator.sh` where `find_best_agent_for_issue()` mixed debug log messages with the actual return value on stdout. This caused specialization routing to silently malfunction.

Closes #1132

## Problem

The function outputs to stdout both:
1. Debug lines like `[HH:MM:SS] Specialization score for agent-X on issue #N: 3`
2. The actual return value (agent name)

When called as `best_agent=$(find_best_agent_for_issue ...)`, `best_agent` captured ALL stdout, causing:
- **False positive routing**: `if [ -n "$best_agent" ]` always true due to debug messages, even when no specialized agent met the threshold
- **Corrupt routing log**: `routing_entry="${issue_num}:${best_agent}"` stored multiline debug text instead of the clean `issue:agent` format expected in `coordinator-state.lastRoutingDecisions`

## Fix

Add `>&2` to the two debug `echo` lines in `find_best_agent_for_issue()`, redirecting them to stderr. Stdout now returns only the agent name (or empty string).

## Changes

- `images/runner/coordinator.sh`: 2 debug echo lines get `>&2` redirect

## Impact

- Specialization routing now correctly returns empty string when no agent meets the threshold
- `coordinator-state.lastRoutingDecisions` will contain clean `issue:agent` entries
- Part of v0.2 milestone (#1102) — fixes identity-based task routing (issue #1113)