### PR TITLE
fix: track specialization labels for self-selected issues (#1147)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3154,14 +3154,29 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   log "All PRs from this session passed CI."
   push_metric "CIPassOnExit" 1
   
-  # Update specialization based on issue labels worked on this session (issue #1098)
-  # Fetch labels from the GitHub issue claimed/worked on this session
-  if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$COORDINATOR_ISSUE" --repo "$REPO" \
-      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
-    if [ -n "$WORKED_LABELS" ]; then
-      update_specialization "$WORKED_LABELS" 2>/dev/null || true
-      log "Specialization tracking updated: labels=$WORKED_LABELS"
+  # Update specialization based on issue labels worked on this session (issue #1098, #1147)
+  # Fetch labels from the GitHub issue claimed/worked on this session.
+  # COORDINATOR_ISSUE is set when coordinator queue assigns the issue.
+  # For self-selected issues (queue was empty), look up our assignment from coordinator-state.
+  if type update_specialization &>/dev/null; then
+    WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
+    if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+      # Self-selected path: resolve our claimed issue from coordinator-state activeAssignments
+      ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+      WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")
+      [ -z "$WORKED_ISSUE" ] && WORKED_ISSUE="0"
+      if [ "$WORKED_ISSUE" != "0" ]; then
+        log "Specialization: resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments"
+      fi
+    fi
+    if [ "$WORKED_ISSUE" != "0" ] && [ -n "$WORKED_ISSUE" ]; then
+      WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        update_specialization "$WORKED_LABELS" 2>/dev/null || true
+        log "Specialization tracking updated: labels=$WORKED_LABELS (issue #$WORKED_ISSUE)"
+      fi
     fi
   fi
   


### PR DESCRIPTION
## Summary

Fixes a bug where specialization label tracking was skipped for agents that self-select issues when the coordinator task queue is empty.

Closes #1147

## Problem

The `update_specialization()` call at step 11.4 was guarded by:
```bash
if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
```

`COORDINATOR_ISSUE` is only set by `request_coordinator_task()` when popping from the coordinator queue. When the queue is empty and an agent self-selects (calling `claim_task <N>` directly from OpenCode), `COORDINATOR_ISSUE` remains 0. The specialization guard check always fails — no labels are ever tracked.

Since the queue is frequently empty (only 1-2 open issues at a time), the **majority of agent sessions never update specialization**, defeating the v0.2 identity-based routing feature (#1113).

## Fix

When `COORDINATOR_ISSUE == 0`, resolve the worked issue by looking up this agent's entry in `coordinator-state.activeAssignments`:

```bash
if type update_specialization &>/dev/null; then
  WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
  if [ "$WORKED_ISSUE" = "0" ]; then
    # Self-selected path: resolve from coordinator-state
    ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state ...)
    WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2)
  fi
  # Update specialization with labels from whichever issue was worked on
  ...
fi
```

This covers both coordinator-queue-assigned and self-selected sessions without requiring any changes to the OpenCode prompt or self-selection flow.

## Changes

- `images/runner/entrypoint.sh`: 23 lines added/changed in step 11.4 — specialization tracking now works for self-selected issues