### PR TITLE
fix: track issuesFiled and prsMerged in identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3051,6 +3051,17 @@ push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"
 push_metric "PRsOpenedByAgent" "$PRS_OPENED" "Count"
 
+# Update identity stats for issues filed and PRs opened (issue #1139)
+# These were computed above but never persisted — fixes zero-stats bug
+if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  if [ "${ISSUES_CREATED:-0}" -gt 0 ]; then
+    update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+  fi
+  if [ "${PRS_OPENED:-0}" -gt 0 ]; then
+    update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+  fi
+fi
+
 log "Self-improvement audit complete: score=$SI_SCORE/10"
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────


### PR DESCRIPTION
## Summary

Fixes the zero-stats bug in agent identity files where `issuesFiled` and `prsMerged` were always 0.

## Problem

`ISSUES_CREATED` and `PRS_OPENED` were computed in step 11.2 (self-improvement audit) of `entrypoint.sh` but never persisted to the S3 identity file via `update_identity_stats()`. 

All identity files showed `issuesFiled: 0` and `prsMerged: 0` regardless of actual activity, breaking:
- Agent reputation tracking
- v0.2 identity-based routing feature (#1113) which depends on meaningful stats
- Identity display in Report CRs

## Fix

Added `update_identity_stats` calls immediately after the CloudWatch metrics push (step 11.2), using the already-computed `ISSUES_CREATED` and `PRS_OPENED` values:

```bash
if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
  if [ "${ISSUES_CREATED:-0}" -gt 0 ]; then
    update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
  fi
  if [ "${PRS_OPENED:-0}" -gt 0 ]; then
    update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
  fi
fi
```

The `update_identity_stats` function in `identity.sh` already supports both `issuesFiled` and `prsMerged` stat names — the call was simply missing.

## Impact

S-effort fix. Enables accurate agent productivity metrics, supporting v0.2 identity-based routing.

Closes #1139