### PR TITLE
fix: write_planning_state writes canonical role/latest.json for reliable N+2 coordination

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -891,8 +891,17 @@ cleanup_old_messages() {
 # Returns: JSON planning state from most recent agent in that role (or empty JSON)
 read_planning_state() {
   local role="$1"
-  
-  # List all plans for this role, sorted by timestamp (most recent first)
+
+  # Preferred path: canonical latest.json written by write_planning_state (issue #1193)
+  # This covers all agents that use plan_for_n_plus_2() or write_planning_state()
+  local canonical_plan
+  canonical_plan=$(aws s3 cp "s3://${S3_BUCKET}/planning/${role}/latest.json" - 2>/dev/null || echo "")
+  if [ -n "$canonical_plan" ] && [ "$canonical_plan" != "{}" ]; then
+    echo "$canonical_plan"
+    return 0
+  fi
+
+  # Fallback: legacy ${role}-plan-${agent}.json files (backward compat)
   local latest_plan
   latest_plan=$(aws s3 ls "s3://${S3_BUCKET}/planning/${role}-plan-" 2>/dev/null | \
     sort -r | head -1 | awk '{print $NF}' || echo "")
@@ -931,15 +940,22 @@ write_planning_state() {
     --arg blockers "$blockers" \
     '{role: $role, agent: $agent, generation: $generation, timestamp: $timestamp, myWork: $myWork, n1Priority: $n1Priority, n2Priority: $n2Priority, blockers: $blockers}')
   
-  # Write to S3 with agent-specific filename
+  # Write to S3 with agent-specific filename (backward compat)
   local s3_output
   if ! s3_output=$(echo "$plan" | aws s3 cp - "s3://${S3_BUCKET}/planning/${role}-plan-${agent}.json" \
     --content-type application/json 2>&1); then
     log "WARNING: Failed to write planning state to S3: $s3_output"
     return 0  # Best-effort, don't fail agent if S3 unavailable
   fi
-  
-  log "✓ Wrote planning state to S3: ${role}-plan-${agent}.json"
+
+  # Also write to canonical path for reliable cross-generation reads (issue #1193)
+  # read_planning_state() reads from here first, ensuring successors always find the plan
+  if ! s3_output=$(echo "$plan" | aws s3 cp - "s3://${S3_BUCKET}/planning/${role}/latest.json" \
+    --content-type application/json 2>&1); then
+    log "WARNING: Failed to write canonical planning state to S3: $s3_output"
+  fi
+
+  log "✓ Wrote planning state to S3: ${role}-plan-${agent}.json + ${role}/latest.json"
   push_metric "PlanningStateWritten" 1
 }
 


### PR DESCRIPTION
## Summary

Fixes N+2 multi-generation coordination: planning state is now reliably readable by successor agents.

Closes #1193

## Problem

`write_planning_state()` wrote plans to agent-specific S3 paths like `planner-gen4-1773122501.json` but `read_planning_state()` only searched for `planner-plan-*` prefix files. The result: most successor plans were invisible to their successors, breaking the Generation 4 multi-step coordination feature.

Evidence of the problem (S3 at time of filing):
- 9+ planning files with wrong naming patterns
- Only 1 file matched the `planner-plan-*` pattern
- The `planner/latest.json` existed but was manually written (not via helpers)

## Fix

Two changes to `images/runner/entrypoint.sh`:

1. **`write_planning_state()`**: Now writes BOTH the legacy agent-specific file AND a canonical `s3://bucket/planning/${role}/latest.json` (always overwritten with most recent plan)

2. **`read_planning_state()`**: Checks canonical `role/latest.json` first (preferred), falls back to legacy `${role}-plan-*` pattern scan

## Impact

- Successor agents now reliably receive predecessor N+2 plans
- Backward compatible: legacy files still written for agents that read them directly  
- The canonical path is role-specific (e.g., `planner/latest.json`, `worker/latest.json`)
- Immediately fixes the coordination: `planner/latest.json` is already used by agents that write it manually; now all agents that call `write_planning_state` or `plan_for_n_plus_2` will also write to this canonical path

## Testing

`bash -n` syntax check passes. The canonical path `s3://agentex-thoughts/planning/planner/latest.json` already exists and is updated by this PR to always contain the most recent plan.