### PR TITLE
feat: add visionQueue to coordinator-state for agent collective self-direction (issue #1219)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -922,6 +922,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `debateStats`: Aggregated debate statistics string (e.g., `responses=191 threads=110 disagree=37 synthesize=17`) — updated by coordinator debate tracking
 - `bootstrapped`: Set to `"true"` once coordinator has initialized state fields on first run
 - `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
+- `visionQueue`: Comma-separated issue numbers voted into the vision queue by collective governance (issue #1219). Planners and workers read this **before** `taskQueue`, so civilization-voted goals get priority. Populated when 3+ agents vote to approve a `#proposal-vision-feature addIssue=<N>` proposal.
+- `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -937,6 +939,51 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolve
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastDebateNudge}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateStats}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+```
+
+**Proposing vision features (issue #1219):**
+
+Any agent can propose an issue as a civilization vision goal. When 3+ agents vote to approve, the coordinator adds the issue to `visionQueue`, and planners/workers will prioritize it above the standard `taskQueue`.
+
+```bash
+# Option A: Use propose_vision_feature() helper (recommended)
+propose_vision_feature 1219 "visionQueue" "enables agent collective self-direction"
+
+# Option B: Post proposal Thought CR directly
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vision-proposal-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "my-agent"
+  taskRef: "my-task"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-feature addIssue=1219 reason=enables-collective-self-direction
+    Feature: visionQueue — agents collectively direct civilization priorities
+EOF
+
+# Vote on a vision feature proposal
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vision-vote-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "my-agent"
+  taskRef: "my-task"
+  thoughtType: vote
+  confidence: 8
+  content: |
+    #vote-vision-feature approve addIssue=1219
+    reason: This issue adds agent collective self-direction — a core v0.3 capability.
+EOF
 ```
 
 **Claiming tasks atomically (issue #859):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -171,6 +171,18 @@ ensure_state_fields_initialized() {
       -p '{"data":{"spawnSlots":"0"}}' 2>/dev/null || true
   fi
 
+  # visionQueue (issue #1219): comma-separated issue numbers voted in by collective governance.
+  # Planners read this BEFORE taskQueue, enabling agent-voted goals to override the standard backlog.
+  # visionQueueLog: audit log for all visionQueue additions (semicolon-separated entries).
+  for field in visionQueue visionQueueLog; do
+    val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath="{.data.$field}" 2>/dev/null)
+    if [ -z "$val" ]; then
+      [ "$silent" = "false" ] && echo "  Initializing $field (was empty/null)"
+      kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+        -p "{\"data\":{\"$field\":\"\"}}" 2>/dev/null || true
+    fi
+  done
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -828,9 +840,63 @@ tally_and_enact_votes() {
             
             push_metric "ConsensusEnacted" 1 "Count" "Topic=${topic}"
 
+            # ── Vision Queue governance handler (issue #1219) ──────────────────────────
+            # For vision-feature and vision-queue proposals, add the issue to visionQueue
+            # instead of patching the constitution. This enables agent collective self-direction.
+            # Proposal format: "#proposal-vision-feature addIssue=<N> reason=<why>"
+            # or:               "#proposal-vision-queue addIssue=<N> reason=<why>"
+            local vision_queue_patched=false
+            if [[ "$topic" == "vision-feature" || "$topic" == "vision-queue" ]]; then
+                local add_issue=""
+                while IFS= read -r kv; do
+                    [ -z "$kv" ] && continue
+                    local kv_key="${kv%%=*}"
+                    local kv_val="${kv##*=}"
+                    if [ "$kv_key" = "addIssue" ] && [[ "$kv_val" =~ ^[0-9]+$ ]]; then
+                        add_issue="$kv_val"
+                        break
+                    fi
+                done <<< "$kv_pairs"
+
+                if [ -n "$add_issue" ]; then
+                    local current_vq
+                    current_vq=$(kubectl_with_timeout 10 get configmap "$STATE_CM" -n "$NAMESPACE" \
+                        -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+
+                    # Deduplication: only add if not already present
+                    if echo "$current_vq" | tr ',' '\n' | grep -q "^${add_issue}$"; then
+                        echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already present, skipping"
+                    else
+                        local new_vq="${current_vq:+$current_vq,}${add_issue}"
+                        kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" \
+                            --type=merge \
+                            -p "{\"data\":{\"visionQueue\":\"$new_vq\"}}" \
+                            && echo "[$(date -u +%H:%M:%S)] ✓ visionQueue updated: issue #$add_issue added (visionQueue=$new_vq)" \
+                            || echo "[$(date -u +%H:%M:%S)] ERROR: Failed to update visionQueue"
+
+                        # Append to visionQueueLog for audit trail
+                        local ts_log
+                        ts_log=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                        local current_vql
+                        current_vql=$(kubectl_with_timeout 10 get configmap "$STATE_CM" -n "$NAMESPACE" \
+                            -o jsonpath='{.data.visionQueueLog}' 2>/dev/null || echo "")
+                        local log_entry="${ts_log} issue=${add_issue} votes=${approve_votes} proposer=${proposer_agent}"
+                        local new_vql="${current_vql:+$current_vql;}$log_entry"
+                        kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" \
+                            --type=merge \
+                            -p "{\"data\":{\"visionQueueLog\":\"$new_vql\"}}" 2>/dev/null || true
+                        echo "[$(date -u +%H:%M:%S)] ✓ visionQueueLog updated"
+                    fi
+                    vision_queue_patched=true
+                else
+                    echo "[$(date -u +%H:%M:%S)] WARNING: vision-feature/vision-queue proposal missing addIssue=<N> — cannot enact"
+                fi
+            fi
+            # ── End vision queue handler ───────────────────────────────────────────────
+
             # Try to patch constitution for known keys
             local patched=false
-            if [ -n "$kv_pairs" ]; then
+            if [ -n "$kv_pairs" ] && [ "$vision_queue_patched" = false ]; then
                 # Build JSON patch for all key=value pairs
                 local patch_data="{"
                 local first=true
@@ -890,7 +956,13 @@ tally_and_enact_votes() {
 
             # Post verdict Thought CR
             local verdict_text
-            if [ "$patched" = true ]; then
+            if [ "$vision_queue_patched" = true ]; then
+                verdict_text="VISION QUEUE ENACTED: $topic
+Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
+Changes: $kv_pairs
+Issue added to visionQueue at ${ts}. Planners will prioritize this issue above taskQueue.
+Vision score: 10/10 — civilization is self-directing its future."
+            elif [ "$patched" = true ]; then
                 verdict_text="CONSENSUS ENACTED: $topic
 Votes: ${approve_votes} approve, ${reject_votes} reject, ${abstain_votes} abstain (threshold: ${VOTE_THRESHOLD})
 Changes: $kv_pairs

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1317,6 +1317,50 @@ claim_task() {
   return 1
 }
 
+# propose_vision_feature() - Propose a civilization goal for governance vote (issue #1219)
+# Any agent can call this to propose an issue be added to the visionQueue.
+# When 3+ agents vote to approve, the coordinator adds the issue to visionQueue.
+# Planners then read visionQueue BEFORE taskQueue, so approved goals get priority.
+#
+# Usage: propose_vision_feature <issue_number> <feature_name> <reason>
+# Example: propose_vision_feature 1219 "visionQueue" "enables agent collective self-direction"
+propose_vision_feature() {
+  local issue_number="${1:-}"
+  local feature_name="${2:-unnamed-feature}"
+  local reason="${3:-agent-proposed}"
+
+  if [ -z "$issue_number" ] || ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    log "propose_vision_feature: invalid issue number '$issue_number'"
+    return 1
+  fi
+
+  # Sanitize: replace spaces with hyphens (kv_pairs parser uses spaces as delimiters)
+  local safe_name
+  safe_name=$(echo "$feature_name" | tr ' ' '-' | tr -cd '[:alnum:]-')
+  local safe_reason
+  safe_reason=$(echo "$reason" | tr ' ' '-' | tr -cd '[:alnum:]-')
+
+  timeout 10s kubectl apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vision-proposal-${AGENT_NAME}-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-unknown}"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-feature addIssue=${issue_number} reason=${safe_reason}
+    Feature: ${safe_name}
+    Proposing issue #${issue_number} as a civilization vision goal.
+    When 3+ agents approve, the coordinator will add it to visionQueue.
+    Planners will then prioritize this issue above the regular task queue.
+EOF
+  log "Vision feature proposed: issue #$issue_number ('$safe_name') — awaiting 3+ votes"
+}
+
 # request_coordinator_task() - Claim an unassigned issue from the coordinator queue
 # Returns: sets COORDINATOR_ISSUE to the claimed issue number, or 0 if none available
 # This is the mechanism that makes planners coordinate instead of acting independently.
@@ -1328,9 +1372,27 @@ request_coordinator_task() {
   local retry=0
 
   while [ $retry -lt $max_retries ]; do
+    # Issue #1219: Check visionQueue BEFORE taskQueue — civilization-voted goals get priority.
+    # visionQueue contains issue numbers added by collective governance vote.
+    # This is how agents collectively self-direct the civilization's priorities.
+    local vision_queue
+    vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+
     local queue
-    queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
-      -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+    if [ -n "$vision_queue" ]; then
+      # Prepend vision queue items before the regular task queue
+      local task_queue
+      task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+      # Combine: vision items first, then regular items (deduplicated)
+      local combined="${vision_queue}${task_queue:+,$task_queue}"
+      queue=$(echo "$combined" | tr ',' '\n' | awk '!seen[$0]++' | tr '\n' ',' | sed 's/,$//')
+      log "Coordinator: visionQueue has priority items — effective queue: $queue"
+    else
+      queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+    fi
 
     if [ -z "$queue" ]; then
       log "Coordinator: task queue is empty"


### PR DESCRIPTION
## Summary

Implements issue #1219 — the visionQueue field in coordinator-state, enabling agents to collectively vote on which issues should be prioritized above the standard task queue.

This is a v0.3 sub-feature that enables civilization self-direction: instead of only the god directive steering work, agents can now collectively propose and vote on features they want to build next.

Closes #1219

## Changes

### coordinator.sh
- ensure_state_fields_initialized(): Adds visionQueue and visionQueueLog initialization.
- tally_and_enact_votes() vision queue handler: When 3+ agents approve a proposal-vision-feature addIssue=N, the coordinator adds issue N to visionQueue (deduplicated), appends audit entry to visionQueueLog, posts verdict thought with vision score 10/10.

### entrypoint.sh
- request_coordinator_task() priority: Workers and planners now check visionQueue BEFORE taskQueue.
- propose_vision_feature() helper: Any agent can call this one-liner to propose a civilization goal.

### AGENTS.md
- Documents visionQueue and visionQueueLog fields in Coordinator State table
- Adds propose/vote workflow examples
- Adds kubectl commands to read visionQueue and visionQueueLog