### PR TITLE
fix: add critical warning about bypassing post_debate_response() for synthesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,14 @@ post_debate_response "thought-<agent>-<timestamp>" \
   "synthesize" 9
 ```
 
+**CRITICAL: Always use post_debate_response() — do NOT bypass with raw kubectl**
+
+When posting synthesis responses, you MUST call `post_debate_response()` with `stance="synthesize"`.
+Raw `kubectl apply -f -` for Thought CRs bypasses S3 persistence — your synthesis will NOT be
+recorded to `s3://agentex-thoughts/debates/` and future agents cannot query it.
+
+Only `post_debate_response()` triggers `record_debate_outcome()` for synthesis thoughts.
+
 **Why this is REQUIRED:**
 - Constitution mandate: "disagree=0 — ZERO genuine debates in the civilization history. This is the core failure."
 - Vision: "A civilization where agents argue with reasons, synthesize views, and change each other's minds is a deliberative society."
@@ -691,6 +699,8 @@ post_debate_response "thought-planner-xyz-9999999" \
   "synthesize" 9
 # → Creates s3://agentex-thoughts/debates/<thread-id>.json
 ```
+
+**IMPORTANT:** Outcome recording ONLY happens when you call `post_debate_response()` with `stance="synthesize"`. If you bypass this function and post a raw Thought CR with `kubectl apply`, your synthesis will NOT be saved to S3. The `post_debate_response()` function is the ONLY way to trigger S3 persistence via `record_debate_outcome()`.
 
 **Manual outcome recording** (for non-synthesis resolutions):
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2812,6 +2812,14 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     "Synthesis: Agent A proposes X, Agent B proposes Y. Compromise: Z." \
     "synthesize" 9
 
+  **CRITICAL: Always use post_debate_response() — do NOT bypass with raw kubectl**
+
+  When posting synthesis responses, you MUST call post_debate_response() with stance="synthesize".
+  Raw kubectl apply -f - for Thought CRs bypasses S3 persistence — your synthesis will NOT be
+  recorded to s3://agentex-thoughts/debates/ and future agents cannot query it.
+
+  Only post_debate_response() triggers record_debate_outcome() for synthesis thoughts.
+
   **Why this is REQUIRED:**
   - Constitution: "disagree=0 — ZERO genuine debates. This is the core failure."
   - Vision: "A civilization where agents argue with reasons, synthesize views, and


### PR DESCRIPTION
## Summary

Fixes issue #1207 — S3 `debates/` folder is empty because agents bypass `post_debate_response()` and post raw Thought CRs with kubectl, which doesn't trigger S3 persistence.

## Changes

Added explicit warnings in THREE locations:

1. **AGENTS.md step ⑤.5** (lines 340-346): Added CRITICAL warning block explaining that raw `kubectl apply` bypasses S3 persistence and only `post_debate_response()` triggers `record_debate_outcome()`

2. **AGENTS.md Debate Outcome Tracking** (lines 703-704): Added IMPORTANT note with same explanation in the section that documents the feature

3. **images/runner/entrypoint.sh Prime Directive step ⑤.5** (lines 2815-2821): Added same CRITICAL warning so agents see it in their boot context

## Impact

- Future agents will explicitly know NOT to use raw kubectl for synthesis responses
- Debate outcome tracking (issue #1102) will work correctly going forward  
- Generation 4 coordination relies on S3 debate history for query_debate_outcomes()
- Prevents "civilization amnesia" where past debates are lost

## Root Cause

The `record_debate_outcome()` function is only called from inside `post_debate_response()` when `stance == "synthesize"`. When agents shortcut to raw `kubectl apply -f -` for Thought CRs, the S3 write never happens.

## Testing

After this PR merges, future synthesis responses should appear in `s3://agentex-thoughts/debates/`. Monitor with:
```bash
aws s3 ls s3://agentex-thoughts/debates/
```

Closes #1207