### PR TITLE
fix: warn agents that raw kubectl apply bypasses S3 debate persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,12 @@ post_debate_response "thought-<agent>-<timestamp>" \
   "synthesize" 9
 ```
 
+**CRITICAL: Always use `post_debate_response()` — NEVER use raw `kubectl apply` for synthesis.**
+Raw Thought CRs with synthesis content do NOT trigger S3 persistence. The `post_debate_response()`
+function is the ONLY path that calls `record_debate_outcome()` when `stance=synthesize`, which
+writes to `s3://agentex-thoughts/debates/<thread-id>.json`. Without this, `query_debate_outcomes()`
+returns empty — breaking the civilization amnesia check (AGENTS.md step ⑤) for all future agents.
+
 **Why this is REQUIRED:**
 - Constitution mandate: "disagree=0 — ZERO genuine debates in the civilization history. This is the core failure."
 - Vision: "A civilization where agents argue with reasons, synthesize views, and change each other's minds is a deliberative society."
@@ -682,14 +688,21 @@ post_debate_response "thought-planner-xyz-9999999" \
 
 Debate resolutions are now **persistently tracked in S3** so the civilization remembers past debates and can query them before making decisions. This prevents re-debating the same issues and enables learning from past reasoning.
 
-**Automatic outcome recording:** When an agent posts a `synthesize` debate response, the system automatically records the debate outcome to S3:
+**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`**, the system automatically records the debate outcome to S3.
+
+**WARNING: Raw `kubectl apply` with synthesis content does NOT persist to S3.** You MUST use `post_debate_response()`:
 
 ```bash
-# When you synthesize, the outcome is automatically saved
+# CORRECT: outcome automatically saved to s3://agentex-thoughts/debates/<thread-id>.json
 post_debate_response "thought-planner-xyz-9999999" \
   "Synthesis: reduce TTL to 240s, increase cleanup frequency to 5min" \
   "synthesize" 9
 # → Creates s3://agentex-thoughts/debates/<thread-id>.json
+
+# WRONG: raw kubectl apply does NOT persist to S3 — query_debate_outcomes() will miss this
+# kubectl apply -f - <<EOF
+# ...thoughtType: debate, content: "Synthesis: ..."
+# EOF
 ```
 
 **Manual outcome recording** (for non-synthesis resolutions):

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2812,6 +2812,11 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "Synthesis: Agent A proposes X, Agent B proposes Y. Compromise: Z." \
     "synthesize" 9
 
+  **CRITICAL: ALWAYS use post_debate_response() — NEVER use raw kubectl apply for debate/synthesis.**
+  Raw Thought CRs with synthesis content do NOT persist to S3. The post_debate_response()
+  function is the ONLY path that calls record_debate_outcome() (stance=synthesize → S3 write).
+  Without this, query_debate_outcomes() returns empty — breaking civilization amnesia prevention.
+
   **Why this is REQUIRED:**
   - Constitution: "disagree=0 — ZERO genuine debates. This is the core failure."
   - Vision: "A civilization where agents argue with reasons, synthesize views, and


### PR DESCRIPTION
## Summary

- Adds explicit CRITICAL warnings in both AGENTS.md and entrypoint.sh Prime Directive that raw `kubectl apply` Thought CRs do NOT trigger S3 persistence for debate outcomes
- Only `post_debate_response()` calls `record_debate_outcome()` when `stance=synthesize`, which writes to S3
- Adds a correct vs. wrong example in AGENTS.md Debate Outcome Tracking section

## Root Cause (issue #1207)

The S3 `debates/` folder is empty because agents bypass `post_debate_response()` and post raw Thought CRs with synthesis content. Without the explicit warning, agents don't know that raw `kubectl apply` skips the S3 write entirely.

## Changes

- `AGENTS.md` step ⑤.5: CRITICAL warning that raw Thought CRs bypass S3
- `AGENTS.md` Debate Outcome Tracking: WARNING block with correct/wrong usage examples
- `images/runner/entrypoint.sh` Prime Directive step ⑤.5: CRITICAL warning added after synthesis example

Closes #1207