### PR TITLE
feat: auto-restart coordinator deployment after successful CI build (issue #1226)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -63,3 +63,18 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPO:latest
           echo "Pushed image with tags: ${{ github.sha }}, latest"
           echo "Agent Jobs will pull :latest tag automatically on next spawn"
+
+      - name: Restart coordinator deployment to pick up new image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Configure kubectl with EKS cluster
+          aws eks update-kubeconfig \
+            --name agentex \
+            --region ${{ env.AWS_REGION }} \
+            --alias agentex
+          # Rolling restart — coordinator picks up new :latest image
+          # This ensures fixes to coordinator.sh take effect immediately after merge
+          # (issue #1226: coordinator ran stale image missing critical bug fixes)
+          kubectl rollout restart deployment/coordinator -n agentex
+          kubectl rollout status deployment/coordinator -n agentex --timeout=120s
+          echo "Coordinator restarted successfully — running latest image"


### PR DESCRIPTION
## Summary

After each successful main-branch build+push of the runner image, automatically restart the coordinator deployment so it picks up the new `:latest` image.

Closes #1226

## Problem

The coordinator is a long-running Kubernetes Deployment using `:latest` tag with `imagePullPolicy: Always`. But `imagePullPolicy: Always` only pulls new images when a pod **starts** — not while it's running. Without a rollout restart, the coordinator stays on stale code indefinitely after merges.

**Evidence from this generation:**
- PR #1181 (jq fix), PR #1182 (S3 synthesis), PR #1189 (field init) merged at ~07:08-07:10
- Coordinator was restarted at 07:22 (manually triggered) — 14 minutes later
- During those 14 minutes, agents experienced:
  - `specializedAssignments` field missing from coordinator-state (v0.2 routing broken)
  - S3 `debates/` folder empty despite 17 syntheses
  - jq parse errors in every 30s cleanup cycle

## Changes

`.github/workflows/build-runner.yml` — adds a final step after `Push image`:
1. Configures kubectl against EKS cluster (using existing OIDC credentials)
2. Runs `kubectl rollout restart deployment/coordinator -n agentex`
3. Waits for rollout to succeed before workflow completes

## Impact

- Coordinator always runs latest code after every merge
- No manual rollout restarts needed
- Fixes take effect in ~30 seconds after push (pod restart time)

## Safety

- Only runs on `main` branch pushes (not on PRs)
- Uses `rollout restart` (rolling update, zero downtime)
- `rollout status --timeout=120s` fails the CI job if coordinator doesn't come healthy
- If rollout fails, god can investigate and re-trigger