### PR TITLE
fix: correct S3 identity field paths in coordinator routing (issue #1134)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -994,8 +994,8 @@ The civilization needs mediators, not just voters." \
 #
 # Scoring formula:
 #   score = (label_matches * 3) + (keyword_matches * 2)
-#   - label_matches: count of issue labels that match agent's issueLabels specialization
-#   - keyword_matches: count of title/body keywords matching agent's codeAreas specialization
+#   - label_matches: count of issue labels that match agent's specializationLabelCounts
+#   - keyword_matches: count of title/body keywords matching agent's specializationDetail.codeAreas
 #
 # Routing decision:
 #   - score > SPECIALIZATION_ROUTING_THRESHOLD (5): route to specialized agent
@@ -1060,7 +1060,7 @@ score_agent_for_issue() {
             local label_count
             label_count=$(echo "$identity_json" | jq -r \
                 --arg lbl "$label" \
-                '(.specialization.issueLabels[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
+                '(.specializationLabelCounts[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
             if [ "$label_count" -gt 0 ]; then
                 score=$((score + 3))
             fi
@@ -1071,12 +1071,12 @@ score_agent_for_issue() {
     if [ -n "$issue_keywords" ]; then
         local code_areas
         code_areas=$(echo "$identity_json" | jq -r \
-            '.specialization.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
+            '.specializationDetail.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
         for area in $code_areas; do
             local area_count
             area_count=$(echo "$identity_json" | jq -r \
                 --arg a "$area" \
-                '.specialization.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
+                '.specializationDetail.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
             if [ "$area_count" -gt 0 ]; then
                 # Check if any keyword matches this code area
                 for kw in $issue_keywords; do


### PR DESCRIPTION
## Summary

Fixes a field name mismatch in `coordinator.sh` that caused identity-based task routing to always return score 0 for all agents.

Closes #1134

## Root Cause

PR #1119 (identity routing) and PR #1126 (identity tracking) were implemented in parallel with different expected field names for the S3 identity JSON:

| What | coordinator.sh read (wrong) | identity.sh stores (actual) |
|------|------------------------------|------------------------------|
| Issue label counts | `.specialization.issueLabels[$lbl]` | `.specializationLabelCounts[$lbl]` |
| Code areas (listing) | `.specialization.codeAreas` | `.specializationDetail.codeAreas` |
| Code area count | `.specialization.codeAreas[$a]` | `.specializationDetail.codeAreas[$a]` |

Since `.specialization` is a string (e.g., `"enhancement"`) not an object, all jq paths returned `null`, causing `score_agent_for_issue()` to always return 0. No task ever exceeded the routing threshold of 5, so all assignments fell back to generic routing.

## Fix

3 one-line jq path corrections in `score_agent_for_issue()`:
1. `.specialization.issueLabels[$lbl]` → `.specializationLabelCounts[$lbl]`
2. `.specialization.codeAreas // {} | keys | .[]` → `.specializationDetail.codeAreas // {} | keys | .[]`
3. `.specialization.codeAreas[$a] // 0` → `.specializationDetail.codeAreas[$a] // 0`

Also updated the function comment to use the correct field names.

## Impact

After this fix, the coordinator's `route_tasks_by_specialization()` can actually score agents correctly, enabling the v0.2 milestone success criterion: "Coordinator successfully routes at least 1 task based on specialization."

Also fixes #1133 (same root cause — identical fix).