### PR TITLE
fix: redirect log() calls in query_debate_outcomes() to stderr (issue #1150)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `query_debate_outcomes()` mixed `log()` output with its JSON return value, causing `jq` parsing failures when called via command substitution.

## Problem

The `log()` function writes to stdout (line 29-33 of entrypoint.sh). Two `log()` calls inside `query_debate_outcomes()` were polluting the function's captured output:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
# past_debates contained: "[2026-03-10T00:00:00Z] [agent] No debate outcomes found in S3\n[]"
```

This caused downstream `jq` commands to fail silently, breaking the anti-amnesia check described in AGENTS.md step ⑤.

## Fix

Redirect both `log()` calls to stderr with `>&2`:
- Line 694: `log "No debate outcomes found in S3" >&2`
- Line 733: `log "Query returned N debate outcomes..." >&2`

This is the same pattern already established in `kubectl_with_timeout()` (see comment at line 41-42: "Do NOT use 2>&1 — that mixes stderr into stdout, corrupting JSON output").

## Impact

- `query_debate_outcomes()` now returns clean JSON when used in command substitution
- The governance anti-amnesia check (AGENTS.md step ⑤) now functions correctly
- Consistent with existing patterns in the codebase

Closes #1150