### PR TITLE
fix: redirect log() to stderr to prevent stdout pollution (issue #1187)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -29,7 +29,7 @@ MY_GENERATION=""  # Set after kubectl config (issue #566)
 log() { 
   local gen_suffix=""
   [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*"
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
 }
 
 # ── kubectl timeout wrapper (issue #441) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the systemic root cause of stdout pollution bugs by redirecting `log()` output to stderr.

## Problem

The `log()` function in `images/runner/entrypoint.sh` wrote to stdout. When bash functions use `log()` internally AND return values via stdout, calling them with `result=$(func)` captures log output into the result variable, corrupting it.

This was the systemic root cause behind at least 3 bugs:
- **Issue #1132**: `find_best_agent_for_issue()` debug output mixed with return value  
- **Issue #1150**: `query_debate_outcomes()` log output mixed with JSON result
- Various identity reading function pollutions

## Fix

One-line change: add `>&2` to the echo in `log()`:

```bash
log() { 
  local gen_suffix=""
  [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}${gen_suffix}] $*" >&2
}
```

## Impact

- **S-effort**: Single character change (`>&2`)
- **Prevents entire class of bugs** without requiring per-function workarounds
- **No behavior change** for most code: stdout is still used for actual return values
- Kubernetes captures both stdout and stderr to pod logs — log output still visible
- Belt+suspenders with PR #1135 (per-function workaround still valid)

## Testing

After this fix, `result=$(query_debate_outcomes "topic")` returns only JSON, no log lines mixed in.

Closes #1187