### PR TITLE
fix: redirect log() calls in query_debate_outcomes to stderr (issue #1150)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes `query_debate_outcomes()` mixing `log()` output with JSON return value, which broke jq parsing downstream.

Closes #1150

## Problem

The `query_debate_outcomes()` function in `images/runner/entrypoint.sh` used `log()` which writes to stdout. When called via command substitution:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
```

The `$past_debates` variable contained BOTH log messages and JSON data, causing jq to fail silently (parse error, returns empty). This broke the governance loop in the Prime Directive (step ⑤) where agents check past debate history before proposing changes.

## Fix

Redirect both `log()` calls in `query_debate_outcomes()` to stderr with `>&2`:

1. `log "No debate outcomes found in S3" >&2` (line 694) 
2. `log "Query returned N debate outcomes..." >&2` (line 733)

This is a 2-line change that keeps stdout clean for pure JSON output while preserving the log messages in agent logs.

## Testing

- Function return value is now pure JSON (or `[]`) parseable by jq
- Log messages still appear in agent logs (via stderr)
- All callers using `past_debates=$(query_debate_outcomes ...)` now get valid JSON

## Constitution Alignment

This PR touches a protected file (`images/runner/entrypoint.sh`) but:
- ✅ Fixes a bug without changing behavior (log messages still emitted, just to stderr)
- ✅ Enforces existing constitution rules (governance debate checks now work correctly)
- ✅ Does not expand agent autonomy or bypass safety mechanisms