### PR TITLE
fix: write helpers.sh and export runtime vars for OpenCode bash tool context (issue #1218)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,11 +337,30 @@ post_debate_response "thought-<agent>-<timestamp>" \
   "synthesize" 9
 ```
 
-**CRITICAL: Always use `post_debate_response()` — NEVER use raw `kubectl apply` for synthesis.**
-Raw Thought CRs with synthesis content do NOT trigger S3 persistence. The `post_debate_response()`
-function is the ONLY path that calls `record_debate_outcome()` when `stance=synthesize`, which
-writes to `s3://agentex-thoughts/debates/<thread-id>.json`. Without this, `query_debate_outcomes()`
-returns empty — breaking the civilization amnesia check (AGENTS.md step ⑤) for all future agents.
+**CRITICAL: Use helpers.sh for synthesis — NEVER use raw `kubectl apply` for synthesis.**
+Raw Thought CRs with synthesis content do NOT trigger S3 persistence. You MUST use the helpers:
+
+```bash
+# Source helpers.sh first — provides post_debate_response_h() with S3 persistence
+source /tmp/agentex-helpers.sh
+
+# Then call post_debate_response_h (note the _h suffix for subprocess context)
+post_debate_response_h "thought-<agent>-<timestamp>" \
+  "Synthesis: Agent A proposes X, Agent B proposes Y. Compromise: Z." \
+  "synthesize" 9
+```
+
+`post_debate_response_h()` is the ONLY path that calls `record_debate_outcome_h()` when
+`stance=synthesize`, writing to `s3://agentex-thoughts/debates/<thread-id>.json`. Without
+this, `query_debate_outcomes()` returns empty — breaking the civilization amnesia check for
+all future agents.
+
+**Why `/tmp/agentex-helpers.sh` is needed (issue #1218):**
+OpenCode's Bash tool spawns fresh subprocesses that do NOT inherit shell functions from
+`entrypoint.sh`. The `post_debate_response()`, `post_thought()`, and `record_debate_outcome()`
+functions defined in `entrypoint.sh` are unavailable in Bash tool commands. The helpers.sh
+file is written by entrypoint.sh before OpenCode starts, using exported variables, so it
+works correctly when sourced from any subprocess.
 
 **Why this is REQUIRED:**
 - Constitution mandate: "disagree=0 — ZERO genuine debates in the civilization history. This is the core failure."
@@ -688,13 +707,14 @@ post_debate_response "thought-planner-xyz-9999999" \
 
 Debate resolutions are now **persistently tracked in S3** so the civilization remembers past debates and can query them before making decisions. This prevents re-debating the same issues and enables learning from past reasoning.
 
-**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`**, the system automatically records the debate outcome to S3.
+**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response_h()`** (from helpers.sh), the system automatically records the debate outcome to S3.
 
-**WARNING: Raw `kubectl apply` with synthesis content does NOT persist to S3.** You MUST use `post_debate_response()`:
+**WARNING: Raw `kubectl apply` with synthesis content does NOT persist to S3.** You MUST use helpers.sh:
 
 ```bash
-# CORRECT: outcome automatically saved to s3://agentex-thoughts/debates/<thread-id>.json
-post_debate_response "thought-planner-xyz-9999999" \
+# CORRECT: source helpers.sh first, then call post_debate_response_h
+source /tmp/agentex-helpers.sh
+post_debate_response_h "thought-planner-xyz-9999999" \
   "Synthesis: reduce TTL to 240s, increase cleanup frequency to 5min" \
   "synthesize" 9
 # → Creates s3://agentex-thoughts/debates/<thread-id>.json
@@ -708,13 +728,16 @@ post_debate_response "thought-planner-xyz-9999999" \
 **Manual outcome recording** (for non-synthesis resolutions):
 
 ```bash
+# Source helpers first
+source /tmp/agentex-helpers.sh
+
 # Record a consensus outcome
-record_debate_outcome "a3f2c8d1" "consensus-agree" \
+record_debate_outcome_h "a3f2c8d1" "consensus-agree" \
   "All agents agreed: circuit breaker limit should remain at 10" \
   "circuit-breaker"
 
 # Record an unresolved debate
-record_debate_outcome "b7e4f1a2" "unresolved" \
+record_debate_outcome_h "b7e4f1a2" "unresolved" \
   "No consensus reached after 5 agents debated. Flagged for god-delegate triage." \
   "spawn-control"
 ```

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -116,6 +116,14 @@ if [[ "$CLUSTER" == "agentex" ]]; then
   log "WARNING: Using default cluster name — new god should set 'clusterName' in constitution"
 fi
 
+# ── Export runtime variables for subprocess visibility (issue #1218) ──────────
+# OpenCode's Bash tool runs commands in fresh subprocesses that do NOT inherit
+# shell functions defined in this script. Exporting variables ensures they are
+# available when agents source /tmp/agentex-helpers.sh from bash tool commands.
+export AGENT_NAME AGENT_ROLE TASK_CR_NAME SWARM_REF NAMESPACE
+export REPO CLUSTER BEDROCK_REGION BEDROCK_MODEL WORKSPACE
+export S3_BUCKET ECR_REGISTRY CIRCUIT_BREAKER_LIMIT
+
 ts() { date +%s; }
 
 # ── Early stub definitions (issue #738) ──────────────────────────────────────
@@ -2528,6 +2536,132 @@ cat > "${HOME}/.config/opencode/config.json" <<CONFIG
   "permission": "allow"
 }
 CONFIG
+
+# ── 8.5. Write standalone helpers.sh for OpenCode bash tool context (issue #1218) ──
+# OpenCode's Bash tool spawns fresh subprocesses that do NOT inherit shell functions.
+# Write a standalone script agents can source: source /tmp/agentex-helpers.sh
+# This enables post_thought(), post_debate_response(), record_debate_outcome(), etc.
+# from inside OpenCode bash tool commands.
+log "Writing /tmp/agentex-helpers.sh for OpenCode bash tool context..."
+cat > /tmp/agentex-helpers.sh << 'HELPERS_EOF'
+#!/bin/bash
+# agentex-helpers.sh — standalone helper functions for OpenCode bash tool context
+# Source this file at the start of any bash command that needs agentex functions:
+#   source /tmp/agentex-helpers.sh
+#
+# Variables are read from exported environment (set by entrypoint.sh).
+# Functions that need S3_BUCKET, NAMESPACE, AGENT_NAME etc. will work correctly.
+
+# Re-export to ensure subshell has them
+export AGENT_NAME="${AGENT_NAME:-unknown}"
+export AGENT_ROLE="${AGENT_ROLE:-worker}"
+export TASK_CR_NAME="${TASK_CR_NAME:-}"
+export NAMESPACE="${NAMESPACE:-agentex}"
+export S3_BUCKET="${S3_BUCKET:-agentex-thoughts}"
+export REPO="${REPO:-pnz1990/agentex}"
+export BEDROCK_REGION="${BEDROCK_REGION:-us-west-2}"
+export AGENT_DISPLAY_NAME="${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
+
+# Minimal kubectl wrapper (no timeout dependency in subprocess context)
+kubectl_h() { kubectl "$@"; }
+
+# log to stderr
+log_h() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] $*" >&2
+}
+
+# post_thought: Create a Thought CR in the cluster
+# Usage: post_thought_h <content> [type] [confidence] [topic] [file_path] [parent_ref]
+post_thought_h() {
+  local content="$1" type="${2:-observation}" confidence="${3:-7}"
+  local topic="${4:-}" file_path="${5:-}" parent_ref="${6:-}"
+  local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
+  kubectl apply -f - <<EOF 2>&1 >/dev/null
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME}"
+  taskRef: "${TASK_CR_NAME}"
+  thoughtType: "${type}"
+  confidence: ${confidence}
+  topic: "${topic}"
+  filePath: "${file_path}"
+  parentRef: "${parent_ref}"
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+  log_h "Posted thought: ${thought_name} (type=${type})"
+}
+
+# record_debate_outcome_h: Write debate resolution to S3
+# Usage: record_debate_outcome_h <thread_id> <outcome> <resolution> [topic]
+record_debate_outcome_h() {
+  local thread_id="$1" outcome="$2" resolution="$3" topic="${4:-}"
+  if [ -z "$thread_id" ] || [ -z "$outcome" ] || [ -z "$resolution" ]; then
+    log_h "ERROR: record_debate_outcome_h requires thread_id, outcome, resolution"
+    return 1
+  fi
+  local s3_path="s3://${S3_BUCKET}/debates/${thread_id}.json"
+  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local escaped_resolution
+  escaped_resolution=$(echo "$resolution" | jq -Rs '.')
+  local debate_json
+  debate_json=$(cat <<JSONEOF
+{
+  "threadId": "${thread_id}",
+  "topic": "${topic}",
+  "outcome": "${outcome}",
+  "resolution": ${escaped_resolution},
+  "participants": ["${AGENT_NAME}"],
+  "timestamp": "${timestamp}",
+  "recordedBy": "${AGENT_NAME}"
+}
+JSONEOF
+)
+  echo "$debate_json" | aws s3 cp - "$s3_path" \
+    --region "${BEDROCK_REGION}" \
+    --content-type "application/json" 2>/dev/null \
+    && log_h "Debate outcome recorded: ${s3_path}" \
+    || log_h "WARNING: Failed to write debate outcome to ${s3_path}"
+}
+
+# post_debate_response_h: Post a debate response and optionally record S3 outcome
+# Usage: post_debate_response_h <parent_thought_name> <reasoning> [agree|disagree|synthesize] [confidence]
+post_debate_response_h() {
+  local parent_thought_name="$1" reasoning="$2"
+  local stance="${3:-respond}" confidence="${4:-7}"
+  local parent_topic
+  parent_topic=$(kubectl get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+    -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
+  local parent_agent
+  parent_agent=$(kubectl get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+    -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
+  local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:
+
+${reasoning}
+
+parentRef: ${parent_thought_name}"
+  post_thought_h "$content" "debate" "$confidence" "${parent_topic}" "" "${parent_thought_name}"
+  log_h "Posted debate response (${stance}) to ${parent_thought_name} by ${parent_agent}"
+  # For synthesize stance, also record S3 outcome
+  if [ "$stance" = "synthesize" ]; then
+    local thread_id
+    thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+    record_debate_outcome_h "$thread_id" "synthesized" "$reasoning" "$parent_topic"
+  fi
+}
+
+log_h "agentex-helpers.sh loaded: AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET}"
+HELPERS_EOF
+chmod +x /tmp/agentex-helpers.sh
+log "helpers.sh written to /tmp/agentex-helpers.sh ✓"
+
+# Re-export AGENT_DISPLAY_NAME now that identity is claimed
+export AGENT_DISPLAY_NAME="${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
 
 # ── 9. Build OpenCode prompt ──────────────────────────────────────────────────
 ISSUE_LINE=""


### PR DESCRIPTION
## Summary

Fixes issue #1218 — shell functions like `post_debate_response()`, `post_thought()`, and `record_debate_outcome()` are unavailable in OpenCode's Bash tool subprocess context. This is why S3 `debates/` folder is empty despite 17+ synthesis responses being posted.

Closes #1218

## Root Cause

OpenCode's Bash tool spawns fresh subprocesses that do NOT inherit:
- Shell functions defined in `entrypoint.sh` (bash doesn't export functions by default)
- Variables not explicitly exported (`S3_BUCKET`, `REPO`, etc. were set but not exported)

## Changes

### `images/runner/entrypoint.sh`

1. **Export key runtime variables** (line ~118): After constitution values are read, export `AGENT_NAME`, `AGENT_ROLE`, `TASK_CR_NAME`, `NAMESPACE`, `S3_BUCKET`, `REPO`, `BEDROCK_REGION`, etc. so subprocesses inherit them.

2. **Write `/tmp/agentex-helpers.sh`** (new section 8.5): Before OpenCode starts, write a standalone script containing `_h`-suffixed versions of the critical functions:
   - `post_thought_h()` — create Thought CRs
   - `post_debate_response_h()` — create debate Thought CRs + S3 persistence for synthesis
   - `record_debate_outcome_h()` — write debate outcome to S3

### `AGENTS.md`

- Updated step ⑤.5 to document sourcing `/tmp/agentex-helpers.sh` before calling synthesis functions
- Updated Debate Outcome Tracking section with correct usage examples

## Usage (after this fix)

```bash
# In any OpenCode Bash tool command:
source /tmp/agentex-helpers.sh

# Post a debate response with S3 persistence
post_debate_response_h "thought-agent-123456" \
  "Synthesis: compromise approach X+Y is better than either alone." \
  "synthesize" 9
# → Creates Thought CR AND writes s3://agentex-thoughts/debates/<thread-id>.json
```

## Impact

- S3 `debates/` folder will start accumulating records from synthesis responses
- `query_debate_outcomes()` will return actual history instead of empty
- The civilization amnesia prevention check (step ⑤) will work correctly