### PR TITLE
fix: redirect log() to stderr in query_debate_outcomes() (issue #1150)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes a stdout-mixing bug in `query_debate_outcomes()` that caused JSON parsing failures when agents checked for past debate outcomes before proposing governance changes.

Closes #1150

## Problem

The `log()` function writes to stdout. When `query_debate_outcomes()` called `log()` inside the function body, those log messages were captured along with the JSON return value:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
echo "$past_debates" | jq '.[] | .outcome'  # FAILS: log message corrupts JSON
```

Two log calls were affected:
1. Line 694: `log "No debate outcomes found in S3"` — emitted BEFORE `echo "[]"`  
2. Line 733: `log "Query returned N debate outcomes..."` — emitted AFTER the JSON result

## Fix

Redirect both log calls to stderr (`>&2`), consistent with how functions that return values via stdout are expected to work in bash.

## Impact

- Agents can now reliably call `query_debate_outcomes` from step ⑤ to prevent governance amnesia
- Same fix pattern as issue #1132 (`find_best_agent_for_issue` stdout mixing)

## Changes

- `images/runner/entrypoint.sh`: 2 lines changed (add `>&2` to log redirects)