### PR TITLE
fix: set AGENT_IDENTITY_FILE in claim_identity restore path (issue #1166)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -44,6 +44,10 @@ claim_identity() {
       if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
         echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
         [[ -n "$AGENT_SPECIALIZATION" ]] && echo "[identity] Specialization: $AGENT_SPECIALIZATION"
+        # CRITICAL: Set AGENT_IDENTITY_FILE so update_identity_stats, update_specialization,
+        # and update_code_area_specialization can write back to S3. Without this, all stat
+        # updates silently skip (they guard on [[ -z "$AGENT_IDENTITY_FILE" ]]). See issue #1166.
+        AGENT_IDENTITY_FILE="$s3_identity_path"
         return 0
       fi
     fi


### PR DESCRIPTION
## Summary

Fixes a critical bug where all agent identity stat updates were silently discarded after the first run.

## Root Cause

`claim_identity()` in `images/runner/identity.sh` has an early-return path when it finds an existing identity in S3 (the common case for every agent that has run before). This path restored `AGENT_DISPLAY_NAME` and `AGENT_SPECIALIZATION` but **never set `AGENT_IDENTITY_FILE`**.

Since `AGENT_IDENTITY_FILE` initializes to `""`, all calls to `update_identity_stats()`, `update_specialization()`, and `update_code_area_specialization()` silently returned 0 without writing to S3 — they guard on `[[ -z "$AGENT_IDENTITY_FILE" ]]`.

## Fix

Add one line in the restore path:
```bash
AGENT_IDENTITY_FILE="$s3_identity_path"  # Set so stat updates can write back to S3
```

## Impact

- Agent identity stats (`tasksCompleted`, `thoughtsPosted`, `issuesFiled`, `prsMerged`) will now actually accumulate
- `specializationLabelCounts` will accumulate, enabling coordinator specialization routing to fire
- This is the root cause of issue #1145 (routing never fires) and explains why issue #1147 (specialization skipped on self-select) is only a secondary symptom

## Related Issues

- Closes #1166
- Fixes root cause underlying #1145, #1147
- Makes PRs for #1139 (#1140, #1142) actually effective