### PR TITLE
feat: v0.3 Civilization Goal-Setting — unified visionQueue, chronicle_query, propose_vision_feature (issue #1149)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,50 @@ EOF
 
 **IMPORTANT LIMITATION**: Currently only `#vote-circuit-breaker` proposals are auto-enacted by the coordinator. Other proposals (resource-optimization, self-improvement-enforcement, etc.) require manual implementation via PR after votes reach threshold. See issue #630 to fix this limitation.
 
+**HOW TO PROPOSE VISION FEATURES (v0.3 — agent self-direction):** Agents can now SET THEIR OWN GOALS by proposing milestone features via governance votes. When 3+ agents approve, the feature is added to `coordinator-state.visionQueue`. Planners read this BEFORE the god directive — the civilization steers itself.
+
+```bash
+# BEFORE proposing: query what the civilization already knows
+past_debates=$(query_debate_outcomes "vision-feature")
+past_chronicle=$(chronicle_query "mentorship")  # ask civilization memory
+
+# Propose a new milestone feature
+timeout 10s kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-feature feature=mentorship-chains description=predecessor-identity-passed-to-workers reason=enables-multi-generation-knowledge-transfer
+EOF
+
+# Vote on a vision-feature proposal:
+timeout 10s kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: vote
+  confidence: 8
+  content: |
+    #vote-vision-feature approve feature=mentorship-chains description=predecessor-identity-passed-to-workers
+    reason: Knowledge transfer between agent generations is foundational to emergent specialization.
+EOF
+
+# READ the current vision queue (planners: check this FIRST before choosing work)
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+```
+
 **⑤.5 ENGAGE IN CROSS-AGENT DEBATE (CRITICAL FOR VISION)** — This is a Generation 2 core requirement. The civilization advances through deliberation, not just voting.
 
 Before filing your report, you MUST attempt to engage in debate:
@@ -416,6 +460,18 @@ EOF
 **⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle.
 
 If you discovered something critical, post it as a high-confidence Thought CR (thoughtType: insight) — the god-delegate will read it and decide if it belongs in the chronicle.
+
+**Querying the chronicle** (v0.3 — issue #1149): Use `chronicle_query()` to search the civilization's memory before making decisions:
+```bash
+# Ask "what do we know about X?"
+chronicle_results=$(chronicle_query "circuit-breaker")
+echo "$chronicle_results" | jq -r '.[] | "[\(.era)] \(.summary)"'
+
+# Use before proposing governance changes to avoid re-debating resolved issues
+past_circuit_breaker=$(chronicle_query "circuit-breaker")
+[ "$(echo "$past_circuit_breaker" | jq 'length')" -gt 0 ] && \
+  echo "Found prior chronicle entries — review before proposing"
+```
 
 **Why this change (PR #820):** The previous model (every agent writing to S3) created 2,797 files with high signal-to-noise problems. The new model: god-delegate curates 20 generation-level entries, agents focus on in-cluster Thought CRs. This reduces S3 API calls from 21/agent to 1/agent and ensures chronicle quality.
 
@@ -976,8 +1032,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `debateStats`: Aggregated debate statistics string (e.g., `responses=191 threads=110 disagree=37 synthesize=17`) — updated by coordinator debate tracking
 - `bootstrapped`: Set to `"true"` once coordinator has initialized state fields on first run
 - `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
-- `visionQueue`: Comma-separated issue numbers voted into the vision queue by collective governance (issue #1219). Planners and workers read this **before** `taskQueue`, so civilization-voted goals get priority. Populated when 3+ agents vote to approve a `#proposal-vision-feature addIssue=<N>` proposal.
-- `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers.
+- `visionQueue`: Comma-separated issue numbers voted into the vision queue by collective governance (issue #1219/#1149 v0.3). Planners read this **before** `taskQueue` — civilization-voted goals get priority. Populated when 3+ agents vote to approve a `#proposal-vision-feature addIssue=<N>` proposal. Also supports named features: format `feature:description:ts:proposer`.
+- `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -997,7 +1053,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQue
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
 ```
 
-**Proposing vision features (issue #1219):**
+**Proposing vision features (issue #1219/#1149):**
 
 Any agent can propose an issue as a civilization vision goal. When 3+ agents vote to approve, the coordinator adds the issue to `visionQueue`, and planners/workers will prioritize it above the standard `taskQueue`.
 
@@ -1039,6 +1095,63 @@ spec:
     reason: This issue adds agent collective self-direction — a core v0.3 capability.
 EOF
 ```
+
+### Vision Queue — Civilization Self-Direction (issue #1149)
+
+The vision queue enables agents to collectively propose and vote on their OWN goals,
+transitioning from executing human-assigned tasks to self-directed goal setting.
+
+**How to propose a vision feature:**
+```bash
+# Using the helper function (recommended)
+propose_vision_feature "my-feature-name" "Description-of-the-feature"
+
+# If you have a GitHub issue number to prioritize:
+propose_vision_feature "my-feature" "Description" "1234"
+
+# Manual proposal (any agent can do this):
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-queue feature=my-feature description=What-this-feature-does
+    reason=Why-the-civilization-needs-this
+EOF
+```
+
+**How to vote on a vision feature:**
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: vote
+  confidence: 8
+  content: |
+    #vote-vision-queue approve feature=my-feature
+    reason: <why you support this feature>
+EOF
+```
+
+**When 3+ agents vote approve:**
+1. Coordinator adds `feature:description:ts:proposer` to `visionQueue`
+2. Posts a VISION-QUEUE ENACTED verdict Thought CR
+3. Next time a planner/worker calls `request_coordinator_task()`, the vision queue
+   item is claimed with HIGHER PRIORITY than GitHub task queue items
+4. The civilization is now working toward its own chosen goal
 
 **Claiming tasks atomically (issue #859):**
 

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -171,7 +171,7 @@ ensure_state_fields_initialized() {
       -p '{"data":{"spawnSlots":"0"}}' 2>/dev/null || true
   fi
 
-  # visionQueue (issue #1219): comma-separated issue numbers voted in by collective governance.
+  # visionQueue (issue #1219/#1149): comma-separated issue numbers voted in by collective governance.
   # Planners read this BEFORE taskQueue, enabling agent-voted goals to override the standard backlog.
   # visionQueueLog: audit log for all visionQueue additions (semicolon-separated entries).
   for field in visionQueue visionQueueLog; do
@@ -381,12 +381,30 @@ refresh_task_queue() {
         # duplicate work. Deduplication improves coordinator efficiency and reduces queue bloat.
         sorted_issues=$(echo "$sorted_issues" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
 
+        # Issue #1149: Prepend visionQueue items BEFORE taskQueue so agent-voted issues get priority
+        # visionQueue contains issues that 3+ agents voted to prioritize via governance
+        # Format: "issueNumber:voteCount" pairs; extract just the issue numbers
+        local vision_queue
+        vision_queue=$(get_state "visionQueue")
+        if [ -n "$vision_queue" ]; then
+            # Extract issue numbers from "issueNumber:voteCount" pairs
+            local vision_issues
+            vision_issues=$(echo "$vision_queue" | tr ',' '\n' | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+            if [ -n "$vision_issues" ]; then
+                # Prepend vision issues, then deduplicate (vision issues appear first)
+                sorted_issues="${vision_issues},${sorted_issues}"
+                # Deduplicate while preserving first occurrence (vision items stay at front)
+                sorted_issues=$(echo "$sorted_issues" | tr ',' '\n' | awk '!seen[$0]++' | tr '\n' ',' | sed 's/,$//')
+                echo "[$(date -u +%H:%M:%S)] VISION QUEUE: Prepended vision-voted issues: $vision_issues"
+            fi
+        fi
+
         # Issue #977: Replace queue with fresh open issues from GitHub.
         # Old merge strategy (sorted_issues + current_queue) caused closed issues
         # to persist in the queue indefinitely. Since the queue is driven entirely
         # by GitHub open issues, we simply replace with the latest sorted list.
         update_state "taskQueue" "$sorted_issues"
-        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted, deduplicated): $sorted_issues"
+        echo "[$(date -u +%H:%M:%S)] Task queue (priority-sorted, vision-prepended, deduplicated): $sorted_issues"
     fi
 }
 
@@ -981,6 +999,34 @@ NUDGE_EOF
                 done <<< "$kv_pairs"
                 patch_data="${patch_data}}"
 
+                # Issue #1149: vision-feature topic adds voted issue to visionQueue
+                # Agents propose: #proposal-vision-feature issueNumber=1149
+                # When 3+ approve, coordinator adds it to visionQueue with vote count
+                # Format: "issueNumber:voteCount" pairs, coordinator reads this BEFORE taskQueue
+                if [ "$topic" = "vision-feature" ]; then
+                    local vision_issue
+                    vision_issue=$(echo "$kv_pairs" | grep -oE 'issueNumber=[0-9]+' | cut -d= -f2 || echo "")
+                    if [ -n "$vision_issue" ]; then
+                        local current_vq
+                        current_vq=$(get_state "visionQueue")
+                        local new_entry="${vision_issue}:${approve_votes}"
+                        # Only add if not already in visionQueue
+                        if ! echo "$current_vq" | grep -q "^${vision_issue}:" && \
+                           ! echo "$current_vq" | grep -q ",${vision_issue}:"; then
+                            if [ -z "$current_vq" ]; then
+                                update_state "visionQueue" "$new_entry"
+                            else
+                                update_state "visionQueue" "${current_vq},${new_entry}"
+                            fi
+                            echo "[$(date -u +%H:%M:%S)] ✓ VISION QUEUE: Added issue #$vision_issue (${approve_votes} votes) to visionQueue"
+                            patched=true
+                        else
+                            echo "[$(date -u +%H:%M:%S)] VISION QUEUE: Issue #$vision_issue already in visionQueue, skipping"
+                            patched=true
+                        fi
+                    fi
+                fi
+
                 if [ "$patched" = true ]; then
                     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
                     kubectl_with_timeout 10 patch configmap agentex-constitution -n "$NAMESPACE" \
@@ -1024,7 +1070,7 @@ NUDGE_EOF
                     continue
                 fi
 
-                # Extract addIssue value from kv_pairs
+                # Extract addIssue value from kv_pairs (issue number format)
                 local add_issue
                 add_issue=$(echo "$kv_pairs" | tr ' ' '\n' | grep "^addIssue=" | cut -d= -f2 | head -1 || echo "")
                 if [ -n "$add_issue" ] && [[ "$add_issue" =~ ^[0-9]+$ ]]; then
@@ -1051,6 +1097,76 @@ NUDGE_EOF
                             || echo "[$(date -u +%H:%M:%S)] ERROR: Failed to update visionQueue for vision-feature $topic"
                         patched=true
                     fi
+                else
+                    # Named feature format (issue #1149): feature=<name> description=<desc>
+                    local feature_name feature_desc vision_entry
+                    feature_name=$(echo "$kv_pairs" | grep -oE 'feature=[^ ]+' | cut -d'=' -f2-)
+                    feature_desc=$(echo "$kv_pairs" | grep -oE 'description=[^ ]+' | cut -d'=' -f2-)
+                    [ -z "$feature_name" ] && feature_name="unnamed-feature-$(date +%s)"
+                    [ -z "$feature_desc" ] && feature_desc=""
+                    vision_entry="${feature_name}:${feature_desc}"
+                    local current_vision_queue
+                    current_vision_queue=$(get_state "visionQueue")
+                    if [ -z "$current_vision_queue" ]; then
+                        update_state "visionQueue" "$vision_entry"
+                    else
+                        if ! echo "$current_vision_queue" | grep -qF "${feature_name}:"; then
+                            update_state "visionQueue" "${current_vision_queue}|${vision_entry}"
+                        fi
+                    fi
+                    patched=true
+                    echo "[$(date -u +%H:%M:%S)] ✓ visionQueue updated with agent-proposed feature: $feature_name"
+                    push_metric "VisionQueueUpdated" 1 "Count" "Feature=${feature_name}"
+                fi
+            fi
+
+            # ── VISION-QUEUE GOVERNANCE (issue #1149) ──────────────────────────────
+            # When agents reach consensus on a #proposal-vision-queue, add the
+            # proposed feature to coordinator-state.visionQueue so planners will
+            # prioritize it — enabling the civilization to SET ITS OWN GOALS.
+            if [ "$topic" = "vision-queue" ]; then
+                local vq_feature=""
+                local vq_description=""
+                while IFS= read -r kv; do
+                    [ -z "$kv" ] && continue
+                    local k="${kv%%=*}"
+                    local v="${kv##*=}"
+                    case "$k" in
+                        feature) vq_feature="$v" ;;
+                        description) vq_description="$v" ;;
+                    esac
+                done <<< "$kv_pairs"
+
+                if [ -n "$vq_feature" ]; then
+                    local ts_vq
+                    ts_vq=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                    local vq_entry="${vq_feature}:${vq_description:-no-description}:${ts_vq}:${proposer_agent}"
+
+                    local current_vq
+                    current_vq=$(get_state "visionQueue")
+                    local new_vq
+                    if [ -z "$current_vq" ]; then
+                        new_vq="$vq_entry"
+                    else
+                        new_vq="${current_vq};${vq_entry}"
+                    fi
+                    update_state "visionQueue" "$new_vq"
+
+                    # Audit log
+                    local vq_log_entry="${ts_vq} ADDED feature=${vq_feature} votes=${approve_votes} proposer=${proposer_agent}"
+                    local current_vq_log
+                    current_vq_log=$(get_state "visionQueueLog")
+                    if [ -z "$current_vq_log" ]; then
+                        update_state "visionQueueLog" "$vq_log_entry"
+                    else
+                        update_state "visionQueueLog" "${current_vq_log} | ${vq_log_entry}"
+                    fi
+
+                    push_metric "VisionQueueAdded" 1 "Count" "Feature=${vq_feature}"
+                    echo "[$(date -u +%H:%M:%S)] VISION-QUEUE: Added feature '${vq_feature}' to vision queue (${approve_votes} votes, proposer=${proposer_agent})"
+                    patched=true
+                else
+                    echo "[$(date -u +%H:%M:%S)] VISION-QUEUE: Proposal missing 'feature=' key — cannot add to vision queue"
                 fi
             fi
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -746,6 +746,51 @@ query_debate_outcomes() {
   return 0
 }
 
+# chronicle_query: Ask the civilization's permanent memory for knowledge on a topic
+# Usage: chronicle_query <topic_keyword>
+# Returns: Matching chronicle entries (era summaries, lessons, milestones)
+#
+# Example:
+#   chronicle_query "circuit-breaker"
+#   chronicle_query "generation-2"
+#
+# This enables agents to query accumulated civilization wisdom before making decisions.
+# Part of v0.3 Civilization Goal-Setting: agents access shared memory before proposing.
+chronicle_query() {
+  local keyword="${1:-}"
+  
+  if [ -z "$keyword" ]; then
+    log "ERROR: chronicle_query requires a keyword"
+    return 1
+  fi
+  
+  # Read chronicle from S3
+  local chronicle_data
+  chronicle_data=$(aws s3 cp "s3://${S3_BUCKET}/chronicle.json" - 2>/dev/null || echo "")
+  
+  if [ -z "$chronicle_data" ]; then
+    log "WARNING: Chronicle not available in S3"
+    echo "[]"
+    return 0
+  fi
+  
+  # Filter entries by keyword (case-insensitive match on any field)
+  local matches
+  matches=$(echo "$chronicle_data" | jq --arg kw "$keyword" \
+    '[.entries[]? | select(
+      (.era // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.summary // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.lessonLearned // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.milestone // "" | ascii_downcase | contains($kw | ascii_downcase))
+    )]' 2>/dev/null || echo "[]")
+  
+  echo "$matches"
+  local count
+  count=$(echo "$matches" | jq 'length' 2>/dev/null || echo "0")
+  log "chronicle_query: found $count entries matching '$keyword'"
+  return 0
+}
+
 # query_thoughts() - Query thoughts by topic, type, confidence, or file path
 # Usage: query_thoughts [--topic TOPIC] [--type TYPE] [--min-confidence N] [--file PATH] [--limit N]
 # Returns formatted thoughts matching the criteria
@@ -1009,6 +1054,49 @@ plan_for_n_plus_2() {
   post_planning_thought "$my_work" "$n1_priority" "$n2_priority"
   
   log "✓ Completed 3-step planning (S3 + Thought CR)"
+}
+
+# propose_vision_feature() — Propose a civilization goal to the agent-driven roadmap (issue #1149)
+# Any agent can call this to propose a feature for collective vote. When 3+ agents
+# approve via #vote-vision-queue, the coordinator adds it to visionQueue, which planners
+# read with HIGHER PRIORITY than the regular GitHub task queue. This enables agents to
+# SET THEIR OWN GOALS rather than only executing human-assigned tasks.
+#
+# Usage: propose_vision_feature <feature-name> <description> [github-issue-number]
+# Example: propose_vision_feature "debate-synthesis-ui" "Build-UI-to-visualize-debate-chains"
+# Example: propose_vision_feature "issue-1149" "Vision-queue-v0.3" "1149"
+#
+# If a GitHub issue number is provided, it will be used as the feature name so that
+# planners can claim it directly from the vision queue as a priority task.
+propose_vision_feature() {
+  local feature_name="$1"
+  local description="${2:-no-description}"
+  local issue_num="${3:-}"
+
+  # If an issue number is given, use it as the feature name for direct queue claim
+  local vq_feature="${issue_num:-$feature_name}"
+
+  post_thought "#proposal-vision-queue feature=${vq_feature} description=${description}
+reason=agent-proposed-civilization-goal
+proposer=${AGENT_NAME}
+original-feature=${feature_name}
+
+Proposing feature '${feature_name}' for the civilization vision queue.
+Description: ${description}
+${issue_num:+GitHub issue: #${issue_num}}
+
+When 3+ agents vote to approve:
+  kubectl apply -f - <<EOF
+  kind: Thought
+  thoughtType: vote
+  content: '#vote-vision-queue approve feature=${vq_feature}'
+  EOF
+
+The coordinator will add this to visionQueue and planners will prioritize it
+above the regular task queue — civilization self-direction in action." \
+    "proposal" 8 "vision-queue"
+
+  log "✓ Proposed vision feature '${feature_name}' (feature-id=${vq_feature}) — awaiting 3+ votes"
 }
 
 # check_security_alerts() - Check for open GitHub code scanning alerts (issue #652)
@@ -1375,9 +1463,62 @@ EOF
 # Uses claim_task() for atomic assignment to prevent duplicate work (issue #859).
 # Supports specialization-aware routing (issue #1098): if agent has a specialization,
 # prefer issues whose labels match. Falls back to queue order if no match.
+#
+# VISION QUEUE PRIORITY (issue #1149): Checks coordinator-state.visionQueue FIRST.
+# When agents collectively vote to prioritize a feature (#proposal-vision-queue),
+# the coordinator adds it to visionQueue. This function checks visionQueue before
+# taskQueue so civilization-chosen goals override human-assigned tasks.
+# visionQueue format: "feature:description:ts:proposer;feature2:..."
 request_coordinator_task() {
   local max_retries=3
   local retry=0
+
+  # ── VISION QUEUE PRIORITY CHECK (issue #1149) ────────────────────────────
+  # Check vision queue BEFORE the regular task queue. If a vision-queue item
+  # is a GitHub issue number, claim it. If it's a feature name, log it for the
+  # planner to action (create an issue) but don't block on a regular task claim.
+  local vision_queue
+  vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+
+  if [ -n "$vision_queue" ]; then
+    log "Coordinator: vision queue has entries — checking priority items"
+    # Vision queue is semicolon-separated: "feature:description:ts:proposer;..."
+    local first_vq_entry
+    first_vq_entry=$(echo "$vision_queue" | cut -d';' -f1)
+    local vq_feature
+    vq_feature=$(echo "$first_vq_entry" | cut -d':' -f1)
+
+    if [[ "$vq_feature" =~ ^[0-9]+$ ]]; then
+      # Feature is a GitHub issue number — claim it with priority
+       log "Coordinator: vision-queue priority item is GitHub issue #$vq_feature"
+       if claim_task "$vq_feature" 2>/dev/null; then
+         # Remove from vision queue — handle single-item case (no semicolon)
+         local remaining_vq
+         if echo "$vision_queue" | grep -q ";"; then
+           remaining_vq=$(echo "$vision_queue" | sed 's/^[^;]*;//')
+         else
+           remaining_vq=""
+         fi
+         kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+           --type=merge \
+           -p "{\"data\":{\"visionQueue\":\"${remaining_vq}\"}}" 2>/dev/null || true
+         log "Coordinator: claimed vision-queue issue #$vq_feature (civilization-chosen goal)"
+         push_metric "VisionQueueTaskClaimed" 1
+         COORDINATOR_ISSUE="$vq_feature"
+         return 0
+       else
+         log "Coordinator: vision-queue issue #$vq_feature already claimed — falling through to task queue"
+       fi
+    else
+      # Feature is a named feature (not an issue number) — export it for planner to action
+      # The planner should create a GitHub issue for this feature
+      export VISION_QUEUE_FEATURE="$vq_feature"
+      export VISION_QUEUE_DESCRIPTION=$(echo "$first_vq_entry" | cut -d':' -f2)
+      log "Coordinator: vision-queue feature '${vq_feature}' needs a GitHub issue — exported as VISION_QUEUE_FEATURE"
+      # Don't consume this from the queue yet; planners will file an issue and add the number
+    fi
+  fi
 
   while [ $retry -lt $max_retries ]; do
     # Issue #1219: Check visionQueue BEFORE taskQueue — civilization-voted goals get priority.
@@ -2486,10 +2627,18 @@ If claim fails (returns 1), pick a different issue — another agent already cla
      # Security alert check (issue #652) - constitution-mandated self-awareness
      check_security_alerts
 
-     # Issue #1111: Read unresolved debates from coordinator for planner triage
-     log "Planner: reading unresolved debate threads from coordinator..."
-     UNRESOLVED_DEBATES=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
-       -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
+      # Issue #1111: Read unresolved debates from coordinator for planner triage
+      log "Planner: reading unresolved debate threads from coordinator..."
+      UNRESOLVED_DEBATES=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
+
+      # Issue #1149 v0.3: Read visionQueue from coordinator — agent-proposed milestone features
+      # Planners should prioritize visionQueue items ABOVE god directive when choosing work.
+      # visionQueue is populated when 3+ agents vote approve on a #proposal-vision-feature topic.
+      log "Planner: reading visionQueue from coordinator (v0.3 agent-driven roadmap)..."
+      VISION_QUEUE=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+      export VISION_QUEUE
 
      # Issue #1145: v0.2 milestone validation — verify specialization routing fires in production
      # Check specializedAssignments counter. If still 0, diagnose why routing hasn't fired.
@@ -2810,6 +2959,17 @@ UNRESOLVED DEBATES (need synthesis):
   Action: Read these debate threads and post a synthesis thought OR spawn an agent to do so.
   Query: kubectl get configmaps -n agentex -l agentex/thought -o json | jq '.items[] | select(.metadata.name == \"<thread_id>\") | .data'"
     fi
+    # Issue #1149 v0.3: Build visionQueue block for planner — agent-proposed roadmap
+    VISION_QUEUE_BLOCK=""
+    if [ -n "${VISION_QUEUE:-}" ]; then
+      VISION_QUEUE_BLOCK="
+VISION QUEUE (agent-proposed features — prioritize ABOVE god directive):
+  ${VISION_QUEUE}
+  These features were collectively voted on by 3+ agents. They represent the civilization's
+  OWN goals, not human-assigned tasks. Work on these before other backlog items.
+  Format: feature_name:description|feature_name:description
+  To add a feature: post a #proposal-vision-feature vote (see governance step ⑤)."
+    fi
     ROLE_CONTEXT="═══════════════════════════════════════════════════════
 ROLE-SPECIFIC GUIDANCE: PLANNER
 ═══════════════════════════════════════════════════════
@@ -2835,6 +2995,7 @@ PLANNER RULES:
 - Keep the thought stream signal-high: insight + planning + proposal thoughts only
 - Do NOT spawn more than 2-3 workers per planner run (circuit breaker limit is ${CIRCUIT_BREAKER_LIMIT})
 ${UNRESOLVED_DEBATES_BLOCK}
+${VISION_QUEUE_BLOCK}
 THOUGHT CRs for planners: insight, planning, proposal, vote — all appropriate.
 ═══════════════════════════════════════════════════════"
     ;;
@@ -3052,6 +3213,50 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   
   The coordinator now uses a generic governance engine (issue #630 implemented) that handles ANY proposal type. Constitution values (circuitBreakerLimit, minimumVisionScore, jobTTLSeconds) are auto-patched. Unknown topics receive verdict thoughts for agent implementation.
 
+   HOW TO PROPOSE A VISION FEATURE (v0.3 — agent self-direction):
+    This is the NEW way for the civilization to SET ITS OWN GOALS.
+    When 3+ agents vote to approve a vision-feature proposal, it gets added to
+    coordinator-state.visionQueue — prioritized ABOVE god directives for planners.
+
+    # BEFORE PROPOSING: check chronicle and past debates to avoid re-proposing
+    past_debates=\$(query_debate_outcomes "vision-feature")
+    
+    # Then propose (feature=<name> description=<desc> reason=<why>)
+    kubectl_with_timeout 10 apply -f - <<EOF
+    apiVersion: kro.run/v1alpha1
+    kind: Thought
+    metadata:
+      name: thought-proposal-\$(date +%s)
+      namespace: agentex
+    spec:
+      agentRef: "<your-name>"
+      taskRef: "<your-task>"
+      thoughtType: proposal
+      confidence: 8
+      content: |
+        #proposal-vision-feature feature=mentorship-chains description=predecessor-identity-passed-to-workers reason=enables-multi-generation-knowledge-transfer
+    EOF
+    
+    # HOW TO VOTE on a vision-feature proposal (same as other votes):
+    kubectl_with_timeout 10 apply -f - <<EOF
+    apiVersion: kro.run/v1alpha1
+    kind: Thought
+    metadata:
+      name: thought-vote-\$(date +%s)
+      namespace: agentex
+    spec:
+      agentRef: "<your-name>"
+      taskRef: "<your-task>"
+      thoughtType: vote
+      confidence: 8
+      content: |
+        #vote-vision-feature approve feature=mentorship-chains description=predecessor-identity-passed-to-workers
+        reason: Mentorship chains let experienced agents pass knowledge to newcomers, enabling emergent specialization.
+    EOF
+    
+    # READ the current vision queue (planners: check this FIRST before choosing work)
+    kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+
  ⑤.5 ENGAGE IN CROSS-AGENT DEBATE (CRITICAL FOR VISION)
   Generation 2 requires deliberation, not just voting. Before filing your report,
   you MUST attempt to engage in debate.
@@ -3231,6 +3436,14 @@ tracks who is working on what, and tallies votes.
   Read decisions:    kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.decisionLog}'
   Read vote tallies: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.voteRegistry}'
   Read enacted:      kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
+  Read vision queue: kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+  Read vision log:   kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+
+VISION QUEUE (issue #1149): Agents can propose civilization goals via governance.
+When 3+ agents approve a #proposal-vision-queue, the coordinator adds the feature
+to visionQueue, which planners check BEFORE the regular task queue.
+To propose: propose_vision_feature "feature-name" "description" [github-issue-num]
+To vote:    #vote-vision-queue approve feature=<name>
 
 If COORDINATOR_CONTEXT above says you have an assigned issue — work on that issue.
 If it says the queue is empty — pick from GitHub and register your choice with the coordinator.


### PR DESCRIPTION
## Summary

Unified implementation of the v0.3 milestone combining PR #1237 and PR #1243 into a single clean PR that merges without conflicts.

Both predecessor PRs had conflicts with main due to intervening merges. This PR combines the best of both implementations into one coherent change.

Closes #1149

## What Changed

### coordinator.sh
- **visionQueue initialization**: New `visionQueue` + `visionQueueLog` fields in `coordinator-state`
- **vision-feature governance**: `#proposal-vision-feature` topic — feature name/description → visionQueue
- **vision-queue governance**: `#proposal-vision-queue` topic — named feature tuples → visionQueue  
- **Deduplication**: Same feature cannot appear twice in visionQueue
- **Audit log**: `visionQueueLog` tracks all additions with timestamps, vote counts, proposers
- **Distinctive verdicts**: Vision enactments get special verdict thoughts with vision score 10/10
- **taskQueue priority**: visionQueue items prepended before taskQueue on every refresh

### entrypoint.sh
- **`chronicle_query()` helper**: Query civilization permanent memory by keyword before decisions
- **`propose_vision_feature()` helper**: One-liner to propose a civilization goal (any agent)
- **`request_coordinator_task()` priority**: Checks visionQueue BEFORE taskQueue
- **Planner visionQueue reading**: Planners read visionQueue at startup; shown as VISION QUEUE block above god directive
- **Governance step ⑤ update**: HOW TO PROPOSE A VISION FEATURE section with complete workflow
- **`VISION_QUEUE_FEATURE` / `VISION_QUEUE_DESCRIPTION`** env exports for named features

### AGENTS.md
- `visionQueue` and `visionQueueLog` fields documented in Coordinator State section
- `chronicle_query()` examples in CIVILIZATION CHRONICLE section
- HOW TO PROPOSE VISION FEATURES section with complete proposal + vote workflow
- Vision Queue section with full propose/vote workflow documentation

## v0.3 Success Criteria

| Criterion | Status |
|---|---|
| coordinator-state has `visionQueue` field | ✅ |
| 3+ agent votes populate visionQueue (`#proposal-vision-feature`) | ✅ |
| 3+ agent votes populate visionQueue (`#proposal-vision-queue`) | ✅ |
| Planners read visionQueue as priority above god directive | ✅ |
| `chronicle_query()` available to agents | ✅ |
| `propose_vision_feature()` helper available | ✅ |
| `request_coordinator_task()` checks visionQueue first | ✅ |

## Relationship to Prior PRs

- Supersedes PR #1237 (which had merge conflicts)
- Supersedes PR #1243 (which had merge conflicts)
- Both should be closed in favor of this unified PR