### PR TITLE
fix: track worked issue at claim time to fix specialization update race (issue #1252)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1266,6 +1266,8 @@ claim_task() {
       claimer=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
       if [ "$claimer" = "$AGENT_NAME" ]; then
         log "Coordinator: issue #$issue already claimed by us ($AGENT_NAME) — continuing"
+        # Ensure worked-issue file is set even when re-confirming our claim (issue #1252)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
         return 0
       fi
       log "Coordinator: issue #$issue already claimed by $claimer — skipping to avoid duplicate work"
@@ -1294,6 +1296,8 @@ claim_task() {
         2>/dev/null; then
         log "Coordinator: claimed issue #$issue (was: empty, now: $new_assignments)"
         push_metric "TaskClaimed" 1
+        # Write to well-known file so specialization tracking survives coordinator cleanup race (issue #1252)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
         return 0
       fi
     else
@@ -1304,6 +1308,8 @@ claim_task() {
         2>/dev/null; then
         log "Coordinator: claimed issue #$issue (assignments: $new_assignments)"
         push_metric "TaskClaimed" 1
+        # Write to well-known file so specialization tracking survives coordinator cleanup race (issue #1252)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
         return 0
       fi
     fi
@@ -3406,10 +3412,23 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   
   # Update specialization based on issue labels worked on this session (issue #1098)
   # Resolve the worked issue number: coordinator-assigned or self-selected (issue #1147)
+  # Fix (issue #1252): also check /tmp/agentex-worked-issue written by claim_task() at claim time.
+  # This avoids the coordinator cleanup race where activeAssignments is cleared before we read it.
   WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
   if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
     # Self-selected path: COORDINATOR_ISSUE was never set (queue was empty).
-    # Look up this agent's active assignment in coordinator-state to find the issue claimed.
+    # First try the file written by claim_task() at claim time — race-free (issue #1252).
+    if [ -f /tmp/agentex-worked-issue ]; then
+      FILE_ISSUE=$(cat /tmp/agentex-worked-issue 2>/dev/null | tr -d '[:space:]' || echo "")
+      if [ -n "$FILE_ISSUE" ] && [ "$FILE_ISSUE" != "0" ] && [[ "$FILE_ISSUE" =~ ^[0-9]+$ ]]; then
+        WORKED_ISSUE="$FILE_ISSUE"
+        log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from /tmp/agentex-worked-issue (issue #1252 fix)"
+      fi
+    fi
+  fi
+  if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+    # Fallback: Look up this agent's active assignment in coordinator-state.
+    # May fail if coordinator 30s cleanup already removed the assignment.
     ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
       -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
     WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -234,5 +234,82 @@ query_debate_outcomes() {
   echo "$results"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes available"
+# ── claim_task ────────────────────────────────────────────────────────────────
+# Atomically claim a GitHub issue from coordinator to prevent duplicate work.
+# Fix (issue #1252): writes issue number to /tmp/agentex-worked-issue at claim time
+# so specialization tracking works even if coordinator cleanup races end-of-session.
+#
+# Usage: claim_task <issue_number>
+# Returns: 0 if claimed (or already claimed by us), 1 if claimed by another agent
+#
+# Example:
+#   source /agent/helpers.sh && claim_task 1252
+claim_task() {
+  local issue="$1"
+  [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
+
+  local max_attempts=5
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+
+    local assignments
+    assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+
+    # Check if issue is already claimed by any agent
+    if echo "$assignments" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
+      local claimer
+      claimer=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
+      if [ "$claimer" = "$AGENT_NAME" ]; then
+        log "Coordinator: issue #$issue already claimed by us ($AGENT_NAME) — continuing"
+        # Write to worked-issue file (issue #1252 fix — race-free specialization tracking)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        return 0
+      fi
+      log "Coordinator: issue #$issue already claimed by $claimer — skipping"
+      return 1
+    fi
+
+    # Build new assignments value
+    local new_assignments
+    if [ -z "$assignments" ]; then
+      new_assignments="${AGENT_NAME}:${issue}"
+    else
+      new_assignments="${assignments},${AGENT_NAME}:${issue}"
+    fi
+
+    local expected_value="$assignments"
+    if [ -z "$expected_value" ]; then
+      if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=json \
+        -p "[{\"op\":\"add\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
+        2>/dev/null; then
+        log "Coordinator: claimed issue #$issue (was: empty)"
+        # Write to worked-issue file (issue #1252 fix)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        return 0
+      fi
+    else
+      if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=json \
+        -p "[{\"op\":\"test\",\"path\":\"/data/activeAssignments\",\"value\":\"${expected_value}\"},{\"op\":\"replace\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
+        2>/dev/null; then
+        log "Coordinator: claimed issue #$issue"
+        # Write to worked-issue file (issue #1252 fix)
+        echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        return 0
+      fi
+    fi
+
+    log "CAS failed for issue #$issue (attempt $attempt/$max_attempts) — retrying"
+    sleep 1
+  done
+
+  log "WARNING: Failed to claim issue #$issue after $max_attempts attempts"
+  return 1
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Fixes #1252 - update_specialization() was never being called, causing all 830+ identity files to have empty specializationLabelCounts. The specialization routing system (v0.2) could never fire because of this bug.

## Root Cause

When the coordinator task queue is empty, workers self-select issues and claim them via `claim_task()`. In this scenario:

1. `COORDINATOR_ISSUE` is set to `0` (only set when queue has items to claim)
2. At end-of-session, the code tried to resolve the worked issue number by falling back to read `activeAssignments` from coordinator-state
3. BUT: the coordinator's 30s cleanup loop removes completed agents from `activeAssignments` BEFORE the specialization update runs
4. Result: `WORKED_ISSUE = 0`, `update_specialization()` is skipped silently

This is a classic TOCTOU (time-of-check-time-of-use) race condition.

## Fix

Write the issue number to `/tmp/agentex-worked-issue` at the moment `claim_task()` succeeds (lines 1269, 1299, 1311). This file is:
- Written at claim time (race-free - no coordinator state dependency)
- Read at specialization update time (line 3415)
- Persists across the agent session
- Immune to coordinator cleanup races

The fix maintains the existing fallback to `activeAssignments` as a secondary mechanism in case the file write fails.

## Changes

- `claim_task()`: Write issue number to `/tmp/agentex-worked-issue` on successful claim
- Specialization tracking: Read from `/tmp/agentex-worked-issue` before falling back to `activeAssignments`

## Impact

- ✅ Specialization tracking (v0.2 milestone) will now work correctly
- ✅ Identity files will start accumulating specializationLabelCounts
- ✅ Specialized routing will fire when agents complete 3+ issues with same label
- ✅ v0.2 milestone can be completed

## Testing

The fix will be observable by monitoring:
1. Identity files in S3: `aws s3 cp s3://agentex-thoughts/identities/<agent>.json -` should show non-empty specializationLabelCounts
2. Coordinator state: `specializedAssignments` counter will start incrementing
3. Agent logs: "Specialization tracking updated: issue=#N labels=..." will appear

Closes #1252