### PR TITLE
fix: suppress jq stderr in coordinator cleanup job-active checks (issue #1170)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -378,9 +378,12 @@ cleanup_stale_assignments() {
         local issue="${pair##*:}"
 
         local job_active
+        # Issue #1170: Add 2>/dev/null to jq to suppress stderr parse errors when kubectl
+        # returns empty output (job not found). The || echo "false" handles the exit code,
+        # but without 2>/dev/null jq's error message still appears in coordinator logs.
         job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
-            || echo "false")
+            2>/dev/null || echo "false")
 
         if [ "$job_active" = "true" ]; then
             # Issue #1094: Even if agent job is running, check if the GitHub issue is still open.
@@ -428,9 +431,12 @@ cleanup_active_agents() {
         
         # Check if Job still active (exists and no completionTime)
         local job_active
+        # Issue #1170: Add 2>/dev/null to jq to suppress stderr parse errors when kubectl
+        # returns empty output (job not found). The || echo "false" handles the exit code,
+        # but without 2>/dev/null jq's error message still appears in coordinator logs.
         job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
             | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
-            || echo "false")
+            2>/dev/null || echo "false")
         
         if [ "$job_active" = "true" ]; then
             [ -n "$cleaned_agents" ] \


### PR DESCRIPTION
## Summary

Fixes recurring jq parse error messages in coordinator pod logs by adding `2>/dev/null` to jq commands in the cleanup functions.

Closes #1170

## Problem

The coordinator's `cleanup_active_assignments()` and `cleanup_active_agents()` functions were emitting `jq: parse error: Invalid numeric literal at line 1, column 6` on every 30-second cleanup cycle. Evidence from coordinator logs:

```
jq: parse error: Invalid numeric literal at line 1, column 6
[07:02:19] Stale: planner-gen4-1773122265 → issue #1146, returning to queue
jq: parse error: Invalid numeric literal at line 1, column 6
[07:02:20] Stale: planner-gen4-1773120294 → issue #1145, returning to queue
```

## Root Cause

When a job doesn't exist, `kubectl_with_timeout 10 get job ... 2>/dev/null` correctly suppresses kubectl's error output, but then pipes empty string to `jq`. The `jq` command emits its parse error to stderr (which was not redirected), and `|| echo "false"` only handles the exit code — too late to suppress the already-emitted error message.

## Fix

Added `2>/dev/null` after the jq expression (before `|| echo "false"`) in two locations:
- `cleanup_active_assignments()` (line ~382) 
- `cleanup_active_agents()` (line ~432)

This aligns with the pattern already used in `reconcile_spawn_slots()` and other coordinator functions.

## Changes

- `images/runner/coordinator.sh`: Added `2>/dev/null` to 2 jq job-active check calls with explanatory comments referencing issue #1170