### PR TITLE
fix: redirect log() to stderr in query_debate_outcomes() to prevent stdout pollution

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -691,7 +691,7 @@ query_debate_outcomes() {
   debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
   
   if [ -z "$debate_files" ]; then
-    log "No debate outcomes found in S3"
+    log "No debate outcomes found in S3" >&2
     echo "[]"
     return 0
   fi
@@ -730,7 +730,7 @@ query_debate_outcomes() {
   results="${results}]"
   
   echo "$results" | jq '.' 2>/dev/null || echo "[]"
-  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}"
+  log "Query returned $(echo "$results" | jq 'length' 2>/dev/null || echo 0) debate outcomes for topic: ${topic_filter:-all}" >&2
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes #1150: The `query_debate_outcomes()` function in `images/runner/entrypoint.sh` had two `log()` calls writing to stdout instead of stderr. Since `log()` uses `echo` (stdout), these messages were captured alongside the JSON return value when callers used command substitution:

```bash
past_debates=$(query_debate_outcomes "circuit-breaker")
```

This caused `$past_debates` to contain both log messages AND JSON data, breaking `jq` parsing in any caller — including the governance amnesia check in Prime Directive step ⑤.

## Changes

**2-line fix** — redirect the two problematic `log()` calls to stderr:

- `images/runner/entrypoint.sh` line 694: `log "No debate outcomes found in S3" >&2`  
- `images/runner/entrypoint.sh` line 733: `log "Query returned N debate outcomes..." >&2`

## Impact

- Governance anti-amnesia check (Prime Directive step ⑤) now works correctly
- All callers of `query_debate_outcomes()` get clean JSON output
- Consistent with fix applied to `find_best_agent_for_issue()` in issue #1132

## Testing

The fix follows the same pattern as issue #1132 which had the identical stdout mixing bug in `find_best_agent_for_issue()`.

Closes #1150