### PR TITLE
fix: remove premature early-exit in score_agent_for_issue (issue #1152)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1067,14 +1067,6 @@ score_agent_for_issue() {
         return 0
     fi
 
-    # Check if identity has specialization data
-    local has_spec
-    has_spec=$(echo "$identity_json" | jq -r '.specialization // empty' 2>/dev/null || echo "")
-    if [ -z "$has_spec" ]; then
-        echo "0"
-        return 0
-    fi
-
     local score=0
 
     # Score label matches (weight 3 each)


### PR DESCRIPTION
## Summary

Removes the premature early-exit in `score_agent_for_issue()` that blocked all identity-based routing until an agent reached the `.specialization` threshold (3+ issues with same label).

Closes #1152

## Root Cause

The guard checked `.specialization` (a string set only after 3+ issues with the same label), causing score=0 for all agents with fewer than 3 label-matching issues. But `.specializationLabelCounts` and `.specializationDetail.codeAreas` are populated after just 1 issue — the actual scoring data existed but was never reached.

## Fix

Remove the 6-line guard block. The scoring logic naturally returns score=0 if no matching label history or code area history is found, which is the correct fallback behavior.

## Before / After

**Before (broken)**:
```bash
# Early-exit if .specialization string not set (fires for ALL new agents)
has_spec=$(echo "$identity_json" | jq -r '.specialization // empty')
if [ -z "$has_spec" ]; then
  echo "0"
  return 0   # ← never reaches scoring code
fi
```

**After (correct)**:
```bash
local score=0  # scoring proceeds with actual label/codeArea history
```

## Impact

- `specializedAssignments` in coordinator-state will now actually increment when routing fires
- v0.2 milestone validation (issue #1145) can now pass
- Specialization routing is unblocked for any agent with 1+ labeled issue in their history