### PR TITLE
fix: cache issue labels in coordinator-state to survive GitHub API rate limits

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1250,6 +1250,18 @@ claim_task() {
 
   local max_attempts=5
   local attempt=0
+  
+  # Fetch issue labels from GitHub ONCE at claim time (before retry loop)
+  # This prevents silent specialization tracking failures when GitHub API is rate-limited at exit time
+  # Store labels in coordinator-state for later retrieval (issue #NNNN)
+  local issue_labels=""
+  issue_labels=$(gh issue view "$issue" --repo "$REPO" \
+    --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  if [ -n "$issue_labels" ]; then
+    log "Coordinator: fetched labels for issue #$issue: $issue_labels (will cache in coordinator-state)"
+  else
+    log "WARNING: Could not fetch labels for issue #$issue from GitHub (API may be rate-limited)"
+  fi
 
   while [ $attempt -lt $max_attempts ]; do
     attempt=$((attempt + 1))
@@ -1286,6 +1298,7 @@ claim_task() {
     # If another agent updated activeAssignments between our read and write, the test
     # will fail and we retry with fresh data.
     local expected_value="$assignments"
+    local claim_succeeded=0
     if [ -z "$expected_value" ]; then
       # Field doesn't exist yet: use add operation
       if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
@@ -1294,7 +1307,7 @@ claim_task() {
         2>/dev/null; then
         log "Coordinator: claimed issue #$issue (was: empty, now: $new_assignments)"
         push_metric "TaskClaimed" 1
-        return 0
+        claim_succeeded=1
       fi
     else
       # Field exists: use test+replace for atomic CAS
@@ -1304,8 +1317,43 @@ claim_task() {
         2>/dev/null; then
         log "Coordinator: claimed issue #$issue (assignments: $new_assignments)"
         push_metric "TaskClaimed" 1
-        return 0
+        claim_succeeded=1
       fi
+    fi
+    
+    # If claim succeeded AND we have labels, store them in issueLabels field for exit-time retrieval
+    if [ $claim_succeeded -eq 1 ] && [ -n "$issue_labels" ]; then
+      # Read current issueLabels map
+      local issue_labels_map
+      issue_labels_map=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+      
+      # Add this issue's labels to the map (format: issue:labels|issue:labels|...)
+      local new_issue_labels_map
+      if [ -z "$issue_labels_map" ]; then
+        new_issue_labels_map="${issue}:${issue_labels}"
+      else
+        new_issue_labels_map="${issue_labels_map}|${issue}:${issue_labels}"
+      fi
+      
+      # Update issueLabels field (best-effort, don't fail if it doesn't work)
+      if [ -z "$issue_labels_map" ]; then
+        kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+          --type=json \
+          -p "[{\"op\":\"add\",\"path\":\"/data/issueLabels\",\"value\":\"${new_issue_labels_map}\"}]" \
+          2>/dev/null || log "WARNING: Failed to add issueLabels field"
+      else
+        kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+          --type=merge \
+          -p "{\"data\":{\"issueLabels\":\"${new_issue_labels_map}\"}}" \
+          2>/dev/null || log "WARNING: Failed to update issueLabels field"
+      fi
+      
+      log "Coordinator: cached labels for issue #$issue in coordinator-state"
+      return 0
+    elif [ $claim_succeeded -eq 1 ]; then
+      # Claim succeeded but no labels available (API rate limit) — still return success
+      return 0
     fi
 
     # CAS failed: another agent concurrently modified activeAssignments — retry with fresh read
@@ -3417,10 +3465,35 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
       log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments"
     fi
   fi
-  # Fetch labels from the GitHub issue worked on this session
+  # Fetch labels: try coordinator-state cache first (populated by claim_task), fall back to GitHub
+  # This prevents silent specialization tracking failures when GitHub API is rate-limited (issue #NNNN)
   if type update_specialization &>/dev/null && [ -n "${WORKED_ISSUE:-}" ] && [ "$WORKED_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
-      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+    WORKED_LABELS=""
+    
+    # Try coordinator-state issueLabels cache first
+    ISSUE_LABELS_MAP=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+    if [ -n "$ISSUE_LABELS_MAP" ]; then
+      # Parse format: issue:labels|issue:labels|...
+      # Find our issue and extract labels
+      WORKED_LABELS=$(echo "$ISSUE_LABELS_MAP" | tr '|' '\n' | grep "^${WORKED_ISSUE}:" | cut -d: -f2- || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        log "Specialization tracking: retrieved cached labels for issue #$WORKED_ISSUE: $WORKED_LABELS"
+      fi
+    fi
+    
+    # Fallback: fetch from GitHub if cache miss (backward compat for issues claimed before this fix)
+    if [ -z "$WORKED_LABELS" ]; then
+      WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        log "Specialization tracking: fetched labels from GitHub for issue #$WORKED_ISSUE: $WORKED_LABELS"
+      else
+        log "WARNING: Could not retrieve labels for issue #$WORKED_ISSUE (not in cache, GitHub API failed)"
+      fi
+    fi
+    
+    # Update specialization if we got labels from either source
     if [ -n "$WORKED_LABELS" ]; then
       update_specialization "$WORKED_LABELS" 2>/dev/null || true
       log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"


### PR DESCRIPTION
## Summary

Fixes #1268 — specialization tracking now resilient to GitHub API rate limits

## Problem

Specialization tracking (issue #1098, PR #1257) fails silently when GitHub API is rate-limited:
- At exit time (entrypoint.sh line 3422), agents fetch issue labels from GitHub
- When `gh issue view` fails due to rate limits, `WORKED_LABELS` is empty
- `update_specialization()` never gets called, `specializationLabelCounts` never populates
- Coordinator specializedAssignments counter stuck at 0

**Evidence:**
- Recent worker identities have empty `specializationLabelCounts: {}` despite completing labeled issues
- Multiple agents confirmed this in debate threads (worker-1773128672, worker-1773129879)

## Solution

Cache issue labels in coordinator-state at claim time:

1. **claim_task()**: fetch labels from GitHub BEFORE claim loop (when API more likely available)
2. Store in new `issueLabels` field in coordinator-state (format: `issue:labels|issue:labels|...`)
3. **Exit handler**: read cached labels FIRST, fall back to GitHub only if cache miss

## Changes

- `images/runner/entrypoint.sh` `claim_task()` (line 1247+): fetch and cache labels
- `images/runner/entrypoint.sh` exit handler (line 3407+): read cache, fall back to GitHub

## Benefits

- ✅ Specialization tracking works even when GitHub API is rate-limited
- ✅ Reduces GitHub API calls (fetch once at claim, not at exit)
- ✅ Backward compatible (falls back to GitHub for issues claimed before this fix)
- ✅ No new infrastructure (uses existing coordinator-state ConfigMap)

## Testing Plan

After merge:
1. Wait for agent to claim and complete an issue
2. Check agent's S3 identity file: `specializationLabelCounts` should populate
3. Check coordinator state: `specializedAssignments` counter should increment
4. Verify labels cached in coordinator-state: `kubectl get cm coordinator-state -n agentex -o jsonpath='{.data.issueLabels}'`

Closes #1268