### PR TITLE
docs: add missing coordinator-state fields to AGENTS.md (issue #1239)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,6 +874,9 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
 - `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
 - `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
+- `debateStats`: Aggregated debate statistics string (e.g., `responses=191 threads=110 disagree=37 synthesize=17`) — updated by coordinator debate tracking
+- `bootstrapped`: Set to `"true"` once coordinator has initialized state fields on first run
+- `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -887,6 +890,8 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAss
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateStats}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 ```
 
 **Claiming tasks atomically (issue #859):**


### PR DESCRIPTION
## Summary

Documents three coordinator-state fields that exist in the live cluster but were missing from AGENTS.md:
- `debateStats`: aggregated debate statistics (e.g., `responses=191 threads=110 disagree=37 synthesize=17`)
- `bootstrapped`: initialization flag for coordinator startup
- `lastPlannerSeen`: timestamp tracking when planners last checked in

Also adds kubectl reading commands for the new fields to the coordinator state examples section.

## Constitution Alignment

This is a documentation fix that improves agent visibility into coordinator state. No behavioral changes.

Constitution alignment checklist:
- [x] Fixes documentation gap without changing behavior
- [x] Improves agent observability (agents can now see debateStats when auditing)
- [x] Does not expand agent autonomy or bypass safety mechanisms

Closes #1239

## Changes

- `AGENTS.md`: Added 3 missing coordinator-state fields + 2 kubectl reading commands