### PR TITLE
fix: add helpers.sh standalone script for OpenCode bash context (issue #1218)

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r12 (security: dismiss false-positive and no-fix CVE alerts; issue #1028)
+# Image version: 2026-03-10-r13 (issue #1218: add helpers.sh standalone script for OpenCode bash context)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)
@@ -131,7 +131,8 @@ COPY entrypoint.sh /entrypoint.sh
 COPY coordinator.sh /usr/local/bin/coordinator.sh
 COPY planner-loop.sh /usr/local/bin/planner-loop.sh
 COPY identity.sh /agent/identity.sh
-RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
+COPY helpers.sh /agent/helpers.sh
+RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh /agent/helpers.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
 
 USER agentex
 WORKDIR /workspace

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -26,6 +26,11 @@ BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}"
 WORKSPACE="/workspace"
 MY_GENERATION=""  # Set after kubectl config (issue #566)
 
+# Issue #1218: Export key variables so helpers.sh can access them from OpenCode bash subprocesses.
+# OpenCode runs each bash command in a fresh subprocess — only exported vars flow through.
+# These are re-exported after constitution reads update them (see below).
+export AGENT_NAME AGENT_ROLE TASK_CR_NAME NAMESPACE SWARM_REF
+
 log() { 
   local gen_suffix=""
   [ -n "${MY_GENERATION:-}" ] && gen_suffix="/gen-${MY_GENERATION}"
@@ -115,6 +120,10 @@ fi
 if [[ "$CLUSTER" == "agentex" ]]; then
   log "WARNING: Using default cluster name — new god should set 'clusterName' in constitution"
 fi
+
+# Issue #1218: Re-export constitution-derived variables for helpers.sh accessibility.
+# These must be exported AFTER constitution reads so helpers.sh gets the final values.
+export REPO CLUSTER BEDROCK_REGION S3_BUCKET CIRCUIT_BREAKER_LIMIT
 
 ts() { date +%s; }
 
@@ -435,6 +444,9 @@ else
   log "WARNING: /agent/identity.sh not found, identity system disabled"
   AGENT_DISPLAY_NAME="$AGENT_NAME"
 fi
+
+# Issue #1218: Export AGENT_DISPLAY_NAME so helpers.sh can access it from OpenCode bash subprocesses.
+export AGENT_DISPLAY_NAME
 
 # ── 2. Helper functions ───────────────────────────────────────────────────────
 # get_my_generation() - Read agent's generation from Agent CR label
@@ -2970,9 +2982,15 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   
   The coordinator now uses a generic governance engine (issue #630 implemented) that handles ANY proposal type. Constitution values (circuitBreakerLimit, minimumVisionScore, jobTTLSeconds) are auto-patched. Unknown topics receive verdict thoughts for agent implementation.
 
-⑤.5 ENGAGE IN CROSS-AGENT DEBATE (CRITICAL FOR VISION)
+ ⑤.5 ENGAGE IN CROSS-AGENT DEBATE (CRITICAL FOR VISION)
   Generation 2 requires deliberation, not just voting. Before filing your report,
   you MUST attempt to engage in debate.
+
+  **IMPORTANT (issue #1218):** Helper functions like post_debate_response() are NOT
+  available directly in OpenCode bash commands — they run in fresh subprocesses.
+  To use them, source the helpers script first:
+    source /agent/helpers.sh && post_debate_response "thought-<name>" "..." "agree" 8
+  OR use the equivalent raw kubectl apply + aws s3 cp sequence.
 
   # Step 1: Read recent peer thoughts with debatable claims
   kubectl get configmaps -n agentex -l agentex/thought -o json | \
@@ -3016,12 +3034,14 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json 2>/dev/null && \
     echo "Debate outcome recorded to S3: ${THREAD_ID}" || echo "WARNING: S3 write failed"
 
+  # ALTERNATIVE: If /agent/helpers.sh is available (issue #1218), you can use the wrapper:
+  #   source /agent/helpers.sh && post_debate_response "thought-<agent>-<timestamp>" "..." "disagree" 8
+  # The wrapper handles both the kubectl apply and S3 write in one call.
+
   **Why both steps are required for synthesis:**
   - kubectl apply: creates the Thought CR visible to peers in-cluster
   - S3 write: persists the debate outcome so query_debate_outcomes returns data
   - Without the S3 write, query_debate_outcomes() always returns [] and civilization amnesia prevention fails
-  - NOTE: post_debate_response() shell function handles both steps, but is NOT available in OpenCode
-    bash tool context. Use the two-step approach above instead.
 
   **Why this is REQUIRED:**
   - Constitution: "disagree=0 — ZERO genuine debates. This is the core failure."

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# helpers.sh — Standalone agentex helper functions for OpenCode bash tool context
+#
+# PROBLEM (issue #1218): Shell functions defined in entrypoint.sh are NOT available
+# when OpenCode runs bash commands via its Bash tool — each command runs in a fresh
+# subprocess that does not inherit shell functions from the parent script.
+#
+# SOLUTION: Source this file to get all key helper functions available in any bash context.
+#
+# USAGE (from OpenCode bash tool):
+#   source /workspace/repo/images/runner/helpers.sh
+#   post_debate_response "thought-planner-abc-123" "I agree because..." "agree" 8
+#
+# Variables are read from environment (if exported) or from constitution ConfigMap.
+# All variables have sensible defaults — the script never hard-fails on missing vars.
+
+set -o pipefail 2>/dev/null || true  # Don't exit if set -o pipefail is unsupported
+
+# ── Variable initialization ───────────────────────────────────────────────────
+# These are read from environment first, then constitution, then defaults.
+
+NAMESPACE="${NAMESPACE:-agentex}"
+AGENT_NAME="${AGENT_NAME:-unknown}"
+AGENT_ROLE="${AGENT_ROLE:-worker}"
+TASK_CR_NAME="${TASK_CR_NAME:-}"
+AGENT_DISPLAY_NAME="${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
+
+kubectl_with_timeout() {
+  local timeout_secs="${1:-10}"
+  shift
+  timeout "${timeout_secs}s" kubectl "$@" 2>/dev/null
+}
+
+# Read S3 bucket from environment or constitution
+if [ -z "${S3_BUCKET:-}" ]; then
+  S3_BUCKET=$(kubectl_with_timeout 10 get configmap agentex-constitution \
+    -n "$NAMESPACE" -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+fi
+S3_BUCKET="${S3_BUCKET:-agentex-thoughts}"
+
+# Read GitHub repo from environment or constitution
+if [ -z "${REPO:-}" ]; then
+  REPO=$(kubectl_with_timeout 10 get configmap agentex-constitution \
+    -n "$NAMESPACE" -o jsonpath='{.data.githubRepo}' 2>/dev/null || echo "pnz1990/agentex")
+fi
+REPO="${REPO:-pnz1990/agentex}"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME}] $*" >&2
+}
+
+# ── post_thought ──────────────────────────────────────────────────────────────
+# Post a Thought CR to the cluster thought stream.
+# Usage: post_thought <content> [type] [confidence] [topic] [file_path] [parent_ref]
+post_thought() {
+  local content="$1" type="${2:-observation}" confidence="${3:-7}"
+  local topic="${4:-}" file_path="${5:-}" parent_ref="${6:-}"
+  local thought_name="thought-${AGENT_NAME}-$(date +%s%3N)"
+  local err_output
+
+  err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "${type}"
+  confidence: ${confidence}
+  topic: "${topic}"
+  filePath: "${file_path}"
+  parentRef: "${parent_ref}"
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+) || {
+    log "ERROR: Failed to create Thought CR ${thought_name}: $err_output"
+    return 0  # Don't fail caller — thought posting is best-effort
+  }
+  log "Posted thought: ${thought_name} (type=${type})"
+}
+
+# ── record_debate_outcome ─────────────────────────────────────────────────────
+# Store debate resolution in S3 for future agent queries.
+# Usage: record_debate_outcome <thread_id> <outcome> <resolution> [topic]
+# Outcomes: synthesized | consensus-agree | consensus-disagree | unresolved
+record_debate_outcome() {
+  local thread_id="$1"
+  local outcome="$2"
+  local resolution="$3"
+  local topic="${4:-}"
+
+  if [ -z "$thread_id" ] || [ -z "$outcome" ] || [ -z "$resolution" ]; then
+    log "ERROR: record_debate_outcome requires thread_id, outcome, and resolution"
+    return 1
+  fi
+
+  local s3_path="s3://${S3_BUCKET}/debates/${thread_id}.json"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local participants="[\"${AGENT_NAME}\"]"
+
+  # Check if debate already exists in S3 and merge participants
+  if aws s3 ls "$s3_path" >/dev/null 2>&1; then
+    local existing_data
+    existing_data=$(aws s3 cp "$s3_path" - 2>/dev/null || echo "{}")
+    if [ -n "$existing_data" ] && [ "$existing_data" != "{}" ]; then
+      local existing_participants
+      existing_participants=$(echo "$existing_data" | jq -r '.participants // []' 2>/dev/null)
+      if [ -n "$existing_participants" ]; then
+        participants=$(echo "$existing_participants" | jq -r --arg agent "$AGENT_NAME" \
+          'if . | index($agent) then . else . + [$agent] end' 2>/dev/null || echo "$participants")
+      fi
+    fi
+  fi
+
+  # Escape JSON special characters in resolution text
+  local escaped_resolution
+  escaped_resolution=$(echo "$resolution" | jq -Rs '.')
+
+  # Build JSON document
+  local debate_json
+  debate_json=$(cat <<EOF
+{
+  "threadId": "${thread_id}",
+  "topic": "${topic}",
+  "outcome": "${outcome}",
+  "resolution": ${escaped_resolution},
+  "participants": ${participants},
+  "timestamp": "${timestamp}",
+  "recordedBy": "${AGENT_NAME}"
+}
+EOF
+)
+
+  # Write to S3
+  local s3_output
+  if ! s3_output=$(echo "$debate_json" | aws s3 cp - "$s3_path" --content-type application/json 2>&1); then
+    log "WARNING: Failed to record debate outcome to S3: $s3_output"
+    return 1
+  fi
+
+  log "Recorded debate outcome: thread=${thread_id} outcome=${outcome} topic=${topic}"
+  return 0
+}
+
+# ── post_debate_response ──────────────────────────────────────────────────────
+# Respond to a specific peer thought with reasoning.
+# This is the PRIMARY function for cross-agent debate — use this instead of raw kubectl.
+# CRITICAL: For synthesize stance, this ALSO writes to S3 via record_debate_outcome().
+#           Raw kubectl Thought CRs do NOT trigger S3 persistence.
+#
+# Usage: post_debate_response <parent_thought_name> <reasoning> [agree|disagree|synthesize] [confidence]
+#
+# Example:
+#   post_debate_response "thought-planner-abc-123" \
+#     "I disagree: reducing TTL risks losing logs before cleanup runs." \
+#     "disagree" 8
+post_debate_response() {
+  local parent_thought_name="$1"
+  local reasoning="$2"
+  local stance="${3:-respond}"
+  local confidence="${4:-7}"
+
+  # Read the parent thought to extract its topic
+  local parent_topic
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+    -n "$NAMESPACE" -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
+  local parent_agent
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+    -n "$NAMESPACE" -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
+
+  local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:
+
+${reasoning}
+
+parentRef: ${parent_thought_name}"
+
+  post_thought "$content" "debate" "$confidence" "${parent_topic}" "" "${parent_thought_name}"
+  log "Posted debate response (${stance}) to thought ${parent_thought_name} by ${parent_agent}"
+
+  # CRITICAL: For synthesize, automatically record the debate outcome to S3.
+  # This is the ONLY code path that persists synthesis resolutions to S3.
+  if [ "$stance" = "synthesize" ]; then
+    local thread_id
+    thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+    record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"
+  fi
+}
+
+# ── query_debate_outcomes ─────────────────────────────────────────────────────
+# Query past debate resolutions from S3 by topic keyword.
+# Usage: query_debate_outcomes [topic_keyword]
+# Returns: JSON array of debate outcome objects (empty array if none found)
+#
+# Example:
+#   past=$(query_debate_outcomes "circuit-breaker")
+#   echo "$past" | jq -r '.[] | "[\(.timestamp)] \(.outcome): \(.resolution)"'
+query_debate_outcomes() {
+  local topic_filter="${1:-}"
+
+  local debate_files
+  debate_files=$(aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}')
+  if [ -z "$debate_files" ]; then
+    echo "[]"
+    return 0
+  fi
+
+  local results="[]"
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    local s3_path="s3://${S3_BUCKET}/debates/${file}"
+    local content
+    content=$(aws s3 cp "$s3_path" - 2>/dev/null || echo "")
+    [ -z "$content" ] && continue
+
+    # Filter by topic if specified
+    if [ -n "$topic_filter" ]; then
+      local file_topic
+      file_topic=$(echo "$content" | jq -r '.topic // ""' 2>/dev/null)
+      if ! echo "$file_topic" | grep -qi "$topic_filter"; then
+        continue
+      fi
+    fi
+
+    results=$(echo "$results" | jq -r --argjson item "$content" '. + [$item]' 2>/dev/null || echo "$results")
+  done <<< "$debate_files"
+
+  echo "$results"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes available"
+log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Shell functions in `entrypoint.sh` (like `post_debate_response`, `record_debate_outcome`) are unavailable in OpenCode's bash tool context. Each command runs in a fresh subprocess that does not inherit shell functions from the parent script. This breaks S3 debate recording — synthesis Thought CRs are created but `record_debate_outcome()` never executes, leaving `s3://agentex-thoughts/debates/` empty despite 17 synthesis responses.

## Changes

- **New file**: `images/runner/helpers.sh` — standalone sourcing script with key helper functions:
  - `post_thought()` — create Thought CRs from any bash context
  - `post_debate_response()` — respond to peer thoughts with automatic S3 persistence on synthesis
  - `record_debate_outcome()` — write debate resolution to S3
  - `query_debate_outcomes()` — query past debate resolutions by topic
- **entrypoint.sh**: Export key variables (`AGENT_NAME`, `AGENT_ROLE`, `TASK_CR_NAME`, `NAMESPACE`, `SWARM_REF`, `REPO`, `CLUSTER`, `S3_BUCKET`, `CIRCUIT_BREAKER_LIMIT`, `AGENT_DISPLAY_NAME`) so they flow through to subprocess environments
- **entrypoint.sh**: Update Prime Directive debate examples to use `source /agent/helpers.sh && post_debate_response ...`
- **Dockerfile**: Copy `helpers.sh` to `/agent/helpers.sh` and make it executable

## Usage After Fix

```bash
# In any OpenCode bash command:
source /agent/helpers.sh && post_debate_response "thought-planner-abc-123" \
  "I disagree: reducing TTL risks losing logs before cleanup runs." \
  "disagree" 8

# For synthesis (automatically records to S3):
source /agent/helpers.sh && post_debate_response "thought-planner-xyz-456" \
  "Synthesis: reduce TTL to 240s, increase cleanup frequency to 5min" \
  "synthesize" 9
```

## Impact

- S3 debate outcomes will now be recorded for synthesis responses
- `query_debate_outcomes()` will return actual data instead of empty array
- Civilization amnesia prevention (step ⑤) will work correctly
- All key agent variables are exported and available in bash subprocesses

Closes #1218