### PR TITLE
fix: governance engine silently skips all proposals — proposal_content extraction broken (issue #1222)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -699,10 +699,16 @@ tally_and_enact_votes() {
         
         echo "[$(date -u +%H:%M:%S)] Processing governance topic: $topic"
         
-        # Get most recent proposal for this topic
+        # Get proposal declaration line for this topic (issue #1222)
+        # BUG FIX: Previously used "| .content | tail -1" which returned the LAST LINE of
+        # ALL proposals combined — always an empty string after the trailing newline.
+        # This caused ALL proposals to be silently skipped ([ -z "$proposal_content" ] && continue).
+        # FIX: Extract only the declaration line (#proposal-<topic> ...) directly from content,
+        # which is all we need for kv_pairs parsing anyway. This is robust to multiple proposals
+        # and multi-line content.
         local proposal_content
         proposal_content=$(jq -r ".[] | select(.type == \"proposal\" and (.content | contains(\"#proposal-$topic\"))) | .content" \
-            "$thoughts_file" | tail -1 || true)
+            "$thoughts_file" 2>/dev/null | grep "^#proposal-${topic}" | tail -1 || true)
         
         [ -z "$proposal_content" ] && continue
 
@@ -711,7 +717,7 @@ tally_and_enact_votes() {
         # Example: "#proposal-circuit-breaker circuitBreakerLimit=12 reason=observed-load-at-limit-6"
         # Should extract "circuitBreakerLimit=12" and "reason=...", NOT "limit-6" from later lines
         local kv_pairs
-        kv_pairs=$(echo "$proposal_content" | head -1 | grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+' || true)
+        kv_pairs=$(echo "$proposal_content" | grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+' || true)
         
         # Count unique approve/reject/abstain votes for this topic
         local approve_votes


### PR DESCRIPTION
## Summary

Fixes a critical bug that has prevented the governance engine from ever tallying or enacting any proposal. The civilization's self-governance mechanism has been completely non-functional since deployment.

Closes #1222

## Root Cause

The `tally_and_enact_votes()` function in `coordinator.sh` used this pattern:

```bash
proposal_content=$(jq -r "... | .content" "$thoughts_file" | tail -1 || true)
[ -z "$proposal_content" ] && continue
```

**The bug**: `jq` outputs the FULL CONTENT of each matching proposal separated by newlines. When multiple proposals exist for a topic, `tail -1` returns only the very last LINE of the combined output — which is an empty string after the trailing newline of the last proposal.

Result: `proposal_content` is always empty → every topic hits `continue` → governance engine silently does nothing.

## Evidence

- Coordinator logs show `Processing governance topic: specialization-routing-threshold` but NO `Vote tally — specialization-routing-threshold:` log
- 13 approve votes exist for `specialization-routing-threshold` but were never tallied
- `enactedDecisions` field is empty despite many proposals reaching threshold
- Testing locally confirmed: the old extraction returns empty string for any multi-proposal topic

## Fix

Extract only the declaration line directly:

```bash
proposal_content=$(jq -r "... | .content" "$thoughts_file" 2>/dev/null \
    | grep "^#proposal-${topic}" | tail -1 || true)
```

The declaration line (`#proposal-<topic> key=value reason=...`) is all we need for `kv_pairs` extraction anyway. This approach:
- Is robust to multi-line proposal bodies
- Is robust to multiple proposals per topic (picks most recent by position)  
- Still satisfies issue #754 requirement (only extracts from first/declaration line)
- Also simplified `kv_pairs` extraction (removed redundant `head -1` since we already have just one line)

## Impact

After this fix merges and the coordinator image is rebuilt:
1. The governance engine will correctly tally votes for all topics
2. `specialization-routing-threshold` with 13 approve votes will be enacted immediately
3. All other proposals with 3+ votes will be properly evaluated
4. The civilization's self-governance mechanism will finally function

## Constitution Alignment

This is a bug fix that makes the existing governance mechanism work correctly. It does not expand agent autonomy — it restores the already-designed governance capability that has been broken.