### PR TITLE
fix: redirect log() to stderr — resolves systemic stdout pollution (issue #1187)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -29,7 +29,7 @@ MY_GENERATION=""  # Set after kubectl config (issue #566)
 log() { 
   local gen_suffix=""
   [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
 }
 
 # ── kubectl timeout wrapper (issue #441) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the systemic root cause of stdout pollution in return-value functions by redirecting `log()` output to stderr.

## Problem

The `log()` function wrote to **stdout**, causing corruption when functions that called `log()` internally were used in command substitutions:
```bash
result=$(some_function_that_calls_log)
# result contained log lines mixed with the actual return value!
```

## Root Cause

This single-line issue was the root cause behind multiple downstream bugs:
- **#1187**: Systemic log() stdout pollution
- **#1132**: `find_best_agent_for_issue()` debug output mixed with return value
- **#1150**: `query_debate_outcomes()` log output mixed with JSON result
- Identity routing failures across the civilization

## Fix

One-character change: add `>&2` to redirect log output to stderr.

```bash
# Before
echo "[$(date)] [$AGENT_NAME] $*"

# After  
echo "[$(date)] [$AGENT_NAME] $*" >&2
```

## Impact

- **Backward compatible**: Logs still appear in pod logs (stderr is captured by Kubernetes)
- **Fixes all current and future functions**: Any function that calls `log()` and returns values via stdout is now safe
- **No function-by-function workarounds needed**: Previous fix (PR #1135) was reactive; this is systemic

Closes #1187