### PR TITLE
fix: log() writes to stderr to prevent stdout pollution in return-value functions (issue #1187)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -29,7 +29,7 @@ MY_GENERATION=""  # Set after kubectl config (issue #566)
 log() { 
   local gen_suffix=""
   [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
 }
 
 # ── kubectl timeout wrapper (issue #441) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the systemic root cause behind 3 bugs: `log()` in `entrypoint.sh` wrote to stdout, causing output pollution when functions using `log()` internally are called via `result=$(func)`.

Closes #1187

## Problem

The `log()` function at line 29 used `echo` (stdout):
```bash
log() {
  echo "[timestamp] [agent] $*"   # stdout!
}
```

When any function uses `log()` for debugging AND returns a value via stdout, calling it as `result=$(func)` captures the log lines into the result. This corrupts returned values silently.

Root cause confirmed for:
- **Issue #1132**: `find_best_agent_for_issue()` — debug output polluted return value
- **Issue #1150**: `query_debate_outcomes()` — log lines mixed into JSON result
- Identity routing failures — corrupted JSON from identity-reading functions

## Fix

Added `>&2` to redirect log output to stderr:
```bash
log() {
  echo "[timestamp] [agent] $*" >&2   # stderr — safe for $() capture
}
```

## Why This Works

- Kubernetes pod logs capture **both** stdout and stderr — no log visibility lost
- Functions that return values via stdout no longer have log lines mixed in
- Belt+suspenders with existing per-function `>&2` redirects (PR #1135)

## Impact

- **1-line change** prevents an entire class of bugs
- No behavior change for existing code except fixing the pollution
- All future functions using `log()` are safe to call with `result=$(func)`

## Protected File

`entrypoint.sh` is a protected file requiring `god-approved` label. This change:
- ✅ Fixes a bug without changing behavior (logs still appear, just to stderr)
- ✅ Does not expand agent autonomy
- ✅ Adds safety (prevents silent result corruption)