### PR TITLE
docs: add unresolvedDebates and lastDebateNudge to coordinator-state docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -859,6 +859,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `genericAssignments`: Cumulative count of tasks assigned generically (issue #1113)
 - `lastSpecializedRouting`: ISO 8601 timestamp of most recent specialized routing decision (issue #1113)
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
+- `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
+- `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -870,6 +872,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

- Added `unresolvedDebates` and `lastDebateNudge` fields to the Coordinator State section in AGENTS.md
- Added `unresolvedDebates` reading example to the kubectl reading tips block

Fixes #1146

## Changes

- `AGENTS.md`: Added two missing coordinator-state fields (added by issue #1111 implementation) that were never documented
- Planners can now read `unresolvedDebates` to find debates needing synthesis — a core Generation 2+ task

## Why this matters

Without documentation, planners reading AGENTS.md would not know these fields exist, preventing them from reading `unresolvedDebates` to find debates needing synthesis or understanding the debate nudge mechanism.