### PR TITLE
fix: score_agent_for_issue gates on .specialization string — blocks v0.2 routing (issue #1152)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1067,10 +1067,17 @@ score_agent_for_issue() {
         return 0
     fi
 
-    # Check if identity has specialization data
-    local has_spec
-    has_spec=$(echo "$identity_json" | jq -r '.specialization // empty' 2>/dev/null || echo "")
-    if [ -z "$has_spec" ]; then
+    # Check if identity has ANY specialization data (label counts or code areas).
+    # NOTE: Do NOT gate on .specialization string field — that is only set after 3+ issues
+    # with the same label (update_specialization threshold). Scoring should work as soon as
+    # an agent has any label count history (even 1 issue). Without this, routing always
+    # returns 0 until an agent crosses the threshold, making v0.2 routing non-functional.
+    # Issue #1152: removed premature early-exit on empty .specialization string.
+    local has_label_data
+    has_label_data=$(echo "$identity_json" | jq -r \
+        'if (.specializationLabelCounts | length) > 0 or (.specializationDetail.codeAreas | length) > 0 then "yes" else "" end' \
+        2>/dev/null || echo "")
+    if [ -z "$has_label_data" ]; then
         echo "0"
         return 0
     fi


### PR DESCRIPTION
## Summary

Fixes a critical bug in specialization routing: `score_agent_for_issue()` in coordinator.sh uses the `.specialization` string field as a gate before scoring, but this field is only set after an agent completes **3+ issues with the same label** (threshold in identity.sh). In practice, routing was always returning score=0 because agents never reached the threshold in normal operation.

Closes #1152

## Root Cause

The old guard:
```bash
has_spec=$(echo "$identity_json" | jq -r '.specialization // empty')
if [ -z "$has_spec" ]; then echo "0"; return 0; fi  # ← blocks routing prematurely
```

The actual scoring fields `.specializationLabelCounts` and `.specializationDetail.codeAreas` are populated after just **1 issue**, but the guard blocked all scoring before those fields were ever checked.

## Fix

Replace the gate with a check for actual scoring data:
```bash
has_label_data=$(echo "$identity_json" | jq -r \
    'if (.specializationLabelCounts | length) > 0 or (.specializationDetail.codeAreas | length) > 0 then "yes" else "" end')
if [ -z "$has_label_data" ]; then echo "0"; return 0; fi
```

## Impact

- Unblocks v0.2 milestone validation (issue #1145)  
- Specialization routing now fires as soon as an agent has worked on 1 matching issue
- No change to scoring formula — only the eligibility guard is fixed
- coordinator.sh is NOT a protected file, no `god-approved` label needed

## Testing

With this fix, a worker who has completed 1 "bug" issue will now score 3 points on a new "bug" issue. With threshold=5, they'd still need 2 label matches to be routed, but routing is no longer permanently blocked.