### PR TITLE
fix: track specialization when agent self-selects issue from GitHub (#1147)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3155,13 +3155,27 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   push_metric "CIPassOnExit" 1
   
   # Update specialization based on issue labels worked on this session (issue #1098)
-  # Fetch labels from the GitHub issue claimed/worked on this session
-  if type update_specialization &>/dev/null && [ -n "${COORDINATOR_ISSUE:-}" ] && [ "$COORDINATOR_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$COORDINATOR_ISSUE" --repo "$REPO" \
-      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
-    if [ -n "$WORKED_LABELS" ]; then
-      update_specialization "$WORKED_LABELS" 2>/dev/null || true
-      log "Specialization tracking updated: labels=$WORKED_LABELS"
+  # Fetch labels from the GitHub issue claimed/worked on this session.
+  # Fix (issue #1147): When coordinator queue was empty and agent self-selected an issue,
+  # COORDINATOR_ISSUE remains 0. Resolve the worked issue from activeAssignments in that case.
+  if type update_specialization &>/dev/null; then
+    WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
+    if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+      # Self-selected path: look up this agent's entry in coordinator-state activeAssignments
+      ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+      WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")
+      if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
+        log "Resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments for specialization tracking"
+      fi
+    fi
+    if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
+      WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        update_specialization "$WORKED_LABELS" 2>/dev/null || true
+        log "Specialization tracking updated: labels=$WORKED_LABELS (issue #$WORKED_ISSUE)"
+      fi
     fi
   fi
   


### PR DESCRIPTION
## Summary

When the coordinator task queue is empty, agents self-select issues via `claim_task <N>` directly. In this path, `COORDINATOR_ISSUE` is never set (remains 0), causing specialization tracking to be silently skipped.

This fix resolves the worked issue from `coordinator-state.activeAssignments` when `COORDINATOR_ISSUE=0`, enabling specialization tracking for the self-selection path.

Closes #1147

## Changes

- `images/runner/entrypoint.sh`: Updated specialization tracking logic (step 11.4) to:
  1. Check if `COORDINATOR_ISSUE` is 0 (self-selection path)
  2. If so, look up `${AGENT_NAME}:<issue>` entry in `coordinator-state.activeAssignments`
  3. Use the resolved issue number for label fetching and `update_specialization()` call
  4. Log when self-selected issue is resolved for observability

## Impact

Without this fix, agents working on self-selected issues (the majority when the queue empties) never build specialization history. This defeats identity-based routing (#1113) which depends on meaningful specialization data.

## Testing

The fix is defensive: `|| echo "0"` fallbacks ensure no regression if coordinator is unavailable. `update_specialization` is guarded by `type ... &>/dev/null` check.