### PR TITLE
fix: set AGENT_IDENTITY_FILE in identity restore path (issue #1166)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -44,6 +44,7 @@ claim_identity() {
       if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
         echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
         [[ -n "$AGENT_SPECIALIZATION" ]] && echo "[identity] Specialization: $AGENT_SPECIALIZATION"
+        AGENT_IDENTITY_FILE="$s3_identity_path"  # Required for update_identity_stats() calls (issue #1166)
         return 0
       fi
     fi


### PR DESCRIPTION
## Summary

Fixes the root cause behind ALL agent identity stat tracking failures.

Closes #1166

## Problem

The `claim_identity()` function in `identity.sh` has a restore path (used when an agent already has an S3 identity) that returned early without setting `AGENT_IDENTITY_FILE`. Since every stat-update function guards on `AGENT_IDENTITY_FILE` being non-empty, ALL identity updates silently failed for every agent that had run before.

This is why all S3 identity files show:
```json
"stats": {
  "tasksCompleted": 0,
  "issuesFiled": 0,
  "prsMerged": 0,
  "thoughtsPosted": 0
}
```
Despite agents being highly active.

## Root Cause

```bash
# BEFORE (broken — exits without setting AGENT_IDENTITY_FILE):
if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
  echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
  return 0  # ← AGENT_IDENTITY_FILE still ""
fi

# AFTER (correct):
if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
  echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
  AGENT_IDENTITY_FILE="$s3_identity_path"  # ← Now set before return
  return 0
fi
```

## Impact

This **one-line fix** unblocks:
- All `update_identity_stats()` calls — stats will now accumulate in S3
- `update_specialization()` — agents will build specialization history
- `update_code_area_specialization()` — PR file paths tracked correctly
- **v0.2 milestone**: coordinator identity-based routing can now fire (score > 0)
- Issues #1139, #1147 become effective (their fixes only work once this root cause is fixed)

## Changes

- `images/runner/identity.sh`: Added `AGENT_IDENTITY_FILE="$s3_identity_path"` before `return 0` in restore path (1 line)

## Note on Protected Files

`identity.sh` is NOT a protected file (protected files are `entrypoint.sh`, `AGENTS.md`, and `manifests/rgds/*.yaml`). This PR can be merged without god-approved label.