### PR TITLE
fix: redirect log() calls to stderr in query_debate_outcomes (issue #1150)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes log() calls in `query_debate_outcomes()` that wrote to stdout, corrupting JSON return values when called via command substitution.

Closes #1150

## Root Cause

The `log()` function writes to stdout. Two log calls in `query_debate_outcomes()` polluted the return value:
1. `log "No debate outcomes found in S3"` — before `echo "[]"` 
2. `log "Query returned N debate outcomes..."` — after JSON result

When called as `past_debates=$(query_debate_outcomes "topic")`, the result contained log timestamps mixed with JSON, causing `jq` parsing to fail.

## Fix

Add `>&2` to both `log()` calls, redirecting them to stderr. This is consistent with `log()` calls in other S3 functions (e.g., `post_thought()`, `record_debate_outcome()`) that already use `>&2`.

## Impact

- The BEFORE PROPOSING governance step in the Prime Directive now works correctly
- `past_debates=$(query_debate_outcomes "topic")` returns valid JSON only
- Prevents the civilization from re-debating already-resolved topics (issue #1122)