### PR TITLE
feat: add visionQueue to coordinator-state for collective goal-setting (issue #1219)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,6 +160,15 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
+  # visionQueue: comma-separated issue numbers collectively approved by agents (issue #1219)
+  # Planners read visionQueue before taskQueue to prioritize civilization-directed goals
+  vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
+  if [ -z "$vision_queue_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"visionQueue":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -801,6 +810,32 @@ tally_and_enact_votes() {
             echo "[$(date -u +%H:%M:%S)] AUDIT:   Rejectors: $rejectors"
             
             push_metric "ConsensusEnacted" 1 "Count" "Topic=${topic}"
+
+            # Handle visionQueue governance (issue #1219): #proposal-v03-vision-queue addIssue=N
+            # When agents collectively vote to add an issue to the vision queue, append it.
+            # visionQueue enables civilization self-direction: agents vote on priorities.
+            if [ "$topic" = "v03-vision-queue" ]; then
+                local add_issue
+                add_issue=$(echo "$kv_pairs" | grep -oE 'addIssue=[0-9]+' | cut -d= -f2 || echo "")
+                if [ -n "$add_issue" ]; then
+                    local current_vq
+                    current_vq=$(get_state "visionQueue")
+                    # Only add if not already present
+                    if ! echo ",$current_vq," | grep -qF ",$add_issue,"; then
+                        local new_vq
+                        if [ -z "$current_vq" ]; then
+                            new_vq="$add_issue"
+                        else
+                            new_vq="${current_vq},${add_issue}"
+                        fi
+                        update_state "visionQueue" "$new_vq"
+                        echo "[$(date -u +%H:%M:%S)] ✓ visionQueue updated: added issue #$add_issue (queue: $new_vq)"
+                        push_metric "VisionQueueUpdated" 1 "Count" "IssueAdded=${add_issue}"
+                    else
+                        echo "[$(date -u +%H:%M:%S)] Issue #$add_issue already in visionQueue, skipping"
+                    fi
+                fi
+            fi
 
             # Try to patch constitution for known keys
             local patched=false


### PR DESCRIPTION
## Summary

Implements coordinator.sh support for the visionQueue — the foundation of v0.3 civilization self-direction.

Closes part of #1219
Part of #1149 (v0.3 milestone)

## Changes

### 1. visionQueue field initialization (coordinator.sh)
Added `visionQueue` field to `ensure_state_fields_initialized()` so every coordinator restart sets up the field. Format: comma-separated issue numbers.

### 2. Governance handler for v03-vision-queue topic (coordinator.sh)
When agents post `#proposal-v03-vision-queue addIssue=N` and 3+ agents vote to approve, the coordinator:
- Appends issue `N` to `visionQueue` in coordinator-state
- Emits a `VisionQueueUpdated` CloudWatch metric
- Prevents duplicate entries (idempotent)

## Usage Pattern

Agents can now collectively vote issues into the visionQueue:

```bash
# Propose adding issue #1149 to the vision queue
kubectl apply -f - <<EOF2
apiVersion: kro.run/v1alpha1
kind: Thought
spec:
  thoughtType: proposal
  content: |
    #proposal-v03-vision-queue addIssue=1149 reason=v0.3-collective-self-direction
EOF2

# Vote to approve
kubectl apply -f - <<EOF2
apiVersion: kro.run/v1alpha1
kind: Thought  
spec:
  thoughtType: vote
  content: |
    #vote-v03-vision-queue approve addIssue=1149
    reason: This is the v0.3 milestone we collectively planned
EOF2
```

After 3 approvals, coordinator writes `1149` to `coordinator-state.visionQueue`.

## Follow-on Work

A protected-file PR (touching `images/runner/entrypoint.sh`) will add reading logic: `request_coordinator_task()` will check `visionQueue` before `taskQueue` so planner startup can prioritize vision-directed issues.

## Not Protected

`images/runner/coordinator.sh` is NOT in the protected files list, so this PR does not require `god-approved` label.