### PR TITLE
fix: coordinator has_spec check uses wrong field — bypasses agents with partial specialization

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1067,9 +1067,17 @@ score_agent_for_issue() {
         return 0
     fi
 
-    # Check if identity has specialization data
+    # Check if identity has ANY specialization data
+    # Fix (issue #1155): check the actual data fields (.specializationLabelCounts and
+    # .specializationDetail.codeAreas), NOT the derived .specialization string.
+    # The .specialization string is only set after 3+ issues with the same label
+    # (update_specialization() threshold), so agents with 1-2 label matches or any
+    # code area data were incorrectly scored as 0 despite having relevant history.
     local has_spec
-    has_spec=$(echo "$identity_json" | jq -r '.specialization // empty' 2>/dev/null || echo "")
+    has_spec=$(echo "$identity_json" | jq -r '
+      if ((.specializationLabelCounts // {} | length) > 0) or
+         ((.specializationDetail.codeAreas // {} | length) > 0)
+      then "yes" else "" end' 2>/dev/null || echo "")
     if [ -z "$has_spec" ]; then
         echo "0"
         return 0


### PR DESCRIPTION
## Summary

Fixes a bug in `score_agent_for_issue()` in `coordinator.sh` where the specialization guard check was looking at the wrong field, causing specialization routing to skip agents who have relevant data.

Closes #1155

## Problem

The guard at line ~1072 was:
```bash
has_spec=$(echo "$identity_json" | jq -r '.specialization // empty')
```

The `.specialization` field is a derived human-readable string (e.g., `"enhancement-specialist"`) that `update_specialization()` in identity.sh only sets after an agent has worked on **3+ issues with the same label**. 

This means:
- Agents with 1-2 label matches in `.specializationLabelCounts` → **silently scored as 0**
- Agents with code area history in `.specializationDetail.codeAreas` but <3 same-label issues → **silently scored as 0**

During the bootstrap phase, no agent has yet hit the 3-label threshold. So specialization routing (issue #1113) **never fires** even with the correct field paths fixed in #1136.

## Fix

Change the guard to check whether the actual data fields are non-empty:
```bash
has_spec=$(echo "$identity_json" | jq -r '
  if ((.specializationLabelCounts // {} | length) > 0) or
     ((.specializationDetail.codeAreas // {} | length) > 0)
  then "yes" else "" end')
```

This allows routing to work during bootstrap and for agents with 1-2 label matches.

## Impact

- S-effort (8 lines changed)
- Specialization routing can now fire during early generations
- Agents contributing code area expertise (from PR file changes) can be routed appropriately
- Directly unblocks v0.2 milestone success criterion (issue #1145)

## Related

- Issue #1155: This bug
- Issue #1136: Fixed field path mismatch (predecessor fix, now this fixes the guard)
- Issue #1145: v0.2 validation — this was one reason routing wasn't firing