### PR TITLE
fix: correct S3 identity field paths in coordinator specialization routing

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -994,8 +994,8 @@ The civilization needs mediators, not just voters." \
 #
 # Scoring formula:
 #   score = (label_matches * 3) + (keyword_matches * 2)
-#   - label_matches: count of issue labels that match agent's issueLabels specialization
-#   - keyword_matches: count of title/body keywords matching agent's codeAreas specialization
+#   - label_matches: count of issue labels that match agent's specializationLabelCounts
+#   - keyword_matches: count of title/body keywords matching agent's specializationDetail.codeAreas
 #
 # Routing decision:
 #   - score > SPECIALIZATION_ROUTING_THRESHOLD (5): route to specialized agent
@@ -1060,7 +1060,7 @@ score_agent_for_issue() {
             local label_count
             label_count=$(echo "$identity_json" | jq -r \
                 --arg lbl "$label" \
-                '(.specialization.issueLabels[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
+                '(.specializationLabelCounts[$lbl] // 0) | tonumber' 2>/dev/null || echo "0")
             if [ "$label_count" -gt 0 ]; then
                 score=$((score + 3))
             fi
@@ -1071,12 +1071,12 @@ score_agent_for_issue() {
     if [ -n "$issue_keywords" ]; then
         local code_areas
         code_areas=$(echo "$identity_json" | jq -r \
-            '.specialization.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
+            '.specializationDetail.codeAreas // {} | keys | .[]' 2>/dev/null || echo "")
         for area in $code_areas; do
             local area_count
             area_count=$(echo "$identity_json" | jq -r \
                 --arg a "$area" \
-                '.specialization.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
+                '.specializationDetail.codeAreas[$a] // 0 | tonumber' 2>/dev/null || echo "0")
             if [ "$area_count" -gt 0 ]; then
                 # Check if any keyword matches this code area
                 for kw in $issue_keywords; do


### PR DESCRIPTION
## Summary

Fixes silent bug in identity-based task routing: `score_agent_for_issue()` used wrong jq field paths to read S3 identity files, causing all specialization scores to be 0 and routing to never trigger.

Closes #1133

## Root Cause

The S3 identity file structure (written by `identity.sh`) uses:
- `specializationLabelCounts` (top-level map)
- `specializationDetail.codeAreas` (nested under specializationDetail)

But `coordinator.sh` was querying:
- `.specialization.issueLabels[$lbl]` — wrong path and wrong field name
- `.specialization.codeAreas` — wrong path

Since these paths don't exist in the identity JSON, jq always returned 0, and no agent ever received a score above the routing threshold.

## Changes

`images/runner/coordinator.sh`:
- `score_agent_for_issue()`: fix 3 wrong jq paths
  - `.specialization.issueLabels[$lbl]` → `.specializationLabelCounts[$lbl]`
  - `.specialization.codeAreas` → `.specializationDetail.codeAreas` (2 occurrences)
- Update comments to reference correct field names

## Impact

Identity-based specialization routing (issue #1113) now works correctly. Agents who have established specializations (worked on 3+ issues with the same label) will be preferentially routed tasks matching their expertise.