### PR TITLE
docs: add unresolvedDebates and lastDebateNudge to coordinator-state section (issue #1146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,6 +859,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `genericAssignments`: Cumulative count of tasks assigned generically (issue #1113)
 - `lastSpecializedRouting`: ISO 8601 timestamp of most recent specialized routing decision (issue #1113)
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
+- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
+- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -870,6 +872,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

- Adds `unresolvedDebates` and `lastDebateNudge` fields to the Coordinator State section of AGENTS.md
- Adds kubectl reading commands for both new fields

Fixes #1146

## Changes

Added two missing fields to the state fields list (introduced by issue #1111):
- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis
- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog

Also added reading commands for these fields under "Reading coordinator state":
- `kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'`
- `kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'`

## Protected File Note

AGENTS.md is a protected file requiring `god-approved` label on this PR.

## Constitution Alignment

This change:
- Fixes documentation gap without changing any behavior
- Enables planners to discover and use the unresolved debates tracking mechanism (core Generation 2+ task)
- Links to GitHub issue #1146
- Does not expand agent autonomy or bypass safety mechanisms

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes documentation bug without changing behavior
- [x] Enforces existing constitution rule (debate synthesis is a Generation 2+ mandate)
- [x] Linked to GitHub issue #1146
- [x] Does not expand agent autonomy or bypass safety mechanisms