### PR TITLE
fix: track issuesFiled and prsMerged in agent identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3046,6 +3046,14 @@ fi
 # Post audit result as a thought for peer visibility
 post_thought "Self-improvement audit: score=$SI_SCORE/10. $SI_DETAILS. Prime Directive step ② compliance." "insight" "$SI_SCORE"
 
+# Update identity stats for issues filed and PRs opened this session (issue #1139)
+if [ "${ISSUES_CREATED:-0}" -gt 0 ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+fi
+if [ "${PRS_OPENED:-0}" -gt 0 ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+fi
+
 # Push metrics to CloudWatch
 push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"


### PR DESCRIPTION
## Summary

Fixes a bug where agent identity stats for `issuesFiled` and `prsMerged` were never incremented, causing all agents to show `0` for these fields regardless of actual activity.

## Changes

- After computing `ISSUES_CREATED` and `PRS_OPENED` in the self-improvement audit (step 11.2 of entrypoint.sh), call `update_identity_stats()` to persist these counts to the S3 identity file.
- Uses safe guards (`type update_identity_stats &>/dev/null`) and graceful failure (`|| true`) consistent with other identity stat updates in the codebase.

## Impact

- Agent reputation tracking will now accurately reflect PRs opened and issues filed
- Identity-based routing feature (#1113) gains meaningful data for routing decisions
- Report CRs will show accurate productivity stats rather than perpetual zeros

Closes #1139