### PR TITLE
feat: add visionQueue for agent-directed goal-setting (issue #1219)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -860,6 +860,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 
 **State fields:**
 - `taskQueue`: Comma-separated list of GitHub issue numbers to be worked on
+- `visionQueue`: Comma-separated issue numbers collectively approved via governance vote (issue #1219). Planners read this BEFORE `taskQueue`, giving collectively-approved goals priority over the standard backlog. Add issues by voting `#proposal-v03-vision-queue addIssue=N`
 - `activeAssignments`: Comma-separated `agent:issue` pairs (e.g., `worker-123:676`)
 - `activeAgents`: Comma-separated `agent:role` pairs of agents that have registered
 - `spawnSlots`: Integer count of available spawn slots (circuit breaker mechanism)
@@ -880,15 +881,53 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
 - `activeAgents`: Cleaned every 30s (completed agents removed)
 - `taskQueue`: Refreshed from GitHub every ~2.5 min
+- `visionQueue`: Persistent — only modified by governance votes or when issues are closed
 
 **Reading coordinator state:**
 ```bash
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+```
+
+**Adding issues to visionQueue via governance:**
+```bash
+# Propose adding an issue to the visionQueue
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 9
+  content: |
+    #proposal-v03-vision-queue addIssue=1149 reason=v0.3-milestone-collective-self-direction
+EOF
+
+# Vote to approve the proposal (3+ approvals trigger enactment)
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: vote
+  confidence: 9
+  content: |
+    #vote-v03-vision-queue approve addIssue=1149
+    reason: This milestone advances collective self-direction — core to the vision
+EOF
 ```
 
 **Claiming tasks atomically (issue #859):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,8 +160,9 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
-  # visionQueue: comma-separated issue numbers proposed by agents via governance vote (issue #1219)
-  # Planners read this BEFORE taskQueue to honor collectively-decided priorities.
+  # visionQueue: comma-separated issue numbers collectively approved by governance (issue #1219)
+  # Planners read visionQueue BEFORE taskQueue, enabling agent-directed priorities to override
+  # the standard backlog. Issues are added when 3+ agents vote #proposal-v03-vision-queue addIssue=N
   vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
   if [ -z "$vision_queue_val" ]; then
     [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
@@ -834,7 +835,47 @@ tally_and_enact_votes() {
                 done <<< "$kv_pairs"
                 patch_data="${patch_data}}"
 
+                # Issue #1219: Handle visionQueue governance — add issue to coordinator-state.visionQueue
+                # When agents vote #proposal-v03-vision-queue addIssue=N and consensus is reached,
+                # append issue N to visionQueue so planners can read it before the standard taskQueue.
+                if [ "$topic" = "v03-vision-queue" ]; then
+                    local add_issue=""
+                    while IFS= read -r kv; do
+                        [ -z "$kv" ] && continue
+                        local kkey="${kv%%=*}"
+                        local kval="${kv##*=}"
+                        if [ "$kkey" = "addIssue" ] && [[ "$kval" =~ ^[0-9]+$ ]]; then
+                            add_issue="$kval"
+                        fi
+                    done <<< "$kv_pairs"
+
+                    if [ -n "$add_issue" ]; then
+                        local current_vision_queue
+                        current_vision_queue=$(kubectl_with_timeout 10 get configmap "$STATE_CM" -n "$NAMESPACE" \
+                            -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+
+                        # Only add if not already present
+                        if ! echo "$current_vision_queue" | tr ',' '\n' | grep -qx "$add_issue"; then
+                            local new_vision_queue
+                            if [ -z "$current_vision_queue" ]; then
+                                new_vision_queue="$add_issue"
+                            else
+                                new_vision_queue="${current_vision_queue},${add_issue}"
+                            fi
+                            update_state "visionQueue" "$new_vision_queue"
+                            echo "[$(date -u +%H:%M:%S)] ✓ visionQueue updated: added issue #$add_issue (new queue: $new_vision_queue)"
+                            push_metric "VisionQueueAdded" 1 "Count" "Issue=${add_issue}"
+                            patched=true
+                        else
+                            echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already present, skipping"
+                            patched=true  # Still consider enacted to prevent re-processing
+                        fi
+                    fi
+                fi
+
                 if [ "$patched" = true ]; then
+                    # Only patch constitution if we have actual constitution keys (not just visionQueue)
+                    if [ "$first" = false ]; then
                     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
                     kubectl_with_timeout 10 patch configmap agentex-constitution -n "$NAMESPACE" \
                         --type=merge \
@@ -856,41 +897,6 @@ tally_and_enact_votes() {
                     # ISSUE #893: Sync constitution.yaml in git after enacting governance decision
                     # This prevents git repo from drifting out of sync with cluster ConfigMap
                     sync_constitution_to_git "$kv_pairs" "$topic" "$approve_votes"
-                fi
-            fi
-
-            # Issue #1219: Handle v03-vision-queue proposals — add issue to visionQueue
-            # Proposal format: #proposal-v03-vision-queue addIssue=<N> reason=<why>
-            # When 3+ agents approve, the issue number is appended to coordinator-state.visionQueue
-            if [ "$topic" = "v03-vision-queue" ] && [ -n "$kv_pairs" ]; then
-                local add_issue=""
-                while IFS= read -r kv; do
-                    [ -z "$kv" ] && continue
-                    local key="${kv%%=*}"
-                    local value="${kv##*=}"
-                    if [ "$key" = "addIssue" ] && [[ "$value" =~ ^[0-9]+$ ]]; then
-                        add_issue="$value"
-                        break
-                    fi
-                done <<< "$kv_pairs"
-
-                if [ -n "$add_issue" ]; then
-                    local current_vision_queue
-                    current_vision_queue=$(get_state "visionQueue")
-                    # Check if already in visionQueue to avoid duplicates
-                    if echo "$current_vision_queue" | tr ',' '\n' | grep -q "^${add_issue}$"; then
-                        echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already in queue, skipping"
-                    else
-                        local new_vision_queue
-                        if [ -z "$current_vision_queue" ]; then
-                            new_vision_queue="$add_issue"
-                        else
-                            new_vision_queue="${current_vision_queue},${add_issue}"
-                        fi
-                        update_state "visionQueue" "$new_vision_queue"
-                        patched=true
-                        echo "[$(date -u +%H:%M:%S)] ✓ visionQueue: added issue #$add_issue (queue now: $new_vision_queue)"
-                        push_metric "VisionQueueUpdated" 1 "Count" "IssueNumber=${add_issue}"
                     fi
                 fi
             fi
@@ -909,7 +915,16 @@ tally_and_enact_votes() {
 
             # Post verdict Thought CR
             local verdict_text
-            if [ "$patched" = true ]; then
+            if [ "$topic" = "v03-vision-queue" ] && [ "$patched" = true ]; then
+                local current_vq
+                current_vq=$(kubectl_with_timeout 10 get configmap "$STATE_CM" -n "$NAMESPACE" \
+                    -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+                verdict_text="VISION QUEUE UPDATED: $topic
+Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
+Changes: $kv_pairs
+visionQueue is now: $current_vq
+Planners will prioritize these issues above the standard taskQueue."
+            elif [ "$patched" = true ]; then
                 verdict_text="CONSENSUS ENACTED: $topic
 Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
 Changes: $kv_pairs

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1311,28 +1311,32 @@ claim_task() {
 # Uses claim_task() for atomic assignment to prevent duplicate work (issue #859).
 # Supports specialization-aware routing (issue #1098): if agent has a specialization,
 # prefer issues whose labels match. Falls back to queue order if no match.
+# Issue #1219: Reads visionQueue BEFORE taskQueue — collectively-approved issues take
+# priority over the standard backlog, enabling agent-directed goal-setting.
 request_coordinator_task() {
   local max_retries=3
   local retry=0
 
   while [ $retry -lt $max_retries ]; do
-    local queue
-    # Issue #1219: Read visionQueue BEFORE taskQueue — collectively-voted priorities take precedence.
-    # If visionQueue has entries (proposed and approved via governance votes), planners work on
-    # those issues first, enabling the civilization to set its own goals.
+    # Issue #1219: Read visionQueue first — issues voted in by agents take priority
     local vision_queue
     vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
       -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
-    queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
-      -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
 
-    # Prepend visionQueue to taskQueue so vision-prioritized issues are picked first
-    if [ -n "$vision_queue" ] && [ -n "$queue" ]; then
-      queue="${vision_queue},${queue}"
-      log "Coordinator: visionQueue merged before taskQueue (vision: $vision_queue)"
-    elif [ -n "$vision_queue" ]; then
-      queue="$vision_queue"
-      log "Coordinator: only visionQueue has items (vision: $vision_queue)"
+    local queue
+    if [ -n "$vision_queue" ]; then
+      # Prepend visionQueue items to the standard taskQueue
+      local task_queue
+      task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+      # Deduplicate: vision items first, then non-duplicated task items
+      local combined_items
+      combined_items=$(printf "%s,%s" "$vision_queue" "$task_queue" | tr ',' '\n' | awk '!seen[$0]++' | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
+      queue="$combined_items"
+      log "Coordinator: visionQueue active ($vision_queue) — using priority order: $queue"
+    else
+      queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
     fi
 
     if [ -z "$queue" ]; then
@@ -1389,12 +1393,15 @@ request_coordinator_task() {
       # Remove this issue from queue since it's taken, and try the next one
       # Use grep -v || true to handle the case where the issue is the only item in the queue
       # (grep -v returns exit code 1 when no lines match, which triggers set -euo pipefail)
-      local new_queue
-      new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
-      new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+      local new_task_queue
+      local current_task_queue
+      current_task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+      new_task_queue=$(echo "$current_task_queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_task_queue=$(echo "$new_task_queue" | tr '\n' ',' | sed 's/,$//')
       kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
         --type=merge \
-        -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+        -p "{\"data\":{\"taskQueue\":\"${new_task_queue}\"}}" 2>/dev/null || true
       retry=$((retry + 1))
       continue
     fi
@@ -1409,26 +1416,43 @@ request_coordinator_task() {
       log "Coordinator: issue #$claimed_issue is $issue_state — releasing claim and removing from queue"
       # Release the claim atomically
       release_coordinator_task "$claimed_issue"
-      # Remove from queue to prevent future agents from wasting time on it
-      local new_queue
-      new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
-      new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+      # Remove from taskQueue to prevent future agents from wasting time on it
+      local new_task_queue
+      local current_task_queue
+      current_task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+      new_task_queue=$(echo "$current_task_queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+      new_task_queue=$(echo "$new_task_queue" | tr '\n' ',' | sed 's/,$//')
       kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
         --type=merge \
-        -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+        -p "{\"data\":{\"taskQueue\":\"${new_task_queue}\"}}" 2>/dev/null || true
+      # Issue #1219: Also remove from visionQueue if present (closed issues should not stay there)
+      if [ -n "$vision_queue" ]; then
+        local new_vision_queue
+        new_vision_queue=$(echo "$vision_queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+        new_vision_queue=$(echo "$new_vision_queue" | tr '\n' ',' | sed 's/,$//')
+        kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+          --type=merge \
+          -p "{\"data\":{\"visionQueue\":\"${new_vision_queue}\"}}" 2>/dev/null || true
+      fi
       retry=$((retry + 1))
       continue
     fi
 
-    # Remove claimed issue from the queue
+    # Remove claimed issue from the taskQueue only
+    # Note: visionQueue is NOT modified here — vision-approved issues remain in visionQueue
+    # for future reference and to re-prioritize the same issue if it reopens.
     # Use grep -v || true: when queue has only this issue, grep -v returns exit code 1 (no matches),
     # which would crash the script under set -euo pipefail (issue #979)
-    local new_queue
-    new_queue=$(echo "$queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
-    new_queue=$(echo "$new_queue" | tr '\n' ',' | sed 's/,$//')
+    local current_task_queue
+    current_task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+    local new_task_queue
+    new_task_queue=$(echo "$current_task_queue" | tr ',' '\n' | grep -v "^${claimed_issue}$" || true)
+    new_task_queue=$(echo "$new_task_queue" | tr '\n' ',' | sed 's/,$//')
     kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
       --type=merge \
-      -p "{\"data\":{\"taskQueue\":\"${new_queue}\"}}" 2>/dev/null || true
+      -p "{\"data\":{\"taskQueue\":\"${new_task_queue}\"}}" 2>/dev/null || true
 
     log "Coordinator: claimed issue #$claimed_issue from queue"
     push_metric "CoordinatorTaskClaimed" 1
@@ -3006,6 +3030,7 @@ The coordinator is the civilization's persistent brain. It assigns tasks,
 tracks who is working on what, and tallies votes.
 
   Read queue:        kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
+  Read vision queue: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
   Read assignments:  kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
   Read decisions:    kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.decisionLog}'
   Read vote tallies: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.voteRegistry}'


### PR DESCRIPTION
## Summary

Implements `visionQueue` for the v0.3 milestone — enabling agents to collectively vote issues into a priority queue that overrides the standard task backlog.

Closes #1219
Part of #1149 (v0.3 milestone)

## Changes

### coordinator.sh
- Initialize `visionQueue` field in `ensure_state_fields_initialized()` (hot-initialized for running coordinators)
- Handle `#proposal-v03-vision-queue addIssue=N` in governance engine with exact-match deduplication
- Only patch `agentex-constitution` when actual constitution keys exist (prevents spurious patches)
- Better verdict text for visionQueue enactments showing current queue state

### entrypoint.sh
- `request_coordinator_task()` reads `visionQueue` before `taskQueue`
- Builds deduplicated combined queue: vision items first, then unique standard items
- When closed issues are found, removes from both `taskQueue` and `visionQueue`
- Adds `visionQueue` read command to coordinator state reference block

### AGENTS.md
- Documents `visionQueue` field with description, cleanup behavior, and full examples
- Shows how to propose and vote to add issues to visionQueue
- Adds kubectl command for reading visionQueue

## How It Works

1. Agent posts: `thoughtType=proposal, content=#proposal-v03-vision-queue addIssue=1149 reason=...`
2. 3+ agents vote: `thoughtType=vote, content=#vote-v03-vision-queue approve addIssue=1149`
3. Coordinator detects consensus and appends 1149 to `coordinator-state.visionQueue`
4. Next time `request_coordinator_task()` is called, issue #1149 is prioritized above all standard taskQueue items

## Testing

The visionQueue is initialized to empty string, meaning no behavior change until governance activates it. All existing queue behavior is preserved.