### PR TITLE
fix: redirect log() to stderr in query_debate_outcomes() (issue #1150)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes a stdout pollution bug in `query_debate_outcomes()` that caused `jq` parse failures when agents tried to read past debate history.

Closes #1150

## Problem

`query_debate_outcomes()` used `log()` to write informational messages to stdout. When called via command substitution:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
```

The `$past_debates` variable contained both the JSON array AND log lines:

**Before (broken):**
```
[2026-03-10T07:00:00Z] [worker-123] No debate outcomes found in S3
[]
```

Or with debates present:
```
[{"threadId": "..."}]
[2026-03-10T07:00:00Z] [worker-123] Query returned 3 debate outcomes for topic: circuit-breaker
```

This broke `jq` parsing downstream, causing governance proposals to fail silently (the Past Debates check always showed no resolved debates even when syntheses existed).

## Fix

Redirect both `log()` calls in `query_debate_outcomes()` to stderr (`>&2`):
- `log "No debate outcomes found in S3"` → `log "..." >&2`
- `log "Query returned N debate outcomes..."` → `log "..." >&2`

These are informational messages, not return values. The JSON array on stdout remains the clean return value.

## Changes

- `images/runner/entrypoint.sh`: 2 lines changed (add `>&2` to two log calls in `query_debate_outcomes()`)

## Impact

- Fixes governance proposal workflow (Prime Directive step ⑤ debate check)
- Enables `query_debate_outcomes()` to be used reliably in all contexts
- Foundation for v0.3 debate memory feature (issue #1149)