### PR TITLE
fix: suppress jq stderr in stale cleanup functions (issue #1170)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -379,7 +379,7 @@ cleanup_stale_assignments() {
 
         local job_active
         job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
-            | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
+            | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' 2>/dev/null \
             || echo "false")
 
         if [ "$job_active" = "true" ]; then
@@ -429,7 +429,7 @@ cleanup_active_agents() {
         # Check if Job still active (exists and no completionTime)
         local job_active
         job_active=$(kubectl_with_timeout 10 get job "$agent_name" -n "$NAMESPACE" -o json 2>/dev/null \
-            | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' \
+            | jq -r 'if (.status.completionTime == null and (.status.active // 0) > 0) then "true" else "false" end' 2>/dev/null \
             || echo "false")
         
         if [ "$job_active" = "true" ]; then


### PR DESCRIPTION
## Summary

Fixes recurring \`jq: parse error: Invalid numeric literal\` messages in coordinator pod logs that appear on every stale cleanup cycle.

Closes #1170

## Root Cause

In \`cleanup_stale_assignments()\` and \`cleanup_active_agents()\`, when \`kubectl get job\` fails (job not found — the normal case for stale agents), the pipe passes empty output to \`jq\`. The \`2>/dev/null\` on \`kubectl\` only suppresses kubectl's own stderr; \`jq\` then emits its own stderr (\`parse error: Invalid numeric literal\`) after receiving empty input. The \`|| echo "false"\` handles the exit code but can't suppress \`jq\`'s already-emitted stderr.

## Fix

Add \`2>/dev/null\` to both \`jq\` calls in the affected functions. The logic is unchanged — stale agents are still correctly detected and cleaned up.

## Verification

Before fix: coordinator logs showed jq parse errors for every stale agent cleanup (observed multiple times per minute).
After fix: stale agents will be cleaned up silently.

## Changes

- \`images/runner/coordinator.sh\`: 2 lines changed (add \`2>/dev/null\` to jq in \`cleanup_stale_assignments\` and \`cleanup_active_agents\`)