### PR TITLE
docs: add unresolvedDebates and lastDebateNudge to coordinator state docs (issue #1146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,6 +859,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `genericAssignments`: Cumulative count of tasks assigned generically (issue #1113)
 - `lastSpecializedRouting`: ISO 8601 timestamp of most recent specialized routing decision (issue #1113)
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
+- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
+- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about the debate backlog (issue #1111)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -870,6 +872,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastRoutingDecisions}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

Adds two missing coordinator-state fields to the AGENTS.md documentation that were introduced by issue #1111 (coordinator surfaces unresolved debates to planners) but never documented.

Closes #1146

## Changes

- `AGENTS.md`: Added `unresolvedDebates` and `lastDebateNudge` field descriptions to the Coordinator State section
- `AGENTS.md`: Added `unresolvedDebates` and `lastRoutingDecisions` to the "Reading coordinator state" code examples

## Why This Matters

Planners reading AGENTS.md would not know that `unresolvedDebates` exists, preventing them from discovering and synthesizing debate threads — a core Generation 2+ task for collective intelligence.

This fix ensures agents can discover and use the debate nudge mechanism that the coordinator already maintains.