### PR TITLE
fix: correct identity JSON paths in coordinator specialization routing

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1052,6 +1052,8 @@ score_agent_for_issue() {
     local score=0
 
     # Score label matches (weight 3 each)
+    # Identity JSON schema (identity.sh): label counts are in .specializationLabelCounts{}
+    # NOT in .specialization.issueLabels{} — that path was incorrect (issue #1102 fix)
     if [ -n "$issue_labels" ]; then
         IFS=',' read -ra label_arr <<< "$issue_labels"
         for label in "${label_arr[@]}"; do
@@ -1060,7 +1062,7 @@ score_agent_for_issue() {
             local label_count
             label_count=$(echo "$identity_json" | jq -r \
                 --arg lbl "$label" \
-                '(.specialization.issueLabels[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
+                '(.specializationLabelCounts[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
             if [ "$label_count" -gt 0 ]; then
                 score=$((score + 3))
             fi
@@ -1068,15 +1070,17 @@ score_agent_for_issue() {
     fi
 
     # Score keyword matches against codeAreas (weight 2 each)
+    # Identity JSON schema (identity.sh): code areas are in .specializationDetail.codeAreas{}
+    # NOT in .specialization.codeAreas{} — that path was incorrect (issue #1102 fix)
     if [ -n "$issue_keywords" ]; then
         local code_areas
         code_areas=$(echo "$identity_json" | jq -r \
-            '.specialization.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
+            '.specializationDetail.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
         for area in $code_areas; do
             local area_count
             area_count=$(echo "$identity_json" | jq -r \
                 --arg a "$area" \
-                '.specialization.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
+                '.specializationDetail.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
             if [ "$area_count" -gt 0 ]; then
                 # Check if any keyword matches this code area
                 for kw in $issue_keywords; do


### PR DESCRIPTION
## Summary

Fixes a critical bug where identity-based task routing (issue #1113) always returned score=0, making specialization-based task assignment completely ineffective.

## Root Cause

The `score_agent_for_issue()` function in `coordinator.sh` used incorrect JSON paths to read from agent identity files stored in S3.

**Identity JSON schema** (set by `identity.sh`):
```json
{
  "specialization": "platform-specialist",
  "specializationLabelCounts": {"enhancement": 5, "bug": 2},
  "specializationDetail": {
    "codeAreas": {"images": 3, "manifests": 1}
  }
}
```

**Wrong paths used (before fix)**:
- `.specialization.issueLabels[$lbl]` → non-existent field, always returned 0
- `.specialization.codeAreas` → non-existent field, always returned 0

**Correct paths (after fix)**:
- `.specializationLabelCounts[$lbl]` → correct label count field
- `.specializationDetail.codeAreas` → correct code areas field

## Impact

Without this fix, even agents with established specializations (e.g., those who've worked on 5+ `enhancement` issues) would never be preferred for routing. The `specializedAssignments` metric in coordinator-state would always be 0.

## Changes

- `images/runner/coordinator.sh`: Fixed jq paths in `score_agent_for_issue()` — 2 path corrections

## Part of v0.2 Milestone

This completes the v0.2 Collective Intelligence milestone (#1102). All 4 sub-issues (#1110, #1111, #1112, #1113) were implemented and merged, but this path mismatch prevented the identity routing (#1113) from actually functioning. With this fix, specialization routing works end-to-end.

Closes #1102

## Verification

After this fix:
1. Agent with `specializationLabelCounts: {enhancement: 5}` scores 3+ on `enhancement` issues
2. Agent with `specializationDetail.codeAreas: {images: 3}` scores 2+ on image-related issues
3. Coordinator `specializedAssignments` counter will increment when routing occurs