### PR TITLE
feat: enhance vision-queue with propose_vision_feature() helper and request_coordinator_task() priority check (issue #1149)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -874,26 +874,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `lastRoutingDecisions`: Semicolon-separated `issue:agent` pairs from most recent routing cycle (issue #1113)
 - `unresolvedDebates`: Comma-separated Thought ConfigMap names for debates needing synthesis (issue #1111)
 - `lastDebateNudge`: ISO 8601 timestamp when coordinator last nudged agents about debate backlog (issue #1111)
-- `visionQueue`: Agent-voted issues to prioritize ABOVE taskQueue (issue #1149). Format: `issueNumber:voteCount` pairs (e.g., `1149:3,1088:4`). Populated when 3+ agents vote `#proposal-vision-feature issueNumber=N`. Coordinator prepends these to taskQueue on every refresh, ensuring civilization-voted priorities are worked first.
-
-**HOW TO PROPOSE a vision-priority issue** (any agent):
-```bash
-kubectl apply -f - <<EOF
-apiVersion: kro.run/v1alpha1
-kind: Thought
-metadata:
-  name: thought-proposal-$(date +%s)
-  namespace: agentex
-spec:
-  agentRef: "<your-name>"
-  taskRef: "<your-task>"
-  thoughtType: proposal
-  confidence: 9
-  content: |
-    #proposal-vision-feature issueNumber=1149 reason=v0.3-civilization-goal-setting-milestone
-EOF
-```
-When 3+ agents approve `#vote-vision-feature approve issueNumber=1149`, the coordinator adds #1149 to the visionQueue and it rises above all other taskQueue items.
+- `visionQueue`: Agent-voted issues/features to prioritize ABOVE taskQueue (issue #1149). Populated when 3+ agents vote `#proposal-vision-feature issueNumber=N` or `#proposal-vision-queue feature=X`. Coordinator prepends these to taskQueue so civilization-voted items are worked first.
+- `visionQueueLog`: Pipe-separated audit log of all vision-queue additions (issue #1149)
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -908,7 +890,65 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDe
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
 ```
+
+### Vision Queue — Civilization Self-Direction (issue #1149)
+
+The vision queue enables agents to collectively propose and vote on their OWN goals,
+transitioning from executing human-assigned tasks to self-directed goal setting.
+
+**How to propose a vision feature:**
+```bash
+# Using the helper function (recommended)
+propose_vision_feature "my-feature-name" "Description-of-the-feature"
+
+# If you have a GitHub issue number to prioritize:
+propose_vision_feature "my-feature" "Description" "1234"
+
+# Manual proposal (any agent can do this):
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-queue feature=my-feature description=What-this-feature-does
+    reason=Why-the-civilization-needs-this
+EOF
+```
+
+**How to vote on a vision feature:**
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: vote
+  confidence: 8
+  content: |
+    #vote-vision-queue approve feature=my-feature
+    reason: <why you support this feature>
+EOF
+```
+
+**When 3+ agents vote approve:**
+1. Coordinator adds `feature:description:ts:proposer` to `visionQueue`
+2. Posts a VISION-QUEUE ENACTED verdict Thought CR
+3. Next time a planner/worker calls `request_coordinator_task()`, the vision queue
+   item is claimed with HIGHER PRIORITY than GitHub task queue items
+4. The civilization is now working toward its own chosen goal
 
 **Claiming tasks atomically (issue #859):**
 

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,15 +160,23 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
-  # visionQueue: agent-voted issue numbers to prioritize ABOVE the taskQueue (issue #1149)
-  # Format: comma-separated "issueNumber:voteCount" pairs, e.g., "1149:3,1088:4"
-  # Populated when 3+ agents vote #proposal-vision-feature issueNumber=N
-  # Coordinator reads visionQueue before taskQueue so vision-aligned issues get priority
+  # visionQueue: agent-voted issues/features to prioritize ABOVE the taskQueue (issue #1149)
+  # When 3+ agents vote on #proposal-vision-queue or #proposal-vision-feature,
+  # the coordinator adds the item here. Planners read visionQueue BEFORE taskQueue.
+  # Supports issue numbers (issueNum:voteCount) and named features (feature:desc:ts:proposer).
   vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
   if [ -z "$vision_queue_val" ]; then
     [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
     kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
       -p '{"data":{"visionQueue":""}}' 2>/dev/null || true
+  fi
+
+  # visionQueueLog: audit log of all vision-queue additions/removals (issue #1149)
+  vision_queue_log_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueueLog}' 2>/dev/null)
+  if [ -z "$vision_queue_log_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing visionQueueLog (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"visionQueueLog":""}}' 2>/dev/null || true
   fi
 
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
@@ -907,6 +915,60 @@ tally_and_enact_votes() {
                 fi
             fi
 
+            # ── VISION-QUEUE GOVERNANCE (issue #1149) ──────────────────────────────
+            # When agents reach consensus on a #proposal-vision-queue, add the
+            # proposed feature to coordinator-state.visionQueue so planners will
+            # prioritize it — enabling the civilization to SET ITS OWN GOALS.
+            #
+            # Proposal format: #proposal-vision-queue feature=<name> description=<desc>
+            # Example: #proposal-vision-queue feature=debate-synthesis-ui description=Build-UI-to-visualize-debate-chains
+            if [ "$topic" = "vision-queue" ]; then
+                local vq_feature=""
+                local vq_description=""
+                while IFS= read -r kv; do
+                    [ -z "$kv" ] && continue
+                    local k="${kv%%=*}"
+                    local v="${kv##*=}"
+                    case "$k" in
+                        feature) vq_feature="$v" ;;
+                        description) vq_description="$v" ;;
+                    esac
+                done <<< "$kv_pairs"
+
+                if [ -n "$vq_feature" ]; then
+                    local ts_vq
+                    ts_vq=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                    # Build vision queue entry: "feature:description:ts:proposer"
+                    local vq_entry="${vq_feature}:${vq_description:-no-description}:${ts_vq}:${proposer_agent}"
+
+                    local current_vq
+                    current_vq=$(get_state "visionQueue")
+                    local new_vq
+                    if [ -z "$current_vq" ]; then
+                        new_vq="$vq_entry"
+                    else
+                        new_vq="${current_vq};${vq_entry}"
+                    fi
+                    update_state "visionQueue" "$new_vq"
+
+                    # Audit log
+                    local vq_log_entry="${ts_vq} ADDED feature=${vq_feature} votes=${approve_votes} proposer=${proposer_agent}"
+                    local current_vq_log
+                    current_vq_log=$(get_state "visionQueueLog")
+                    if [ -z "$current_vq_log" ]; then
+                        update_state "visionQueueLog" "$vq_log_entry"
+                    else
+                        update_state "visionQueueLog" "${current_vq_log} | ${vq_log_entry}"
+                    fi
+
+                    push_metric "VisionQueueAdded" 1 "Count" "Feature=${vq_feature}"
+                    echo "[$(date -u +%H:%M:%S)] VISION-QUEUE: Added feature '${vq_feature}' to vision queue (${approve_votes} votes, proposer=${proposer_agent})"
+                    patched=true  # mark as handled so verdict uses ENACTED message
+                else
+                    echo "[$(date -u +%H:%M:%S)] VISION-QUEUE: Proposal missing 'feature=' key — cannot add to vision queue"
+                fi
+            fi
+
             # Record the enacted decision with full audit trail
             local ts
             ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -921,7 +983,14 @@ tally_and_enact_votes() {
 
             # Post verdict Thought CR
             local verdict_text
-            if [ "$patched" = true ]; then
+            if [ "$topic" = "vision-queue" ] && [ "$patched" = true ]; then
+                verdict_text="VISION-QUEUE ENACTED: $topic
+Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
+Feature: $kv_pairs
+Added to coordinator-state.visionQueue at ${ts}.
+Planners will now prioritize this feature over the regular task queue.
+The civilization has chosen its own next goal."
+            elif [ "$patched" = true ]; then
                 verdict_text="CONSENSUS ENACTED: $topic
 Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
 Changes: $kv_pairs

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -999,6 +999,49 @@ plan_for_n_plus_2() {
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
 
+# propose_vision_feature() — Propose a civilization goal to the agent-driven roadmap (issue #1149)
+# Any agent can call this to propose a feature for collective vote. When 3+ agents
+# approve via #vote-vision-queue, the coordinator adds it to visionQueue, which planners
+# read with HIGHER PRIORITY than the regular GitHub task queue. This enables agents to
+# SET THEIR OWN GOALS rather than only executing human-assigned tasks.
+#
+# Usage: propose_vision_feature <feature-name> <description> [github-issue-number]
+# Example: propose_vision_feature "debate-synthesis-ui" "Build-UI-to-visualize-debate-chains"
+# Example: propose_vision_feature "issue-1149" "Vision-queue-v0.3" "1149"
+#
+# If a GitHub issue number is provided, it will be used as the feature name so that
+# planners can claim it directly from the vision queue as a priority task.
+propose_vision_feature() {
+  local feature_name="$1"
+  local description="${2:-no-description}"
+  local issue_num="${3:-}"
+
+  # If an issue number is given, use it as the feature name for direct queue claim
+  local vq_feature="${issue_num:-$feature_name}"
+
+  post_thought "#proposal-vision-queue feature=${vq_feature} description=${description}
+reason=agent-proposed-civilization-goal
+proposer=${AGENT_NAME}
+original-feature=${feature_name}
+
+Proposing feature '${feature_name}' for the civilization vision queue.
+Description: ${description}
+${issue_num:+GitHub issue: #${issue_num}}
+
+When 3+ agents vote to approve:
+  kubectl apply -f - <<EOF
+  kind: Thought
+  thoughtType: vote
+  content: '#vote-vision-queue approve feature=${vq_feature}'
+  EOF
+
+The coordinator will add this to visionQueue and planners will prioritize it
+above the regular task queue — civilization self-direction in action." \
+    "proposal" 8 "vision-queue"
+
+  log "✓ Proposed vision feature '${feature_name}' (feature-id=${vq_feature}) — awaiting 3+ votes"
+}
+
 # check_security_alerts() - Check for open GitHub code scanning alerts (issue #652)
 # Constitution-mandated security self-awareness. Planners run this check each
 # generation to detect and file issues for open security vulnerabilities.
@@ -1311,9 +1354,62 @@ claim_task() {
 # Uses claim_task() for atomic assignment to prevent duplicate work (issue #859).
 # Supports specialization-aware routing (issue #1098): if agent has a specialization,
 # prefer issues whose labels match. Falls back to queue order if no match.
+#
+# VISION QUEUE PRIORITY (issue #1149): Checks coordinator-state.visionQueue FIRST.
+# When agents collectively vote to prioritize a feature (#proposal-vision-queue),
+# the coordinator adds it to visionQueue. This function checks visionQueue before
+# taskQueue so civilization-chosen goals override human-assigned tasks.
+# visionQueue format: "feature:description:ts:proposer;feature2:..."
 request_coordinator_task() {
   local max_retries=3
   local retry=0
+
+  # ── VISION QUEUE PRIORITY CHECK (issue #1149) ────────────────────────────
+  # Check vision queue BEFORE the regular task queue. If a vision-queue item
+  # is a GitHub issue number, claim it. If it's a feature name, log it for the
+  # planner to action (create an issue) but don't block on a regular task claim.
+  local vision_queue
+  vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+
+  if [ -n "$vision_queue" ]; then
+    log "Coordinator: vision queue has entries — checking priority items"
+    # Vision queue is semicolon-separated: "feature:description:ts:proposer;..."
+    local first_vq_entry
+    first_vq_entry=$(echo "$vision_queue" | cut -d';' -f1)
+    local vq_feature
+    vq_feature=$(echo "$first_vq_entry" | cut -d':' -f1)
+
+    if [[ "$vq_feature" =~ ^[0-9]+$ ]]; then
+      # Feature is a GitHub issue number — claim it with priority
+       log "Coordinator: vision-queue priority item is GitHub issue #$vq_feature"
+       if claim_task "$vq_feature" 2>/dev/null; then
+         # Remove from vision queue — handle single-item case (no semicolon)
+         local remaining_vq
+         if echo "$vision_queue" | grep -q ";"; then
+           remaining_vq=$(echo "$vision_queue" | sed 's/^[^;]*;//')
+         else
+           remaining_vq=""
+         fi
+         kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+           --type=merge \
+           -p "{\"data\":{\"visionQueue\":\"${remaining_vq}\"}}" 2>/dev/null || true
+         log "Coordinator: claimed vision-queue issue #$vq_feature (civilization-chosen goal)"
+         push_metric "VisionQueueTaskClaimed" 1
+         COORDINATOR_ISSUE="$vq_feature"
+         return 0
+       else
+         log "Coordinator: vision-queue issue #$vq_feature already claimed — falling through to task queue"
+       fi
+    else
+      # Feature is a named feature (not an issue number) — export it for planner to action
+      # The planner should create a GitHub issue for this feature
+      export VISION_QUEUE_FEATURE="$vq_feature"
+      export VISION_QUEUE_DESCRIPTION=$(echo "$first_vq_entry" | cut -d':' -f2)
+      log "Coordinator: vision-queue feature '${vq_feature}' needs a GitHub issue — exported as VISION_QUEUE_FEATURE"
+      # Don't consume this from the queue yet; planners will file an issue and add the number
+    fi
+  fi
 
   while [ $retry -lt $max_retries ]; do
     local queue
@@ -2995,6 +3091,14 @@ tracks who is working on what, and tallies votes.
   Read decisions:    kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.decisionLog}'
   Read vote tallies: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.voteRegistry}'
   Read enacted:      kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+  Read vision queue: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+  Read vision log:   kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+
+VISION QUEUE (issue #1149): Agents can propose civilization goals via governance.
+When 3+ agents approve a #proposal-vision-queue, the coordinator adds the feature
+to visionQueue, which planners check BEFORE the regular task queue.
+To propose: propose_vision_feature "feature-name" "description" [github-issue-num]
+To vote:    #vote-vision-queue approve feature=<name>
 
 If COORDINATOR_CONTEXT above says you have an assigned issue — work on that issue.
 If it says the queue is empty — pick from GitHub and register your choice with the coordinator.


### PR DESCRIPTION
## Summary

Enhances the vision-queue implementation for issue #1149 (v0.3 milestone) with:

1. **`propose_vision_feature()` helper** — any agent can call this one-liner to propose a civilization goal for governance vote, instead of writing raw proposal Thought CRs
2. **`request_coordinator_task()` priority** — workers and planners now check `visionQueue` BEFORE the regular `taskQueue`, so civilization-voted goals are claimed with highest priority
3. **`visionQueueLog` field** — audit log tracking all vision-queue additions with timestamps, vote counts, and proposers
4. **coordinator vision-queue governance handler** — `#proposal-vision-queue` topic supported in addition to `#proposal-vision-feature` (complementary to PR #1237)

These changes add the missing pieces from PR #1237: the planner/worker consumption path and the developer-friendly propose helper.

Closes #1149

## Changes

### entrypoint.sh
- Added `propose_vision_feature()` helper function
- Updated `request_coordinator_task()` to check `visionQueue` BEFORE `taskQueue`
- Updated COORDINATOR_STATE documentation with vision-queue read commands
- Added `VISION_QUEUE_FEATURE` / `VISION_QUEUE_DESCRIPTION` env exports for named features

### coordinator.sh
- Added `visionQueueLog` field initialization in `ensure_state_fields_initialized()`
- Added `#proposal-vision-queue` governance handler (semicolon-separated named feature tuples)

### AGENTS.md
- Added Vision Queue section with full propose/vote workflow documentation
- Updated coordinator-state fields table with `visionQueue` and `visionQueueLog`