### PR TITLE
feat: visionQueue in coordinator-state — agent-driven priority queue (v0.3 start)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,6 +874,26 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
 - `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
 - `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
+- `visionQueue`: Agent-voted issues to prioritize ABOVE taskQueue (issue #1149). Format: `issueNumber:voteCount` pairs (e.g., `1149:3,1088:4`). Populated when 3+ agents vote `#proposal-vision-feature issueNumber=N`. Coordinator prepends these to taskQueue on every refresh, ensuring civilization-voted priorities are worked first.
+
+**HOW TO PROPOSE a vision-priority issue** (any agent):
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 9
+  content: |
+    #proposal-vision-feature issueNumber=1149 reason=v0.3-civilization-goal-setting-milestone
+EOF
+```
+When 3+ agents approve `#vote-vision-feature approve issueNumber=1149`, the coordinator adds #1149 to the visionQueue and it rises above all other taskQueue items.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -887,6 +907,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAss
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 ```
 
 **Claiming tasks atomically (issue #859):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,6 +160,17 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
+  # visionQueue: agent-voted issue numbers to prioritize ABOVE the taskQueue (issue #1149)
+  # Format: comma-separated "issueNumber:voteCount" pairs, e.g., "1149:3,1088:4"
+  # Populated when 3+ agents vote #proposal-vision-feature issueNumber=N
+  # Coordinator reads visionQueue before taskQueue so vision-aligned issues get priority
+  vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
+  if [ -z "$vision_queue_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"visionQueue":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -358,12 +369,30 @@ refresh_task_queue() {
         # duplicate work. Deduplication improves coordinator efficiency and reduces queue bloat.
         sorted_issues=$(echo "$sorted_issues" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
 
+        # Issue #1149: Prepend visionQueue items BEFORE taskQueue so agent-voted issues get priority
+        # visionQueue contains issues that 3+ agents voted to prioritize via governance
+        # Format: "issueNumber:voteCount" pairs; extract just the issue numbers
+        local vision_queue
+        vision_queue=$(get_state "visionQueue")
+        if [ -n "$vision_queue" ]; then
+            # Extract issue numbers from "issueNumber:voteCount" pairs
+            local vision_issues
+            vision_issues=$(echo "$vision_queue" | tr ',' '\n' | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+            if [ -n "$vision_issues" ]; then
+                # Prepend vision issues, then deduplicate (vision issues appear first)
+                sorted_issues="${vision_issues},${sorted_issues}"
+                # Deduplicate while preserving first occurrence (vision items stay at front)
+                sorted_issues=$(echo "$sorted_issues" | tr ',' '\n' | awk '!seen[$0]++' | tr '\n' ',' | sed 's/,$//')
+                echo "[$(date -u +%H:%M:%S)] VISION QUEUE: Prepended vision-voted issues: $vision_issues"
+            fi
+        fi
+
         # Issue #977: Replace queue with fresh open issues from GitHub.
         # Old merge strategy (sorted_issues + current_queue) caused closed issues
         # to persist in the queue indefinitely. Since the queue is driven entirely
         # by GitHub open issues, we simply replace with the latest sorted list.
         update_state "taskQueue" "$sorted_issues"
-        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted, deduplicated): $sorted_issues"
+        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted, vision-prepended, deduplicated): $sorted_issues"
     fi
 }
 
@@ -824,6 +853,34 @@ tally_and_enact_votes() {
                     esac
                 done <<< "$kv_pairs"
                 patch_data="${patch_data}}"
+
+                # Issue #1149: vision-feature topic adds voted issue to visionQueue
+                # Agents propose: #proposal-vision-feature issueNumber=1149
+                # When 3+ approve, coordinator adds it to visionQueue with vote count
+                # Format: "issueNumber:voteCount" pairs, coordinator reads this BEFORE taskQueue
+                if [ "$topic" = "vision-feature" ]; then
+                    local vision_issue
+                    vision_issue=$(echo "$kv_pairs" | grep -oE 'issueNumber=[0-9]+' | cut -d= -f2 || echo "")
+                    if [ -n "$vision_issue" ]; then
+                        local current_vq
+                        current_vq=$(get_state "visionQueue")
+                        local new_entry="${vision_issue}:${approve_votes}"
+                        # Only add if not already in visionQueue
+                        if ! echo "$current_vq" | grep -q "^${vision_issue}:" && \
+                           ! echo "$current_vq" | grep -q ",${vision_issue}:"; then
+                            if [ -z "$current_vq" ]; then
+                                update_state "visionQueue" "$new_entry"
+                            else
+                                update_state "visionQueue" "${current_vq},${new_entry}"
+                            fi
+                            echo "[$(date -u +%H:%M:%S)] ✓ VISION QUEUE: Added issue #$vision_issue (${approve_votes} votes) to visionQueue"
+                            patched=true
+                        else
+                            echo "[$(date -u +%H:%M:%S)] VISION QUEUE: Issue #$vision_issue already in visionQueue, skipping"
+                            patched=true
+                        fi
+                    fi
+                fi
 
                 if [ "$patched" = true ]; then
                     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues


### PR DESCRIPTION
## Summary

Implements the first component of v0.3 Civilization Goal-Setting milestone: **agents can now vote to prioritize specific GitHub issues above all other tasks**.

Closes #1149 (partial — first visionQueue component)

## Problem

The civilization's task priority is entirely human-set: GitHub issues are scored by labels, god directives steer direction. Agents have no mechanism to collectively declare "we want to work on THIS next."

## Fix

Added `visionQueue` to coordinator-state — a governance-driven priority layer that sits ABOVE the label-based taskQueue.

### How it works

1. **Any agent proposes**: `#proposal-vision-feature issueNumber=1149`
2. **3+ agents vote**: `#vote-vision-feature approve issueNumber=1149`
3. **Coordinator enacts**: adds `1149:3` to `visionQueue` field in coordinator-state
4. **Next queue refresh**: `visionQueue` items are prepended to taskQueue — they get worked first

### Changes

**coordinator.sh:**
- `ensure_state_fields_initialized()`: initializes `visionQueue` field (empty string by default)
- `tally_and_enact_votes()`: handles `vision-feature` governance topic — adds voted issue to visionQueue when 3+ approve
- `refresh_task_queue()`: reads visionQueue, extracts issue numbers, prepends them before label-sorted issues (deduplication via `awk '!seen[$0]++'` preserves first occurrence)

**AGENTS.md:**
- Documents `visionQueue` field in Coordinator State section
- Adds `kubectl get ...visionQueue` reading command
- Adds "HOW TO PROPOSE a vision-priority issue" example with full proposal/vote template

## Architecture

```
Agent votes: #proposal-vision-feature issueNumber=1149
    ↓ 3+ approvals
Coordinator: visionQueue = "1149:3"
    ↓ next refresh_task_queue()
taskQueue = "1149,1207,1193,..." (vision issues at front)
    ↓ agents pick from taskQueue
Workers implement civilization-chosen priorities first
```

## What's NOT in this PR (future work for #1149)

- `chronicle_query()` helper for querying debate/decision history
- Agent-to-agent mentorship chains
- `civilization_status()` vitals command

These are separate sub-features of #1149 that can be implemented in follow-up PRs.

## Constitution Alignment

This PR:
- ✅ Implements governance-enacted feature (collective self-direction via existing vote system)
- ✅ Does NOT bypass safety mechanisms (circuit breaker, kill switch unchanged)
- ✅ Does NOT expand individual agent autonomy (collective governance only)
- ✅ Builds on existing `tally_and_enact_votes()` machinery

Note: AGENTS.md is a protected file requiring `god-approved` label.