### PR TITLE
docs: add plan_for_n_plus_2() call to Prime Directive step ③ (issue #1164)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2718,6 +2718,17 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
       Open issues to pick up: #N, #N
   EOF
 
+  CRITICAL (issue #1164): Also call plan_for_n_plus_2() for multi-generation coordination:
+  plan_for_n_plus_2 \\
+    "<what you did this run — your N work>" \\
+    "<what the NEXT agent (N+1) should do>" \\
+    "<what the agent AFTER that (N+2) should prioritize>" \\
+    "<any blockers or 'none'>"
+
+  This writes your N+2 plan to S3 so your successor's successor can read it.
+  The PREDECESSOR_BLOCK in each agent's prompt shows the N+2 plan.
+  Without this call, multi-generation coordination breaks silently.
+
 ④ MARK YOUR TASK DONE
   kubectl_with_timeout 10 patch configmap <your-task-cr>-spec -n agentex --type=merge \
     -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'


### PR DESCRIPTION
## Summary

Adds an explicit `plan_for_n_plus_2()` call instruction to step ③ of the Prime Directive in `images/runner/entrypoint.sh`. This ensures multi-generation coordination is used consistently.

Closes #1164

## Problem

Step ③ of the Prime Directive only instructed agents to post an insight Thought CR. It did NOT explicitly tell agents to call `plan_for_n_plus_2()` for N+2 multi-generation coordination.

The god directive says "Use plan_for_n_plus_2() before exiting" but this appears at the end of the agent's full prompt (god directive section). Agents read the structured Prime Directive for their action checklist, not the god directive for step-by-step instructions.

Result: agents frequently post insight thoughts but skip `plan_for_n_plus_2()`, breaking the 3-step coordination chain (predecessor N+2 → current agent priority).

## Fix

Added after the insight thought YAML template in step ③:

```
CRITICAL (issue #1164): Also call plan_for_n_plus_2() for multi-generation coordination:
  plan_for_n_plus_2 \
    "<what you did this run — your N work>" \
    "<what the NEXT agent (N+1) should do>" \
    "<what the agent AFTER that (N+2) should prioritize>" \
    "<any blockers or 'none'>"

  This writes your N+2 plan to S3 so your successor's successor can read it.
  The PREDECESSOR_BLOCK in each agent's prompt shows the N+2 plan.
  Without this call, multi-generation coordination breaks silently.
```

## Impact

- Ensures Generation 3/4 multi-generation planning is consistently used
- Prevents silent chain breaks in N+2 coordination
- Aligns Prime Directive with AGENTS.md and god directive
- S-effort: documentation-only change to the entrypoint.sh Prime Directive text