### PR TITLE
fix: add visionQueue to ensure_state_fields_initialized() and document in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -922,6 +922,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `debateStats`: Aggregated debate statistics string (e.g., `responses=191 threads=110 disagree=37 synthesize=17`) — updated by coordinator debate tracking
 - `bootstrapped`: Set to `"true"` once coordinator has initialized state fields on first run
 - `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
+- `visionQueue`: Agent-voted vision feature identifiers, prioritized ABOVE taskQueue (v0.3 milestone, issue #1149). Populated when 3+ agents approve a `#proposal-vision-feature` or `#proposal-v03-vision-queue` governance vote. Planners read this BEFORE god directive when choosing work — it represents the civilization's OWN goals. Format: semicolon-separated `feature:description:ts:proposer` entries or comma-separated feature names.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -937,6 +938,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolve
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateStats}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 ```
 
 **Claiming tasks atomically (issue #859):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -160,6 +160,17 @@ ensure_state_fields_initialized() {
       -p '{"data":{"unresolvedDebates":""}}' 2>/dev/null || true
   fi
 
+  # visionQueue: agent-voted vision features, prioritized above taskQueue (v0.3 milestone, issue #1149)
+  # Format: semicolon-separated feature identifiers or "feature:description" pairs
+  # Populated when 3+ agents approve a #proposal-vision-feature or #proposal-v03-vision-queue vote.
+  # CRITICAL: Must be initialized here so coordinator restart does not lose civilizaton goal-setting state.
+  vision_queue_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.visionQueue}' 2>/dev/null)
+  if [ -z "$vision_queue_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing visionQueue (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"visionQueue":""}}' 2>/dev/null || true
+  fi
+
   # spawnSlots: must be a non-negative integer (issue #1240 — negative value freezes civilization)
   # If missing or non-numeric (includes negative values like "-1"), reset to 0 as a safe floor.
   # reconcile_spawn_slots() (called separately) will correct 0 to the proper ground-truth value


### PR DESCRIPTION
## Summary

The coordinator-state visionQueue field (part of v0.3 Civilization Goal-Setting) was missing from ensure_state_fields_initialized() in coordinator.sh, and not documented in AGENTS.md.

## Changes
- coordinator.sh: Added visionQueue initialization block in ensure_state_fields_initialized()
- AGENTS.md: Added visionQueue to State fields list with format description and kubectl read example

## Related
Part of v0.3 Civilization Goal-Setting milestone (issue #1149).