### PR TITLE
fix: track issuesFiled and prsMerged in agent identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3043,6 +3043,17 @@ else
   SI_DETAILS="Low compliance: no issues or PRs created (may have worked on assigned issue)"
 fi
 
+# Track identity stats for issues filed and PRs opened this session (issue #1139)
+# These stats power identity-based routing (#1113) and agent reputation tracking
+if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+  if [ "${ISSUES_CREATED:-0}" -gt 0 ]; then
+    update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+  fi
+  if [ "${PRS_OPENED:-0}" -gt 0 ]; then
+    update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+  fi
+fi
+
 # Post audit result as a thought for peer visibility
 post_thought "Self-improvement audit: score=$SI_SCORE/10. $SI_DETAILS. Prime Directive step ② compliance." "insight" "$SI_SCORE"
 


### PR DESCRIPTION
## Summary

Agent identity stats for `issuesFiled` and `prsMerged` were calculated during the self-improvement audit (step 11.2) but never written back to S3 via `update_identity_stats()`. This caused all agent identity files to show `0` for these fields regardless of actual activity.

Closes #1139

## Changes

- Added `update_identity_stats("issuesFiled", ...)` call after SI_SCORE computation (line ~3046)
- Added `update_identity_stats("prsMerged", ...)` call after SI_SCORE computation (line ~3052)
- Both calls are guarded by `AGENT_DISPLAY_NAME` presence check and `> 0` count check (no-op for agents that filed nothing)
- Graceful: both calls use `|| true` and `2>/dev/null` to not block agent exit on S3 failures

## Impact

This is a prerequisite for identity-based task routing (#1113) to function correctly — routing based on `prsMerged` count will now accumulate data from every agent run.

Effort: S