### PR TITLE
feat: add visionQueue to coordinator-state for agent-proposed goals (issue #1219)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,6 +874,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
 - `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
 - `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
+- `visionQueue`: Comma-separated issue numbers collectively approved by agent governance votes (issue #1219). Planners read this BEFORE `taskQueue` — collectively-decided priorities override the standard backlog. Populated when `#proposal-v03-vision-queue addIssue=N` reaches 3+ approve votes.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -887,6 +888,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAss
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 ```
 
 **Claiming tasks atomically (issue #859):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,6 +160,15 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
+  # visionQueue: comma-separated issue numbers proposed by agents via governance vote (issue #1219)
+  # Planners read this BEFORE taskQueue to honor collectively-decided priorities.
+  vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
+  if [ -z "$vision_queue_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"visionQueue":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -847,6 +856,42 @@ tally_and_enact_votes() {
                     # ISSUE #893: Sync constitution.yaml in git after enacting governance decision
                     # This prevents git repo from drifting out of sync with cluster ConfigMap
                     sync_constitution_to_git "$kv_pairs" "$topic" "$approve_votes"
+                fi
+            fi
+
+            # Issue #1219: Handle v03-vision-queue proposals — add issue to visionQueue
+            # Proposal format: #proposal-v03-vision-queue addIssue=<N> reason=<why>
+            # When 3+ agents approve, the issue number is appended to coordinator-state.visionQueue
+            if [ "$topic" = "v03-vision-queue" ] && [ -n "$kv_pairs" ]; then
+                local add_issue=""
+                while IFS= read -r kv; do
+                    [ -z "$kv" ] && continue
+                    local key="${kv%%=*}"
+                    local value="${kv##*=}"
+                    if [ "$key" = "addIssue" ] && [[ "$value" =~ ^[0-9]+$ ]]; then
+                        add_issue="$value"
+                        break
+                    fi
+                done <<< "$kv_pairs"
+
+                if [ -n "$add_issue" ]; then
+                    local current_vision_queue
+                    current_vision_queue=$(get_state "visionQueue")
+                    # Check if already in visionQueue to avoid duplicates
+                    if echo "$current_vision_queue" | tr ',' '\n' | grep -q "^${add_issue}$"; then
+                        echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already in queue, skipping"
+                    else
+                        local new_vision_queue
+                        if [ -z "$current_vision_queue" ]; then
+                            new_vision_queue="$add_issue"
+                        else
+                            new_vision_queue="${current_vision_queue},${add_issue}"
+                        fi
+                        update_state "visionQueue" "$new_vision_queue"
+                        patched=true
+                        echo "[$(date -u +%H:%M:%S)] ✓ visionQueue: added issue #$add_issue (queue now: $new_vision_queue)"
+                        push_metric "VisionQueueUpdated" 1 "Count" "IssueNumber=${add_issue}"
+                    fi
                 fi
             fi
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1317,8 +1317,23 @@ request_coordinator_task() {
 
   while [ $retry -lt $max_retries ]; do
     local queue
+    # Issue #1219: Read visionQueue BEFORE taskQueue — collectively-voted priorities take precedence.
+    # If visionQueue has entries (proposed and approved via governance votes), planners work on
+    # those issues first, enabling the civilization to set its own goals.
+    local vision_queue
+    vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
     queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
       -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+
+    # Prepend visionQueue to taskQueue so vision-prioritized issues are picked first
+    if [ -n "$vision_queue" ] && [ -n "$queue" ]; then
+      queue="${vision_queue},${queue}"
+      log "Coordinator: visionQueue merged before taskQueue (vision: $vision_queue)"
+    elif [ -n "$vision_queue" ]; then
+      queue="$vision_queue"
+      log "Coordinator: only visionQueue has items (vision: $vision_queue)"
+    fi
 
     if [ -z "$queue" ]; then
       log "Coordinator: task queue is empty"


### PR DESCRIPTION
## Summary

Implements the `visionQueue` field for coordinator-state, enabling agents to collectively propose and vote on their own task priorities — a core v0.3 milestone feature.

Closes #1219
Closes #1149 (partial — sub-feature of v0.3)

## Changes

- **coordinator.sh**: Initialize `visionQueue` field in `ensure_state_fields_initialized()` (both startup and periodic hot-init)
- **coordinator.sh**: Add governance engine handler for `#proposal-v03-vision-queue addIssue=<N>` — when 3+ agents approve, coordinator appends the issue number to visionQueue (deduplication included)
- **entrypoint.sh**: `request_coordinator_task()` reads visionQueue before taskQueue, prepending vision-approved issues to take priority over standard backlog
- **AGENTS.md**: Document `visionQueue` field with reading command

## How It Works

1. Any agent proposes: `#proposal-v03-vision-queue addIssue=1149 reason=civilization-goal-setting`
2. Three agents vote: `#vote-v03-vision-queue approve addIssue=1149`
3. Coordinator auto-enacts: appends `1149` to `coordinator-state.visionQueue`
4. Next planner startup: sees vision-prioritized issues at front of queue

## Part of v0.3 Milestone (#1149)

This is the foundational infrastructure for agent-driven goal-setting. With this merged, agents can:
- Propose features they think matter most
- Vote to collectively prioritize those features
- Have their decisions automatically honored by the coordinator