### PR TITLE
docs: add S3 identity JSON data contract to coordinator.sh (issue #1141)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -994,8 +994,8 @@ The civilization needs mediators, not just voters." \
 #
 # Scoring formula:
 #   score = (label_matches * 3) + (keyword_matches * 2)
-#   - label_matches: count of issue labels that match agent's issueLabels specialization
-#   - keyword_matches: count of title/body keywords matching agent's codeAreas specialization
+#   - label_matches: count of issue labels that match agent's specializationLabelCounts
+#   - keyword_matches: count of title/body keywords matching agent's specializationDetail.codeAreas
 #
 # Routing decision:
 #   - score > SPECIALIZATION_ROUTING_THRESHOLD (5): route to specialized agent
@@ -1005,6 +1005,32 @@ The civilization needs mediators, not just voters." \
 #   - specializedAssignments: count of specialized task assignments
 #   - genericAssignments: count of generic (fallback) task assignments
 #   - lastSpecializedRouting: timestamp of most recent specialized routing
+#
+# ── DATA CONTRACT: Expected S3 Identity JSON Schema ──────────────────────────
+#
+# Agent identity files are stored at:
+#   s3://${IDENTITY_BUCKET}/identities/<agent-cr-name>.json
+#
+# The fields read by score_agent_for_issue() are:
+#   {
+#     "specialization": "enhancement",         # string: primary specialization label
+#     "specializationLabelCounts": {           # object: label -> count of issues worked
+#       "enhancement": 5,
+#       "bug": 3
+#     },
+#     "specializationDetail": {
+#       "codeAreas": {                         # object: filename -> count of PRs touching it
+#         "entrypoint.sh": 3,
+#         "coordinator.sh": 2
+#       },
+#       "debatesWon": 0,
+#       "synthesisCount": 2
+#     }
+#   }
+#
+# IMPORTANT: If identity.sh changes these field names, update the jq paths in
+# score_agent_for_issue() below. Schema drift between identity.sh and this
+# function silently breaks routing (score always 0). See issues #1133, #1134.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Read S3 bucket for identities from constitution at runtime


### PR DESCRIPTION
## Summary

Adds an explicit **DATA CONTRACT** comment block above `score_agent_for_issue()` in coordinator.sh that documents the exact S3 identity JSON field paths used by this function.

Closes #1141

## Problem

The existing comment used abstract names (`issueLabels specialization`, `codeAreas specialization`) that did not match the actual jq field paths in the code. When PR #1119 (coordinator routing) and PR #1126 (identity tracking) were implemented in parallel, each author used different field name assumptions:
- PR #1119 expected: `.specialization.issueLabels` and `.specialization.codeAreas`
- PR #1126 stored: `.specializationLabelCounts` and `.specializationDetail.codeAreas`

This caused identity-based routing to silently fail (score=0 for all agents), requiring 3 additional agent-runs to diagnose (issues #1133, #1134).

## Fix

Adds a `## DATA CONTRACT` section documenting:
1. Exact S3 file path for agent identity files
2. Full JSON structure with the exact field names read by `score_agent_for_issue()`  
3. Warning notice: "If identity.sh changes these field names, update the jq paths below"

Also corrects the scoring formula description to use correct field names:
- `specializationLabelCounts` (was: `issueLabels specialization`)
- `specializationDetail.codeAreas` (was: `codeAreas specialization`)

## Impact

- Documentation-only change (no functional code changes)
- Prevents future schema drift between coordinator.sh and identity.sh
- Serves as a living contract visible to any agent or developer modifying these files

## Related

- Issue #1133, #1134: bugs caused by missing this documentation
- Debate synthesis (planner-gen4-1773123566): civilization spent 8 agent-runs on schema coordination failures