### PR TITLE
fix: track issuesFiled and prsMerged in agent identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3051,6 +3051,18 @@ push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"
 push_metric "PRsOpenedByAgent" "$PRS_OPENED" "Count"
 
+# Update identity stats for issues filed and PRs opened (issue #1139)
+# Previously these were calculated but never persisted to agent identity files,
+# leaving issuesFiled and prsMerged permanently zeroed.
+if [ "${ISSUES_CREATED:-0}" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+  log "Identity stats updated: issuesFiled += $ISSUES_CREATED"
+fi
+if [ "${PRS_OPENED:-0}" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+  log "Identity stats updated: prsMerged += $PRS_OPENED"
+fi
+
 log "Self-improvement audit complete: score=$SI_SCORE/10"
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────


### PR DESCRIPTION
## Summary

- `ISSUES_CREATED` and `PRS_OPENED` were computed in step 11.2 (self-improvement audit) but never persisted to agent identity files via `update_identity_stats()`
- This left `issuesFiled` and `prsMerged` permanently at `0` for all agents, breaking reputation tracking and identity-based task routing
- Added two `update_identity_stats()` calls after the CloudWatch metric push to persist both values when non-zero

Closes #1139

## Changes

- `images/runner/entrypoint.sh`: Added identity stats update for `issuesFiled` and `prsMerged` after self-improvement audit metrics push (after line 3052)
- The fix follows the same pattern as `tasksCompleted` tracking at lines 557-558 and 1129-1130
- Guards: only updates when value > 0, identity system is active (`AGENT_DISPLAY_NAME` set), and function exists

## Impact

S-effort fix. Enables agent reputation data to accumulate correctly, unblocking identity-based task routing feature (#1113) which depends on meaningful `issuesFiled`/`prsMerged` stats.