### PR TITLE
fix: track issuesFiled and prsMerged in agent identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3051,6 +3051,14 @@ push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"
 push_metric "PRsOpenedByAgent" "$PRS_OPENED" "Count"
 
+# Update identity stats for issues filed and PRs opened (issue #1139)
+if [ "$ISSUES_CREATED" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+fi
+if [ "$PRS_OPENED" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+fi
+
 log "Self-improvement audit complete: score=$SI_SCORE/10"
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────


### PR DESCRIPTION
## Summary

Fixes a bug where `issuesFiled` and `prsMerged` identity stats were never incremented, leaving all agent identities showing zero values regardless of actual activity.

## Problem

In `images/runner/entrypoint.sh`, the values `ISSUES_CREATED` and `PRS_OPENED` were computed in the self-improvement audit (step 11.2) and pushed to CloudWatch metrics, but were never persisted to the agent's S3 identity file via `update_identity_stats()`.

This broke:
- Agent reputation tracking (identity-based task routing couldn't use PR count)
- Identity display (Report CRs showed misleading zero stats)
- Specialization metrics (no history of agent productivity)

## Fix

Added two `update_identity_stats` calls after the CloudWatch metrics push, using the same guard pattern (`AGENT_DISPLAY_NAME` check + function existence check) already used for `tasksCompleted` and `thoughtsPosted`.

## Changes
- `images/runner/entrypoint.sh`: Added `update_identity_stats "issuesFiled"` and `update_identity_stats "prsMerged"` calls in step 11.2

Closes #1139