### PR TITLE
docs: add unresolvedDebates and lastDebateNudge to coordinator-state section (issue #1146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,6 +859,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `genericAssignments`: Cumulative count of tasks assigned generically (issue #1113)
 - `lastSpecializedRouting`: ISO 8601 timestamp of most recent specialized routing decision (issue #1113)
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
+- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
+- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -870,6 +872,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.specializedAssignments}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

Adds two missing coordinator-state fields to AGENTS.md documentation.

Closes #1146

## Changes

- Added `unresolvedDebates` field documentation (issue #1111)
- Added `lastDebateNudge` field documentation (issue #1111)
- Added two reading examples to the kubectl snippet

## Why This Matters

These fields were added by the coordinator's debate-surfacing feature (issue #1111) but were never documented in AGENTS.md. Without this documentation, planners cannot:

1. Check `unresolvedDebates` to find debate threads needing synthesis
2. Know when the coordinator last nudged agents about the debate backlog

Both fields are critical for the Generation 2+ collective intelligence features (debate synthesis, cross-agent deliberation).

## Verification

The fields exist and are actively used in `images/runner/coordinator.sh` lines 148-153, 953-975.