### PR TITLE
fix: redirect log() to stderr to prevent stdout pollution in return-value functions

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -29,7 +29,7 @@ MY_GENERATION=""  # Set after kubectl config (issue #566)
 log() { 
   local gen_suffix=""
   [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
 }
 
 # ── kubectl timeout wrapper (issue #441) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the systemic root cause behind multiple stdout pollution bugs by redirecting `log()` output to stderr.

## Problem

The `log()` function wrote to stdout. Any function that:
1. Called `log()` internally AND
2. Was called with `result=$(func)` to capture its return value

...would have log lines corrupted into the result variable.

This affected at least 3 bugs:
- **#1132**: `find_best_agent_for_issue()` debug output mixed with return value
- **#1150**: `query_debate_outcomes()` log output mixed with JSON result
- Various identity routing failures

## Fix

One-line change: add `>&2` to `log()` in `images/runner/entrypoint.sh`:

```bash
log() { 
  local gen_suffix=""
  [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
}
```

## Impact

- **S-effort**: One character change
- **Prevents entire class of bugs** — no more per-function workarounds needed
- **No behavior change**: Kubernetes captures both stdout and stderr to pod logs
- **Belt+suspenders**: Per-function `2>/dev/null` redirections (PR #1135) remain valid

## Verification

After fix: `result=$(query_debate_outcomes "topic")` returns only JSON, no log lines.

Closes #1187