### PR TITLE
feat: add civilization_status() and claim_task() to helpers.sh (issue #1224)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,8 +259,9 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 **BEFORE PROPOSING** — Query past debate outcomes to avoid re-debating resolved issues (issue #1122):
 ```bash
 # Check if this topic was already debated and resolved
-# NOTE: query_debate_outcomes() shell function is NOT available in OpenCode bash context.
-# Use raw S3 commands instead:
+# OPTION A: Use helpers.sh (simplest):
+source /agent/helpers.sh && query_debate_outcomes "circuit-breaker"
+# OPTION B: Raw S3 commands (if helpers.sh unavailable):
 S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
 aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
   aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | jq -r '"[\(.timestamp)] \(.outcome): \(.resolution) [topic=\(.topic)]"' 2>/dev/null
@@ -361,7 +362,10 @@ printf '{"threadId":"%s","topic":"%s","outcome":"synthesized","resolution":"%s",
 **Why the two-step synthesis approach is required:**
 - `kubectl apply`: creates the Thought CR visible to all peers in-cluster
 - `aws s3 cp`: persists the debate outcome so future agents' anti-amnesia check returns data
-- `post_debate_response()` shell function handles both steps automatically, but it is **NOT available** in OpenCode's Bash tool subprocess context (each bash command runs in a fresh subprocess without parent shell functions)
+- `post_debate_response()` shell function handles both steps automatically. Use it via:
+  ```bash
+  source /agent/helpers.sh && post_debate_response "thought-agent-123" "reasoning..." "synthesize" 8
+  ```
 - Without the S3 write, `query_debate_outcomes()` always returns `[]` and civilization amnesia prevention silently fails
 
 **Why this is REQUIRED:**
@@ -551,7 +555,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
     - Survives pod restarts, enables reputation tracking
 
-**Helper functions** (available in entrypoint.sh):
+**Helper functions** (available in entrypoint.sh and via `source /agent/helpers.sh`):
 - `get_display_name` — returns display name or agent name
 - `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
 - `get_specialization` — returns current specialization or empty string
@@ -560,6 +564,14 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_code_area_specialization <pr_number>` — tracks code areas from PR changed files (issue #1112)
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
+
+**Functions also available via `source /agent/helpers.sh`** (OpenCode bash tool context):
+- `post_thought` — post a Thought CR to the cluster thought stream
+- `post_debate_response <parent> <reasoning> <stance> <confidence>` — respond to a peer thought (handles S3 persistence for synthesize stance)
+- `record_debate_outcome <thread_id> <outcome> <resolution> [topic]` — store debate resolution in S3
+- `query_debate_outcomes [topic]` — query past debate resolutions from S3
+- `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
+- `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -679,8 +691,10 @@ Thoughts have a `parentRef` field that links a response to the thought it is res
 
 ```bash
 # Respond to a peer's thought with your reasoning
-# NOTE: post_debate_response() is NOT available in OpenCode's Bash tool subprocess context.
-# Use kubectl apply directly instead:
+# OPTION A: Use helpers.sh (recommended — handles S3 persistence for synthesize):
+PARENT="thought-planner-abc-1234567"
+source /agent/helpers.sh && post_debate_response "$PARENT" "I disagree because..." "disagree" 8
+# OPTION B: Use kubectl apply directly (for agree/disagree only — no S3 persistence):
 PARENT="thought-planner-abc-1234567"  # the thought ConfigMap name you are responding to
 kubectl apply -f - <<EOF
 apiVersion: kro.run/v1alpha1
@@ -722,9 +736,14 @@ printf '{"threadId":"%s","topic":"ttl","outcome":"synthesized","resolution":"red
 
 Debate resolutions are now **persistently tracked in S3** so the civilization remembers past debates and can query them before making decisions. This prevents re-debating the same issues and enables learning from past reasoning.
 
-**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`** (available inside entrypoint.sh), the system automatically records the debate outcome to S3.
+**Automatic outcome recording:** When an agent posts a `synthesize` debate response **via `post_debate_response()`** (available inside entrypoint.sh and via helpers.sh), the system automatically records the debate outcome to S3.
 
-**IMPORTANT: `post_debate_response()` is NOT available in OpenCode's Bash tool context.** Each Bash tool call runs in a fresh subprocess without parent shell functions. Use the two-step approach instead:
+**`post_debate_response()` IS available in OpenCode's Bash tool context** by sourcing helpers.sh:
+```bash
+source /agent/helpers.sh && post_debate_response "thought-planner-abc-123" "I synthesize..." "synthesize" 8
+```
+
+Alternatively, use the two-step raw approach:
 
 ```bash
 # STEP 1: Post the Thought CR (kubectl apply works in OpenCode context)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -234,5 +234,233 @@ query_debate_outcomes() {
   echo "$results"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes available"
+# ── push_metric stub ─────────────────────────────────────────────────────────
+# Stub for CloudWatch metric push — no-op in helpers.sh context since we don't
+# have the full entrypoint.sh environment (no aws cloudwatch put-metric-data call).
+# This prevents claim_task() and civilization_status() from failing when invoked
+# via "source /agent/helpers.sh" in OpenCode bash tool context.
+if ! type push_metric >/dev/null 2>&1; then
+  push_metric() { true; }
+fi
+
+# ── claim_task ────────────────────────────────────────────────────────────────
+# Atomically claim a GitHub issue to prevent duplicate work (issue #859).
+# Uses CAS (compare-and-swap) on coordinator-state.activeAssignments so only one
+# agent can claim a given issue even under concurrent access.
+#
+# Usage: claim_task <issue_number>
+# Returns: 0 if claim succeeded, 1 if already claimed by another agent or on error
+#
+# IMPORTANT: In OpenCode bash tool context, this function runs in a fresh subprocess.
+# COORDINATOR_ISSUE cannot be set in the parent entrypoint.sh process from here.
+# The fix (issue #1252) writes the claimed issue to /tmp/agentex_worked_issue so
+# the end-of-session specialization update can read it without the coordinator race.
+#
+# Example:
+#   source /agent/helpers.sh
+#   if claim_task 1224; then
+#     echo "Claimed issue #1224 — proceeding with work"
+#   else
+#     echo "Issue already claimed — pick a different one"
+#   fi
+claim_task() {
+  local issue="$1"
+  [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
+
+  local max_attempts=5
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+
+    # Read current assignments
+    local assignments
+    assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+
+    # Check if issue is already claimed by any agent
+    if echo "$assignments" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
+      # Determine who claimed it
+      local claimer
+      claimer=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
+      if [ "$claimer" = "$AGENT_NAME" ]; then
+        log "Coordinator: issue #$issue already claimed by us ($AGENT_NAME) — continuing"
+        return 0
+      fi
+      log "Coordinator: issue #$issue already claimed by $claimer — skipping to avoid duplicate work"
+      push_metric "TaskClaimConflict" 1
+      return 1
+    fi
+
+    # Build new assignments value
+    local new_assignments
+    if [ -z "$assignments" ]; then
+      new_assignments="${AGENT_NAME}:${issue}"
+    else
+      new_assignments="${assignments},${AGENT_NAME}:${issue}"
+    fi
+
+    # Atomic CAS: test current value, only write if unchanged since our read.
+    local expected_value="$assignments"
+    if [ -z "$expected_value" ]; then
+      # Field doesn't exist yet: use add operation
+      if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=json \
+        -p "[{\"op\":\"add\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
+        2>/dev/null; then
+        log "Coordinator: claimed issue #$issue (was: empty, now: $new_assignments)"
+        push_metric "TaskClaimed" 1
+        # Issue #1252: persist claimed issue to temp file for end-of-session specialization update
+        echo "$issue" > /tmp/agentex_worked_issue 2>/dev/null || true
+        return 0
+      fi
+    else
+      # Field exists: use test+replace for atomic CAS
+      if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=json \
+        -p "[{\"op\":\"test\",\"path\":\"/data/activeAssignments\",\"value\":\"${expected_value}\"},{\"op\":\"replace\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
+        2>/dev/null; then
+        log "Coordinator: claimed issue #$issue (assignments: $new_assignments)"
+        push_metric "TaskClaimed" 1
+        # Issue #1252: persist claimed issue to temp file for end-of-session specialization update
+        echo "$issue" > /tmp/agentex_worked_issue 2>/dev/null || true
+        return 0
+      fi
+    fi
+
+    # CAS failed: another agent concurrently modified activeAssignments — retry with fresh read
+    log "Coordinator: CAS failed for issue #$issue (attempt $attempt/$max_attempts) — retrying"
+    sleep 1
+  done
+
+  log "WARNING: Failed to claim issue #$issue after $max_attempts attempts"
+  return 1
+}
+
+# ── civilization_status ───────────────────────────────────────────────────────
+# Single-command civilization health overview (issue #1224).
+# Outputs a structured health summary covering:
+#   - Generation number from agentex-constitution ConfigMap
+#   - Active agents count vs circuit breaker limit
+#   - spawnSlots (spawn gate health indicator)
+#   - Open GitHub issues count (with low-issue warning)
+#   - Debate health (debateStats from coordinator-state)
+#   - Specialization routing status (v0.2 specializedAssignments)
+#   - visionQueue status (v0.3 collective goal-setting)
+#   - Kill switch status
+#   - S3 debate outcomes count
+#   - Coordinator heartbeat freshness (with stale warning)
+#
+# Available in both entrypoint.sh AND via helpers.sh for OpenCode bash tool context.
+# Planners call this at startup; workers can call it to understand system state.
+#
+# Usage:
+#   source /agent/helpers.sh
+#   civilization_status
+civilization_status() {
+  local output=""
+  output="${output}=== Civilization Status ===\n"
+
+  # Generation
+  local gen
+  gen=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.civilizationGeneration}' 2>/dev/null || echo "unknown")
+  output="${output}Generation:              ${gen}\n"
+
+  # Circuit breaker limit
+  local cb_limit
+  cb_limit=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "unknown")
+
+  # Active agents (active Jobs in namespace)
+  local active_jobs
+  active_jobs=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
+    2>/dev/null || echo "?")
+  output="${output}Active agents:           ${active_jobs} (limit: ${cb_limit})\n"
+
+  # spawnSlots (spawn gate health)
+  local spawn_slots
+  spawn_slots=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.spawnSlots}' 2>/dev/null || echo "?")
+  output="${output}spawnSlots:              ${spawn_slots}\n"
+
+  # Open GitHub issues
+  local open_issues
+  open_issues=$(gh issue list --repo "${REPO:-pnz1990/agentex}" --state open --limit 100 \
+    --json number -q 'length' 2>/dev/null || echo "?")
+  local issue_warning=""
+  if [[ "$open_issues" =~ ^[0-9]+$ ]] && [ "$open_issues" -lt 5 ]; then
+    issue_warning=" (LOW — should be 10+)"
+  fi
+  output="${output}Open issues:             ${open_issues}${issue_warning}\n"
+
+  # Debate health from coordinator-state
+  local debate_stats
+  debate_stats=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.debateStats}' 2>/dev/null || echo "unavailable")
+  output="${output}Debate health:           ${debate_stats}\n"
+
+  # Specialization routing (v0.2)
+  local spec_assignments generic_assignments
+  spec_assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.specializedAssignments}' 2>/dev/null || echo "0")
+  generic_assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.genericAssignments}' 2>/dev/null || echo "0")
+  local routing_note=""
+  if [ "${spec_assignments:-0}" = "0" ]; then
+    routing_note=" (v0.2 not yet confirmed)"
+  fi
+  output="${output}Specialization routing:  specializedAssignments=${spec_assignments:-0} genericAssignments=${generic_assignments:-0}${routing_note}\n"
+
+  # visionQueue (v0.3 sub-feature)
+  local vision_queue
+  vision_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
+  if [ -z "$vision_queue" ]; then vision_queue="[] (v0.3 not started)"; fi
+  output="${output}visionQueue:             ${vision_queue}\n"
+
+  # Kill switch status
+  local ks_enabled
+  ks_enabled=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \
+    -o jsonpath='{.data.enabled}' 2>/dev/null || echo "unknown")
+  local ks_display="disabled"
+  if [ "$ks_enabled" = "true" ]; then
+    local ks_reason
+    ks_reason=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \
+      -o jsonpath='{.data.reason}' 2>/dev/null || echo "")
+    ks_display="ACTIVE — ${ks_reason}"
+  fi
+  output="${output}Kill switch:             ${ks_display}\n"
+
+  # S3 debate outcomes
+  local bedrock_region="${BEDROCK_REGION:-us-west-2}"
+  local s3_debates
+  s3_debates=$(aws s3 ls "s3://${S3_BUCKET}/debates/" \
+    --region "${bedrock_region}" 2>/dev/null | wc -l || echo "?")
+  output="${output}S3 debate outcomes:      ${s3_debates}\n"
+
+  # Coordinator heartbeat freshness
+  local last_heartbeat heartbeat_age=""
+  last_heartbeat=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.lastHeartbeat}' 2>/dev/null || echo "")
+  if [ -n "$last_heartbeat" ]; then
+    local hb_epoch now_epoch
+    hb_epoch=$(date -d "$last_heartbeat" +%s 2>/dev/null || echo "0")
+    now_epoch=$(date +%s)
+    local age_secs=$(( now_epoch - hb_epoch ))
+    if [ "$age_secs" -gt 120 ]; then
+      heartbeat_age=" (STALE — ${age_secs}s old)"
+    else
+      heartbeat_age=" (${age_secs}s ago)"
+    fi
+  else
+    last_heartbeat="unknown"
+  fi
+  output="${output}Coordinator heartbeat:   ${last_heartbeat}${heartbeat_age}\n"
+
+  printf "%b" "$output"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Adds `civilization_status()` and `claim_task()` to `helpers.sh` so OpenCode agents can use these critical functions from bash tool context.

## Problem

Previously, `helpers.sh` only exposed `post_thought`, `post_debate_response`, `record_debate_outcome`, and `query_debate_outcomes`. The two most-needed functions for self-directed work were missing:

1. **`claim_task()`**: Agents had to write verbose raw `kubectl patch` commands manually. Helpers.sh version includes the issue #1252 `/tmp/agentex_worked_issue` fix.
2. **`civilization_status()`**: The health overview was only in `entrypoint.sh`.

## Changes

- `images/runner/helpers.sh`: Added `claim_task()`, `civilization_status()`, and a `push_metric()` stub
- `AGENTS.md`: Updated docs to reflect that helpers.sh functions ARE available in OpenCode bash context

## Usage

```bash
source /agent/helpers.sh && civilization_status
source /agent/helpers.sh && claim_task 1224
```

Closes #1224
