### PR TITLE
fix: specialization tracking fires on self-selected issues (#1147)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3155,13 +3155,28 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   push_metric "CIPassOnExit" 1
   
   # Update specialization based on issue labels worked on this session (issue #1098)
-  # Fetch labels from the GitHub issue claimed/worked on this session
-  if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$COORDINATOR_ISSUE" --repo "$REPO" \
-      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
-    if [ -n "$WORKED_LABELS" ]; then
-      update_specialization "$WORKED_LABELS" 2>/dev/null || true
-      log "Specialization tracking updated: labels=$WORKED_LABELS"
+  # Fetch labels from the GitHub issue claimed/worked on this session.
+  # Fix #1147: when COORDINATOR_ISSUE is 0 (self-selected from GitHub), look up
+  # this agent's assignment in coordinator-state.activeAssignments so specialization
+  # tracking fires even on the self-selection path.
+  if type update_specialization &>/dev/null; then
+    WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
+    if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+      # Self-selected path: resolve the issue number from coordinator activeAssignments
+      ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+      WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")
+      if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
+        log "Specialization tracking: resolved self-selected issue #${WORKED_ISSUE} from activeAssignments"
+      fi
+    fi
+    if [ -n "${WORKED_ISSUE:-}" ] && [ "$WORKED_ISSUE" != "0" ]; then
+      WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        update_specialization "$WORKED_LABELS" 2>/dev/null || true
+        log "Specialization tracking updated: issue=#${WORKED_ISSUE} labels=$WORKED_LABELS"
+      fi
     fi
   fi
   


### PR DESCRIPTION
## Summary

- Fixes specialization label tracking for agents that self-select an issue when the coordinator queue is empty
- When `COORDINATOR_ISSUE` is 0, now looks up the agent's own entry in `coordinator-state.activeAssignments` to resolve the issue number
- `update_specialization()` then runs normally, building label history for identity-based routing (#1113)

## Root Cause

The guard at the specialization tracking step required `COORDINATOR_ISSUE != 0`, but that variable is only set when the coordinator queue is non-empty. Agents on the self-selection path (via `claim_task <N>`) register in `activeAssignments` but `COORDINATOR_ISSUE` stays 0, so specialization was silently skipped.

## Fix

After CI passes (step 11.3), if `COORDINATOR_ISSUE == 0`, query `coordinator-state.activeAssignments` for `${AGENT_NAME}:N` to recover the actual worked issue number, then proceed with label fetch and `update_specialization()` as before.

## Testing

Logic change only in `images/runner/entrypoint.sh`. The fix is additive — existing coordinator-queue path is unchanged. The new self-select resolution path uses the same `kubectl_with_timeout` pattern as the rest of the entrypoint.

Closes #1147