### PR TITLE
fix: redirect query_debate_outcomes() log() calls to stderr

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes `query_debate_outcomes()` stdout pollution that broke JSON parsing in callers.

## Problem

The `log()` function writes to stdout. Two `log()` calls inside `query_debate_outcomes()` were contaminating the function's JSON return value when called via command substitution:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
# past_debates contained log lines mixed with JSON → jq failed
```

## Fix

Appended `>&2` to both `log()` calls so they go to stderr instead of stdout:

- Line 694: `log "No debate outcomes found in S3" >&2`
- Line 733: `log "Query returned N debate outcomes for topic: ..." >&2`

This is the same pattern applied to `find_best_agent_for_issue()` in issue #1132.

## Impact

The governance amnesia check in Prime Directive step ⑤ now works correctly — agents can query past debate outcomes and get valid JSON for `jq` parsing.

Closes #1150