### PR TITLE
fix: specialization tracking for self-selected issues (issue #1147)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3155,13 +3155,26 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   push_metric "CIPassOnExit" 1
   
   # Update specialization based on issue labels worked on this session (issue #1098)
-  # Fetch labels from the GitHub issue claimed/worked on this session
-  if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$COORDINATOR_ISSUE" --repo "$REPO" \
+  # Fetch labels from the GitHub issue claimed/worked on this session.
+  # Fix (issue #1147): also detect self-selected issues (when COORDINATOR_ISSUE=0
+  # because agent self-selected from GitHub rather than via coordinator queue).
+  WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
+  if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+    # Self-selected: look up our own assignment in coordinator-state activeAssignments
+    ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+    WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' \
+      | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")
+    if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
+      log "Specialization tracking: detected self-selected issue #$WORKED_ISSUE from coordinator-state"
+    fi
+  fi
+  if type update_specialization &>/dev/null && [ -n "${WORKED_ISSUE:-}" ] && [ "$WORKED_ISSUE" != "0" ]; then
+    WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
       --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
     if [ -n "$WORKED_LABELS" ]; then
       update_specialization "$WORKED_LABELS" 2>/dev/null || true
-      log "Specialization tracking updated: labels=$WORKED_LABELS"
+      log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"
     fi
   fi
   


### PR DESCRIPTION
## Summary

Fixes a missing specialization tracking case: when agents self-select issues from GitHub (coordinator queue empty), their specialization labels were never updated.

Closes #1147

## Problem

When an agent calls `claim_task <N>` directly (self-selection path), `COORDINATOR_ISSUE` remains 0 throughout the session. The specialization update at step 11.4 is guarded by `[ "$COORDINATOR_ISSUE" != "0" ]`, so it always skips for self-selected issues.

Since the coordinator queue is often empty (all issues claimed or queue not refreshed), the majority of agent sessions use self-selection — meaning virtually no agent ever accumulated specialization data in practice.

## Fix

After CI passes, if `COORDINATOR_ISSUE` is 0/empty, look up the agent's own entry in `coordinator-state.activeAssignments` to find the self-selected issue number. Then update specialization labels from that issue as normal.

```bash
WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
  # Self-selected: look up our own assignment in coordinator-state
  ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state ...)
  WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2)
fi
```

## Impact

S-effort. Critical for v0.2 milestone success: without this fix, identity-based routing (#1113) can never accumulate the specialization data it needs to route tasks.

## Changes

- `images/runner/entrypoint.sh`: 13 lines changed in the specialization tracking block (step 11.4)