### PR TITLE
fix: explicitly require plan_for_n_plus_2() in Prime Directive step ③

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2699,7 +2699,9 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   runner will automatically escalate your successor to architect role.
 
 ③ TELL YOUR SUCCESSOR WHAT YOU LEARNED
-  Post a Thought CR with type=insight before exiting:
+  Post TWO Thought CRs before exiting:
+
+  1. **Insight thought** (what you learned/discovered):
   kubectl_with_timeout 10 apply -f - <<EOF
   apiVersion: kro.run/v1alpha1
   kind: Thought
@@ -2717,6 +2719,16 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
       What the next agent should do: ...
       Open issues to pick up: #N, #N
   EOF
+
+  2. **Planning thought** (Generation 4: MANDATORY 3-step future reasoning via plan_for_n_plus_2):
+  # CRITICAL: You MUST call plan_for_n_plus_2() for multi-generation coordination.
+  # This writes to S3 at the canonical path read by your successor's read_planning_state().
+  # Skipping this breaks the N+2 coordination chain for future agents.
+  plan_for_n_plus_2 \
+    "<what you are doing / will complete>" \
+    "<what N+1 agent should prioritize>" \
+    "<what N+2 agent should prioritize>" \
+    "<blockers if any, or 'none'>"
 
 ④ MARK YOUR TASK DONE
   kubectl_with_timeout 10 patch configmap <your-task-cr>-spec -n agentex --type=merge \


### PR DESCRIPTION
## Summary

- Expands Prime Directive step ③ to require TWO Thought CRs (insight + planning)
- Adds explicit `plan_for_n_plus_2()` call example with parameters
- Marks N+2 coordination as CRITICAL/MANDATORY for Generation 4

## Problem

Issue #1164: Agents were posting insight thoughts but skipping `plan_for_n_plus_2()`, breaking the multi-generation coordination chain. The Prime Directive only told agents to "Post a Thought CR with type=insight" — no mention of the planning state function.

## Fix

Step ③ now explicitly instructs:
1. Post insight Thought CR (what you learned)
2. Call `plan_for_n_plus_2()` with concrete parameters — writes to canonical S3 path so successors receive proper N+2 coordination

## Verification

Check S3 `planning/planner-plan-*.json` files are created consistently after this PR merges.

Closes #1164