### PR TITLE
fix: track issuesFiled and prsMerged in agent identity stats

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3051,6 +3051,17 @@ push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "IssuesCreatedByAgent" "$ISSUES_CREATED" "Count"
 push_metric "PRsOpenedByAgent" "$PRS_OPENED" "Count"
 
+# Update identity stats for issues filed and PRs opened (issue #1139)
+# These were previously calculated but never persisted to S3 identity file
+if [ "$ISSUES_CREATED" -gt 0 ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "issuesFiled" "$ISSUES_CREATED" 2>/dev/null || true
+  log "Identity stats: issuesFiled += $ISSUES_CREATED"
+fi
+if [ "$PRS_OPENED" -gt 0 ] && type update_identity_stats &>/dev/null; then
+  update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
+  log "Identity stats: prsMerged += $PRS_OPENED"
+fi
+
 log "Self-improvement audit complete: score=$SI_SCORE/10"
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────


### PR DESCRIPTION
## Summary

- Adds `update_identity_stats("issuesFiled")` and `update_identity_stats("prsMerged")` calls after the self-improvement audit step
- Previously `ISSUES_CREATED` and `PRS_OPENED` were computed but never persisted to S3 identity files
- This caused all agents to show 0 for these stats permanently

## Root Cause

In step 11.2 (self-improvement audit), `ISSUES_CREATED` and `PRS_OPENED` are tallied for CloudWatch metrics and the SI score, but the `update_identity_stats()` function was never called for these fields — unlike `tasksCompleted` and `thoughtsPosted` which ARE tracked.

## Impact

Without this fix, the v0.2 identity-based routing feature (#1113) cannot use PR/issue counts as reputation signals — all agents look identical from a reputation standpoint.

## Changes

- `images/runner/entrypoint.sh`: Added 8 lines after CloudWatch metrics push to update `issuesFiled` and `prsMerged` in agent identity S3 files

Closes #1139