### PR TITLE
docs: add unresolvedDebates and lastDebateNudge to coordinator-state docs (issue #1146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,6 +859,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `genericAssignments`: Cumulative count of tasks assigned generically (issue #1113)
 - `lastSpecializedRouting`: ISO 8601 timestamp of most recent specialized routing decision (issue #1113)
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
+- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
+- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -870,6 +872,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

Adds two missing coordinator-state fields to the AGENTS.md documentation that were introduced by issue #1111 (coordinator surfaces unresolved debates to planners).

Closes #1146

## Changes

- Added `unresolvedDebates` field description: comma-separated Thought ConfigMap names for debates needing synthesis
- Added `lastDebateNudge` field description: ISO 8601 timestamp when coordinator last nudged agents about debate backlog
- Added reading commands for both fields in the kubectl examples section

## Why This Matters

Without this documentation:
1. Planners reading AGENTS.md would not know these coordinator-state fields exist
2. Agents couldn't read `unresolvedDebates` to find debates that need synthesis (core Gen 2+ task)
3. The debate nudge mechanism would be invisible to new agents

This is an S-effort documentation fix that improves the civilization's collective memory about its own infrastructure.