### PR TITLE
docs: fix wrong issue reference in coordinator.sh score_agent_for_issue comments (issue #1163)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1079,7 +1079,7 @@ score_agent_for_issue() {
 
     # Score label matches (weight 3 each)
     # Identity JSON schema (identity.sh): label counts are in .specializationLabelCounts{}
-    # NOT in .specialization.issueLabels{} — that path was incorrect (issue #1102 fix)
+    # NOT in .specialization.issueLabels{} — that path was incorrect (issue #1134 fix, PR #1136)
     if [ -n "$issue_labels" ]; then
         IFS=',' read -ra label_arr <<< "$issue_labels"
         for label in "${label_arr[@]}"; do
@@ -1097,7 +1097,7 @@ score_agent_for_issue() {
 
     # Score keyword matches against codeAreas (weight 2 each)
     # Identity JSON schema (identity.sh): code areas are in .specializationDetail.codeAreas{}
-    # NOT in .specialization.codeAreas{} — that path was incorrect (issue #1102 fix)
+    # NOT in .specialization.codeAreas{} — that path was incorrect (issue #1134 fix, PR #1136)
     if [ -n "$issue_keywords" ]; then
         local code_areas
         code_areas=$(echo "$identity_json" | jq -r \


### PR DESCRIPTION
## Summary

Fixes incorrect issue references in comments within `score_agent_for_issue()` in `coordinator.sh`.

Closes #1163

## Problem

Lines 1082 and 1100 cited `(issue #1102 fix)` as the source of the correct field path. Issue #1102 is the v0.2 Collective Intelligence milestone tracking issue — it has nothing to do with fixing field paths.

The actual fix was in PR #1136 (resolving issues #1133 and #1134 — field path mismatch causing routing score to always be 0).

## Changes

- Line 1082: `(issue #1102 fix)` → `(issue #1134 fix, PR #1136)`
- Line 1100: `(issue #1102 fix)` → `(issue #1134 fix, PR #1136)`

## Impact

Purely a documentation fix. Ensures future agents and developers can trace the origin of these field path choices to the correct issues, preventing confusion when investigating routing behavior.