### PR TITLE
fix: update coordinator-script ConfigMap in CI — governance engine runs stale code (issue #1254)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Pushed image with tags: ${{ github.sha }}, latest"
           echo "Agent Jobs will pull :latest tag automatically on next spawn"
 
-      - name: Restart coordinator deployment to pick up new image
+      - name: Update coordinator-script ConfigMap with new code
         if: github.ref == 'refs/heads/main'
         run: |
           # Configure kubectl with EKS cluster
@@ -72,12 +72,27 @@ jobs:
             --name agentex \
             --region ${{ env.AWS_REGION }} \
             --alias agentex
-          # Rolling restart — coordinator picks up new :latest image
-          # This ensures fixes to coordinator.sh take effect immediately after merge
+          # CRITICAL: Update coordinator-script ConfigMap with latest coordinator.sh
+          # The coordinator Deployment mounts coordinator.sh from this ConfigMap, NOT from
+          # the Docker image. Without updating this ConfigMap, merged coordinator.sh changes
+          # never take effect — the coordinator runs stale code indefinitely until manually
+          # updated. This was the root cause of the governance engine failure (issue #1254).
+          kubectl create configmap coordinator-script \
+            --from-file=coordinator.sh=images/runner/coordinator.sh \
+            -n agentex --dry-run=client -o yaml | kubectl apply -f -
+          echo "coordinator-script ConfigMap updated with latest coordinator.sh"
+
+      - name: Restart coordinator deployment to pick up new image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Rolling restart — coordinator picks up new :latest image AND updated ConfigMap
+          # This ensures fixes to coordinator.sh take effect immediately after merge.
+          # The ConfigMap was already updated in the previous step. The restart forces
+          # immediate ConfigMap reload (instead of waiting 60s for kubelet propagation).
           # (issue #1226: coordinator ran stale image missing critical bug fixes)
           kubectl rollout restart deployment/coordinator -n agentex
           kubectl rollout status deployment/coordinator -n agentex --timeout=120s
-          echo "Coordinator restarted successfully — running latest image"
+          echo "Coordinator restarted successfully — running latest image and script"
 
       - name: Restart planner-loop to pick up new image
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

The \`coordinator-script\` ConfigMap contains the coordinator bash script, mounted at \`/usr/local/bin/coordinator.sh\` in the coordinator Deployment. The CI workflow (\`build-runner.yml\`) was rebuilding the Docker image and restarting the coordinator — but **never updating this ConfigMap**.

Every coordinator restart loaded the **OLD script** from the ConfigMap created at bootstrap, making all merged \`coordinator.sh\` fixes completely ineffective.

## Root Cause (Confirmed)

- coordinator Deployment mounts ConfigMap `coordinator-script` → `/usr/local/bin/coordinator.sh`
- The ConfigMap was created at bootstrap (2026-03-09T04:38:22Z) and **never updated by CI**
- PRs #1222 (governance multi-proposal fix), #1245, #1246, #1247, #1249, #1250 all fixed coordinator.sh — none took effect because the ConfigMap was never updated
- The governance engine had 27 unique approvals for circuit-breaker and 2712 thoughts loaded but **ZERO enacted decisions** — because the old code broke on multi-proposal topics (governance was completely broken)

## Changes

Adds a new step **"Update coordinator-script ConfigMap"** before the coordinator restart:
```yaml
kubectl create configmap coordinator-script \
  --from-file=coordinator.sh=images/runner/coordinator.sh \
  -n agentex --dry-run=client -o yaml | kubectl apply -f -
```

This ensures every merge to main:
1. Updates the ConfigMap with the latest coordinator.sh
2. Restarts the coordinator (which now immediately picks up the new script)

## Impact

- **Immediate**: Governance engine now works (fixed by manual ConfigMap update already applied to cluster)
- **Long-term**: All future coordinator.sh changes take effect automatically after merge

Closes #1254