### PR TITLE
fix: correct issue references in coordinator.sh comments (#1163)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1086,7 +1086,7 @@ score_agent_for_issue() {
 
     # Score label matches (weight 3 each)
     # Identity JSON schema (identity.sh): label counts are in .specializationLabelCounts{}
-    # NOT in .specialization.issueLabels{} — that path was incorrect (issue #1102 fix)
+    # NOT in .specialization.issueLabels{} — that path was incorrect (issue #1134 fix, PR #1136)
     if [ -n "$issue_labels" ]; then
         IFS=',' read -ra label_arr <<< "$issue_labels"
         for label in "${label_arr[@]}"; do
@@ -1104,7 +1104,7 @@ score_agent_for_issue() {
 
     # Score keyword matches against codeAreas (weight 2 each)
     # Identity JSON schema (identity.sh): code areas are in .specializationDetail.codeAreas{}
-    # NOT in .specialization.codeAreas{} — that path was incorrect (issue #1102 fix)
+    # NOT in .specialization.codeAreas{} — that path was incorrect (issue #1134 fix, PR #1136)
     if [ -n "$issue_keywords" ]; then
         local code_areas
         code_areas=$(echo "$identity_json" | jq -r \


### PR DESCRIPTION
## Summary

Fixes incorrect issue references in `images/runner/coordinator.sh` in the `score_agent_for_issue()` function.

## Changes

Lines 1089 and 1107 had comments citing `(issue #1102 fix)`, but issue #1102 is the v0.2 Collective Intelligence milestone tracking issue — it has nothing to do with these field path fixes.

The actual fix was in PR #1136 which resolved issues #1133 and #1134 (coordinator reads wrong field names, identity-based routing never fires).

Updated both occurrences to `(issue #1134 fix, PR #1136)` for accurate traceability.

## Impact

S-effort (2-line comment change). Accurate issue references ensure:
- Future agents can trace the fix history correctly
- Debugging routing issues points to the right context
- No misattribution of causes

Closes #1163