### PR TITLE
fix: set AGENT_IDENTITY_FILE in claim_identity restore path (issue #1166)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -44,6 +44,11 @@ claim_identity() {
       if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
         echo "[identity] Restored identity: $AGENT_DISPLAY_NAME"
         [[ -n "$AGENT_SPECIALIZATION" ]] && echo "[identity] Specialization: $AGENT_SPECIALIZATION"
+        # Issue #1166: Set AGENT_IDENTITY_FILE so update_identity_stats() and
+        # update_specialization() can persist stats to S3.
+        # Without this, all stat update calls silently return 0 because the guard
+        # `[[ -z "$AGENT_IDENTITY_FILE" ]]` in update_identity_stats() triggers.
+        AGENT_IDENTITY_FILE="$s3_identity_path"
         return 0
       fi
     fi


### PR DESCRIPTION
## Summary

Fixes a critical bug where the `claim_identity()` restore path (used by agents that have run before) never set `AGENT_IDENTITY_FILE`, causing **all identity stat updates to silently fail for every returning agent**.

## Root Cause

`claim_identity()` in `images/runner/identity.sh` has two paths:

1. **New agent path**: Calls `save_identity()` which sets `AGENT_IDENTITY_FILE="$s3_path"` ✅
2. **Returning agent path (restore)**: Restores `AGENT_DISPLAY_NAME` and `AGENT_SPECIALIZATION` but **never sets `AGENT_IDENTITY_FILE`** ❌ → returns early with `AGENT_IDENTITY_FILE=""` 

The `update_identity_stats()` function has this guard:
```bash
if [[ -z "$AGENT_IDENTITY_FILE" ]]; then
  # No S3 identity file, skip update
  return 0
fi
```

Since `AGENT_IDENTITY_FILE` is always empty for returning agents, **every stat update call silently returned 0** without writing anything to S3.

## Fix

One line added in the restore path to set `AGENT_IDENTITY_FILE` before returning:

```bash
AGENT_IDENTITY_FILE="$s3_identity_path"  # Added — issue #1166 fix
return 0
```

## Impact

This fix unblocks:
- **Agent reputation tracking** (#1139): `issuesFiled`, `prsMerged`, `thoughtsPosted` stats now persist
- **Identity-based routing** (#1113): agents now accumulate label history via `update_specialization()`
- **v0.2 milestone validation** (#1145): specialization routing can now fire once agents build history
- **Emergent specialization** (#1098): agents form specialization via actual accumulated evidence

## Evidence

Every S3 identity file currently shows `stats: {tasksCompleted: 0, issuesFiled: 0, ...}` for agents that have run many times. The fix ensures stat updates reach S3 for returning agents.

Closes #1166