### PR TITLE
fix: prevent duplicate planners in planner-loop race window (#1253)

### DIFF
--- a/images/runner/planner-loop.sh
+++ b/images/runner/planner-loop.sh
@@ -68,9 +68,20 @@ count_active_jobs() {
 }
 
 count_active_planners() {
-    # Redirect stderr to /dev/null to avoid mixing error output with the integer result
+    # Count planner Jobs that are either:
+    # 1. Actively running (status.active > 0), OR
+    # 2. Recently created but not yet active (within 30s grace window)
+    # This prevents the race condition where a Job was just spawned but Kubernetes
+    # hasn't set status.active = 1 yet, causing a second planner to be spawned.
+    # Evidence: planner-1773128676 (07:44:46Z) + planner-1773128680 (07:44:50Z) spawned 4s apart.
     timeout 10s kubectl get jobs -n "$NAMESPACE" -l agentex/role=planner -o json 2>/dev/null | \
-        jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' 2>/dev/null || echo "0"
+        jq --argjson now "$(date +%s)" '[.items[] | select(
+            .status.completionTime == null and
+            (
+                (.status.active // 0) > 0 or
+                ((.metadata.creationTimestamp | fromdateiso8601) > ($now - 30))
+            )
+        )] | length' 2>/dev/null || echo "0"
 }
 
 spawn_planner_job() {


### PR DESCRIPTION
## Summary

Fixes the planner-loop race condition where two planners could be spawned within seconds of each other, violating the single-planner constraint.

Closes #1253

## Root Cause

count_active_planners() only counted Jobs where status.active > 0. Kubernetes takes 2-5 seconds to set status.active after a Job is created. During this window, the next iteration of the planner-loop would see 0 active planners and spawn another.

Evidence: Two planners spawned 4 seconds apart:
- planner-1773128676 created at 2026-03-10T07:44:46Z  
- planner-1773128680 created at 2026-03-10T07:44:50Z

Both appeared in coordinator activeAssignments, claiming different issues concurrently.

## Fix

count_active_planners() now counts Jobs that are:
1. Actively running (status.active > 0), OR
2. Recently created (within 30 seconds) — even if status.active has not been set yet

The 30-second grace window closes the race between Job creation and Kubernetes setting status.active.

## Changes

images/runner/planner-loop.sh: Added fromdateiso8601 check for recently-created planner Jobs within 30s grace window.