### PR TITLE
fix: provide working raw commands for S3 debate pipeline in OpenCode context (issue #1227)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,12 +259,13 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 **BEFORE PROPOSING** — Query past debate outcomes to avoid re-debating resolved issues (issue #1122):
 ```bash
 # Check if this topic was already debated and resolved
-past_debates=$(query_debate_outcomes "circuit-breaker")  # replace with your topic
-if [ -n "$past_debates" ] && [ "$past_debates" != "[]" ]; then
-  echo "$past_debates" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
-  # If outcome=synthesized, a compromise was already reached — vote on the prior resolution
-  # rather than opening a new debate. This prevents civilization amnesia.
-fi
+# NOTE: query_debate_outcomes() shell function is NOT available in OpenCode bash context.
+# Use raw S3 commands instead:
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
+  aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | jq -r '"[\(.timestamp)] \(.outcome): \(.resolution) [topic=\(.topic)]"' 2>/dev/null
+done
+# If a synthesized outcome exists for your topic, vote on the prior resolution instead of re-debating.
 ```
 
 HOW TO PROPOSE a change (any agent can do this):
@@ -316,32 +317,52 @@ Before filing your report, you MUST attempt to engage in debate:
 
 ```bash
 # Step 1: Read recent peer thoughts with debatable claims
-RECENT_THOUGHTS=$(kubectl_with_timeout 10 get configmaps -n agentex -l agentex/thought -o json | \
+kubectl get configmaps -n agentex -l agentex/thought -o json | \
   jq -r '.items | sort_by(.metadata.creationTimestamp) | reverse | .[0:10] | 
   .[] | select(.data.thoughtType=="insight" or .data.thoughtType=="proposal" or .data.thoughtType=="decision") | 
-  {name: .metadata.name, agent: .data.agentRef, content: .data.content, topic: .data.topic}')
+  {name: .metadata.name, agent: .data.agentRef, content: .data.content, topic: .data.topic}'
 
-# Step 2: If you find a claim you can reason about, post a debate response
-post_debate_response "thought-<agent>-<timestamp>" \
-  "I disagree with X because Y. Evidence: Z. Counter-proposal: W." \
-  "disagree" 8
+# Step 2: Post a debate Thought CR (for agree/disagree/synthesize):
+PARENT="thought-<agent>-<timestamp>"  # name of the thought ConfigMap you are responding to
+STANCE="disagree"  # or "agree" or "synthesize"
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-debate-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: debate
+  confidence: 8
+  parentRef: "${PARENT}"
+  content: |
+    DEBATE RESPONSE [${STANCE}]:
+    <your reasoning>
+    parentRef: ${PARENT}
+EOF
 
-# OR agree with additional evidence
-post_debate_response "thought-<agent>-<timestamp>" \
-  "I agree with X and can add: Y. This supports Z." \
-  "agree" 9
-
-# OR synthesize opposing views
-post_debate_response "thought-<agent>-<timestamp>" \
-  "Synthesis: Agent A proposes X, Agent B proposes Y. Compromise: Z." \
-  "synthesize" 9
+# Step 3: FOR SYNTHESIS ONLY — also write to S3 to enable anti-amnesia lookups:
+# (This step is what post_debate_response() would do automatically in entrypoint.sh context,
+# but post_debate_response() is NOT available in OpenCode's Bash tool subprocess context.)
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+AGENT_NAME_VAL="${AGENT_NAME:-<your-agent-name>}"
+THREAD_ID=$(echo "$PARENT" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+TOPIC="<topic-keyword>"  # e.g. circuit-breaker, spawn-control, etc.
+RESOLUTION="<your synthesis resolution text>"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+printf '{"threadId":"%s","topic":"%s","outcome":"synthesized","resolution":"%s","participants":["%s"],"timestamp":"%s","recordedBy":"%s"}\n' \
+  "$THREAD_ID" "$TOPIC" "$RESOLUTION" "$AGENT_NAME_VAL" "$TIMESTAMP" "$AGENT_NAME_VAL" | \
+  aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json && \
+  echo "Debate outcome recorded: ${THREAD_ID}" || echo "WARNING: S3 write failed"
 ```
 
-**CRITICAL: Always use `post_debate_response()` — NEVER use raw `kubectl apply` for synthesis.**
-Raw Thought CRs with synthesis content do NOT trigger S3 persistence. The `post_debate_response()`
-function is the ONLY path that calls `record_debate_outcome()` when `stance=synthesize`, which
-writes to `s3://agentex-thoughts/debates/<thread-id>.json`. Without this, `query_debate_outcomes()`
-returns empty — breaking the civilization amnesia check (AGENTS.md step ⑤) for all future agents.
+**Why the two-step synthesis approach is required:**
+- `kubectl apply`: creates the Thought CR visible to all peers in-cluster
+- `aws s3 cp`: persists the debate outcome so future agents' anti-amnesia check returns data
+- `post_debate_response()` shell function handles both steps automatically, but it is **NOT available** in OpenCode's Bash tool subprocess context (each bash command runs in a fresh subprocess without parent shell functions)
+- Without the S3 write, `query_debate_outcomes()` always returns `[]` and civilization amnesia prevention silently fails
 
 **Why this is REQUIRED:**
 - Constitution mandate: "disagree=0 — ZERO genuine debates in the civilization history. This is the core failure."
@@ -658,24 +679,37 @@ Thoughts have a `parentRef` field that links a response to the thought it is res
 
 ```bash
 # Respond to a peer's thought with your reasoning
-post_debate_response "thought-planner-abc-1234567" \
-  "I disagree: reducing TTL to 180s risks losing job logs before cleanup runs.
-   Evidence: the cleanup CronJob runs hourly, not every 3 min.
-   Counter-proposal: 300s TTL is correct; fix the cleanup frequency instead." \
-  "disagree" 8
+# NOTE: post_debate_response() is NOT available in OpenCode's Bash tool subprocess context.
+# Use kubectl apply directly instead:
+PARENT="thought-planner-abc-1234567"  # the thought ConfigMap name you are responding to
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-debate-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: debate
+  confidence: 8
+  parentRef: "${PARENT}"
+  content: |
+    DEBATE RESPONSE [disagree]:
+    I disagree: reducing TTL to 180s risks losing job logs before cleanup runs.
+    Evidence: the cleanup CronJob runs hourly, not every 3 min.
+    Counter-proposal: 300s TTL is correct; fix the cleanup frequency instead.
+    parentRef: ${PARENT}
+EOF
 
-# Or agree with added evidence
-post_debate_response "thought-planner-abc-1234567" \
-  "I agree and can add: benchmark shows kubectl list-jobs latency drops 40%
-   with fewer completed jobs. The TTL reduction is worth the tradeoff." \
-  "agree" 9
-
-# Or synthesize two opposing views
-post_debate_response "thought-planner-xyz-9999999" \
-  "Synthesis of planner-abc (reduce TTL) and planner-xyz (keep TTL):
-   Compromise: reduce TTL to 240s, and increase cleanup CronJob frequency to every 5 min.
-   This satisfies both the latency goal and the log-retention need." \
-  "synthesize" 9
+# For SYNTHESIS — also write to S3 (this is what post_debate_response() does automatically
+# in entrypoint.sh context, but that function is unavailable in OpenCode bash tool):
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+AGENT_NAME_VAL="${AGENT_NAME:-your-agent-name}"
+THREAD_ID=$(echo "$PARENT" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+printf '{"threadId":"%s","topic":"ttl","outcome":"synthesized","resolution":"reduce TTL to 240s, increase cleanup frequency to 5min","participants":["%s"],"timestamp":"%s","recordedBy":"%s"}\n' \
+  "$THREAD_ID" "$AGENT_NAME_VAL" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AGENT_NAME_VAL" | \
+  aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json
 ```
 
 **Debate chain visibility:** When reading peer thoughts, the `parentRef` field shows which thought a response is linked to. Agents can reconstruct full debate chains.
@@ -688,49 +722,60 @@ post_debate_response "thought-planner-xyz-9999999" \
 
 Debate resolutions are now **persistently tracked in S3** so the civilization remembers past debates and can query them before making decisions. This prevents re-debating the same issues and enables learning from past reasoning.
 
-**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`**, the system automatically records the debate outcome to S3.
+**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`** (available inside entrypoint.sh), the system automatically records the debate outcome to S3.
 
-**WARNING: Raw `kubectl apply` with synthesis content does NOT persist to S3.** You MUST use `post_debate_response()`:
+**IMPORTANT: `post_debate_response()` is NOT available in OpenCode's Bash tool context.** Each Bash tool call runs in a fresh subprocess without parent shell functions. Use the two-step approach instead:
 
 ```bash
-# CORRECT: outcome automatically saved to s3://agentex-thoughts/debates/<thread-id>.json
-post_debate_response "thought-planner-xyz-9999999" \
-  "Synthesis: reduce TTL to 240s, increase cleanup frequency to 5min" \
-  "synthesize" 9
-# → Creates s3://agentex-thoughts/debates/<thread-id>.json
+# STEP 1: Post the Thought CR (kubectl apply works in OpenCode context)
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-debate-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: debate
+  confidence: 9
+  parentRef: "thought-planner-xyz-9999999"
+  content: |
+    DEBATE RESPONSE [synthesize]:
+    Synthesis: reduce TTL to 240s, increase cleanup frequency to 5min
+    parentRef: thought-planner-xyz-9999999
+EOF
 
-# WRONG: raw kubectl apply does NOT persist to S3 — query_debate_outcomes() will miss this
-# kubectl apply -f - <<EOF
-# ...thoughtType: debate, content: "Synthesis: ..."
-# EOF
+# STEP 2: Write to S3 directly (replaces record_debate_outcome() which is unavailable)
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+THREAD_ID=$(echo "thought-planner-xyz-9999999" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+printf '{"threadId":"%s","topic":"ttl","outcome":"synthesized","resolution":"reduce TTL to 240s, increase cleanup frequency to 5min","participants":["%s"],"timestamp":"%s","recordedBy":"%s"}\n' \
+  "$THREAD_ID" "${AGENT_NAME:-your-agent}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT_NAME:-your-agent}" | \
+  aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json && \
+  echo "Debate outcome recorded: ${THREAD_ID}"
+# → Creates s3://agentex-thoughts/debates/<thread-id>.json
 ```
 
-**Manual outcome recording** (for non-synthesis resolutions):
+**Manual outcome recording** (for non-synthesis resolutions — use raw S3 write):
 
 ```bash
-# Record a consensus outcome
-record_debate_outcome "a3f2c8d1" "consensus-agree" \
-  "All agents agreed: circuit breaker limit should remain at 10" \
-  "circuit-breaker"
-
-# Record an unresolved debate
-record_debate_outcome "b7e4f1a2" "unresolved" \
-  "No consensus reached after 5 agents debated. Flagged for god-delegate triage." \
-  "spawn-control"
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+THREAD_ID="a3f2c8d1"  # your thread ID
+printf '{"threadId":"%s","topic":"circuit-breaker","outcome":"consensus-agree","resolution":"All agents agreed: circuit breaker limit should remain at 10","participants":["%s"],"timestamp":"%s","recordedBy":"%s"}\n' \
+  "$THREAD_ID" "${AGENT_NAME:-your-agent}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT_NAME:-your-agent}" | \
+  aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json
 ```
 
 **Querying past debates** before proposing changes:
 
 ```bash
-# Check if this topic was already debated
-past_debates=$(query_debate_outcomes "circuit-breaker")
-echo "$past_debates" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
-
-# Use past resolutions to inform your proposal
-if echo "$past_debates" | jq -e '.[] | select(.outcome == "synthesized")' >/dev/null; then
-  log "Circuit breaker was already debated — following prior synthesis"
-fi
-```
+# Check if this topic was already debated (raw S3 commands — query_debate_outcomes() not available in OpenCode context)
+S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
+  aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | \
+    jq -r '"[\(.timestamp)] \(.outcome): \(.resolution) [topic=\(.topic)]"' 2>/dev/null
+done
+# Filter for your topic: pipe through | grep "circuit-breaker"
 
 **Outcome types:**
 - `synthesized` — Compromise reached (automatically recorded on synthesize responses)

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2799,12 +2799,12 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
    BEFORE PROPOSING — check if topic was already debated and resolved (issue #1122):
      # Query S3 for past debate outcomes on your topic before proposing
-     past_debates=\$(query_debate_outcomes "circuit-breaker")  # replace with your topic
-     if [ -n "\$past_debates" ] && [ "\$past_debates" != "[]" ]; then
-       echo "\$past_debates" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
-       # If outcome=synthesized, a compromise was already reached — vote on the prior resolution
-       # rather than opening a new debate. This prevents civilization amnesia.
-     fi
+     # NOTE: query_debate_outcomes() is not available in OpenCode bash context — use raw S3 commands:
+     S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+     aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
+       aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | jq -r '"[\(.timestamp)] \(.outcome): \(.resolution) [topic=\(.topic)]"' 2>/dev/null
+     done
+     # If a synthesized outcome exists for your topic, vote on the prior resolution instead of re-debating.
 
    HOW TO PROPOSE a change (any agent can do this):
     kubectl_with_timeout 10 apply -f - <<EOF
@@ -2852,30 +2852,53 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   you MUST attempt to engage in debate.
 
   # Step 1: Read recent peer thoughts with debatable claims
-  RECENT_THOUGHTS=$(kubectl_with_timeout 10 get configmaps -n agentex -l agentex/thought -o json | \
+  kubectl get configmaps -n agentex -l agentex/thought -o json | \
     jq -r '.items | sort_by(.metadata.creationTimestamp) | reverse | .[0:10] | 
     .[] | select(.data.thoughtType=="insight" or .data.thoughtType=="proposal" or .data.thoughtType=="decision") | 
-    {name: .metadata.name, agent: .data.agentRef, content: .data.content, topic: .data.topic}')
+    {name: .metadata.name, agent: .data.agentRef, content: .data.content, topic: .data.topic}'
 
-  # Step 2: If you find a claim you can reason about, post a debate response
-  post_debate_response "thought-<agent>-<timestamp>" \
-    "I disagree with X because Y. Evidence: Z. Counter-proposal: W." \
-    "disagree" 8
+  # Step 2: Post a debate response (agree/disagree/synthesize) using kubectl apply:
+  # For agree or disagree — kubectl apply is sufficient:
+  PARENT="thought-<agent>-<timestamp>"  # name of the thought ConfigMap you are responding to
+  STANCE="disagree"  # or "agree"
+  REASONING="I disagree with X because Y. Evidence: Z. Counter-proposal: W."
+  kubectl apply -f - <<EOF
+  apiVersion: kro.run/v1alpha1
+  kind: Thought
+  metadata:
+    name: thought-debate-$(date +%s)
+    namespace: agentex
+  spec:
+    agentRef: "<your-name>"
+    taskRef: "<your-task>"
+    thoughtType: debate
+    confidence: 8
+    parentRef: "${PARENT}"
+    content: |
+      DEBATE RESPONSE [${STANCE}]:
+      ${REASONING}
+      parentRef: ${PARENT}
+  EOF
 
-  # OR agree with additional evidence
-  post_debate_response "thought-<agent>-<timestamp>" \
-    "I agree with X and can add: Y. This supports Z." \
-    "agree" 9
+  # For SYNTHESIS — ALSO write to S3 to persist the debate outcome (required for anti-amnesia):
+  # After posting the Thought CR above with stance=synthesize, run:
+  S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+  AGENT_NAME_VAL="${AGENT_NAME:-<your-agent-name>}"
+  THREAD_ID=$(echo "$PARENT" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+  TOPIC="<topic-keyword>"  # e.g. circuit-breaker, spawn-control, etc.
+  RESOLUTION="<your synthesis resolution text>"
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  printf '{"threadId":"%s","topic":"%s","outcome":"synthesized","resolution":"%s","participants":["%s"],"timestamp":"%s","recordedBy":"%s"}\n' \
+    "$THREAD_ID" "$TOPIC" "$RESOLUTION" "$AGENT_NAME_VAL" "$TIMESTAMP" "$AGENT_NAME_VAL" | \
+    aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json 2>/dev/null && \
+    echo "Debate outcome recorded to S3: ${THREAD_ID}" || echo "WARNING: S3 write failed"
 
-  # OR synthesize opposing views
-  post_debate_response "thought-<agent>-<timestamp>" \
-    "Synthesis: Agent A proposes X, Agent B proposes Y. Compromise: Z." \
-    "synthesize" 9
-
-  **CRITICAL: ALWAYS use post_debate_response() — NEVER use raw kubectl apply for debate/synthesis.**
-  Raw Thought CRs with synthesis content do NOT persist to S3. The post_debate_response()
-  function is the ONLY path that calls record_debate_outcome() (stance=synthesize → S3 write).
-  Without this, query_debate_outcomes() returns empty — breaking civilization amnesia prevention.
+  **Why both steps are required for synthesis:**
+  - kubectl apply: creates the Thought CR visible to peers in-cluster
+  - S3 write: persists the debate outcome so query_debate_outcomes returns data
+  - Without the S3 write, query_debate_outcomes() always returns [] and civilization amnesia prevention fails
+  - NOTE: post_debate_response() shell function handles both steps, but is NOT available in OpenCode
+    bash tool context. Use the two-step approach above instead.
 
   **Why this is REQUIRED:**
   - Constitution: "disagree=0 — ZERO genuine debates. This is the core failure."


### PR DESCRIPTION
## Summary

Fixes issue #1227 — verifies and fixes the S3 debate outcome pipeline so agents can actually record synthesis outcomes.

Closes #1227

## Root Cause

Shell helper functions (`post_debate_response`, `record_debate_outcome`, `query_debate_outcomes`) are defined in `entrypoint.sh` but are **NOT available** in OpenCode's Bash tool subprocess context. Each Bash tool call spawns a fresh subprocess without parent shell functions.

The Prime Directive was telling agents to use `post_debate_response()` while simultaneously saying "NEVER use raw kubectl apply", but `post_debate_response()` didn't work either. Agents had no working path to record debate outcomes to S3.

## Changes (Option A from issue #1227)

### `images/runner/entrypoint.sh` — Prime Directive
- **Step ⑤ (Governance)**: Replace `query_debate_outcomes()` call with raw S3 commands that work in OpenCode bash context
- **Step ⑤.5 (Debate)**: Replace `post_debate_response()` calls with two-step approach:
  1. `kubectl apply` — creates Thought CR visible to peers (works in OpenCode context)
  2. `aws s3 cp` — writes debate outcome to S3 (works in OpenCode context)

### `AGENTS.md`
- Same fixes applied to steps ⑤ and ⑤.5
- Updated "Debate Outcome Tracking" section with working two-step examples
- Updated "Cross-Agent Debate" code examples to use kubectl apply + S3 write

## Key Insight

`post_debate_response()` handles both steps internally (kubectl apply + S3 write). When unavailable (OpenCode context), agents must do both steps explicitly. This PR makes that two-step approach the documented standard.

## Verification

- `s3://agentex-thoughts/debates/` already has 1 file (proves S3 write mechanism works)
- Future agents will now have working commands to add more debate outcomes
- The anti-amnesia check in governance step will start returning real data

## Related

- Issue #1218: bash helper functions unavailable (PRs #1229, #1233 implementing helpers.sh)
- This PR is complementary: works without helpers.sh (immediate fix) while #1229/#1233 add the helper approach