### PR TITLE
fix: persist claimed issue to /tmp/my_worked_issue to fix specialization tracking race (#1252)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1292,10 +1292,14 @@ claim_task() {
         --type=json \
         -p "[{\"op\":\"add\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]" \
         2>/dev/null; then
-        log "Coordinator: claimed issue #$issue (was: empty, now: $new_assignments)"
-        push_metric "TaskClaimed" 1
-        return 0
-      fi
+         log "Coordinator: claimed issue #$issue (was: empty, now: $new_assignments)"
+         push_metric "TaskClaimed" 1
+         # Persist claimed issue to temp file so end-of-session specialization
+         # tracking works even if coordinator cleans up activeAssignments before then.
+         # (issue #1252: WORKED_ISSUE=0 race with coordinator 30s cleanup)
+         echo "$issue" > /tmp/my_worked_issue 2>/dev/null || true
+         return 0
+       fi
     else
       # Field exists: use test+replace for atomic CAS
       if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
@@ -1304,8 +1308,12 @@ claim_task() {
         2>/dev/null; then
         log "Coordinator: claimed issue #$issue (assignments: $new_assignments)"
         push_metric "TaskClaimed" 1
+        # Persist claimed issue to temp file so end-of-session specialization
+        # tracking works even if coordinator cleans up activeAssignments before then.
+        # (issue #1252: WORKED_ISSUE=0 race with coordinator 30s cleanup)
+        echo "$issue" > /tmp/my_worked_issue 2>/dev/null || true
         return 0
-      fi
+       fi
     fi
 
     # CAS failed: another agent concurrently modified activeAssignments — retry with fresh read
@@ -3406,15 +3414,29 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   
   # Update specialization based on issue labels worked on this session (issue #1098)
   # Resolve the worked issue number: coordinator-assigned or self-selected (issue #1147)
+  # Fix for issue #1252: claim_task() now writes to /tmp/my_worked_issue at claim time.
+  # This temp file is the most reliable source because it is written atomically when the
+  # issue is claimed, before any coordinator cleanup can race and remove the assignment.
   WORKED_ISSUE="${COORDINATOR_ISSUE:-0}"
   if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
-    # Self-selected path: COORDINATOR_ISSUE was never set (queue was empty).
-    # Look up this agent's active assignment in coordinator-state to find the issue claimed.
+    # Primary fallback: read from temp file written by claim_task() at claim time.
+    # This is resistant to the 30s coordinator cleanup race that previously zeroed WORKED_ISSUE.
+    if [ -f /tmp/my_worked_issue ]; then
+      WORKED_ISSUE=$(cat /tmp/my_worked_issue 2>/dev/null | tr -d '[:space:]' || echo "0")
+      if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
+        log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from /tmp/my_worked_issue (claim_task persisted)"
+      else
+        WORKED_ISSUE="0"
+      fi
+    fi
+  fi
+  if [ "$WORKED_ISSUE" = "0" ] || [ -z "$WORKED_ISSUE" ]; then
+    # Secondary fallback: coordinator activeAssignments (may already be cleaned up, but try anyway).
     ACTIVE_ASSIGNMENTS=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
       -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
     WORKED_ISSUE=$(echo "$ACTIVE_ASSIGNMENTS" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 || echo "0")
     if [ -n "$WORKED_ISSUE" ] && [ "$WORKED_ISSUE" != "0" ]; then
-      log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments"
+      log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments (fallback)"
     fi
   fi
   # Fetch labels from the GitHub issue worked on this session


### PR DESCRIPTION
## Summary

Fixes `update_specialization()` never being called for self-selecting agents due to a race condition between end-of-session code and the coordinator's 30s cleanup loop.

Closes #1252

## Root Cause

When the coordinator task queue is empty:
1. `COORDINATOR_ISSUE` stays `0` (never populated from queue)
2. End-of-session specialization code falls back to reading `activeAssignments` from coordinator-state
3. But the coordinator's 30s cleanup loop **removes completed agents' assignments** before this code runs (~30+ min into agent session)
4. Result: `WORKED_ISSUE=0` → `update_specialization()` never called → zero specialization tracking across all 830+ agent runs

## Fix

`claim_task()` now writes the successfully claimed issue number to `/tmp/my_worked_issue` immediately after the atomic CAS claim succeeds. This file:
- Is written at claim time (before any cleanup races)
- Persists for the pod lifetime
- Is never cleaned up by the coordinator

End-of-session resolution order is now:
1. `COORDINATOR_ISSUE` (queue-assigned path)
2. `/tmp/my_worked_issue` (written by `claim_task()` at claim time) — **NEW**
3. `coordinator activeAssignments` (legacy fallback, still present if cleanup hasn't run yet)

## Changes

- `claim_task()`: write `$issue` to `/tmp/my_worked_issue` on successful claim (both CAS branches: empty and non-empty assignments)
- End-of-session specialization block: add `/tmp/my_worked_issue` as primary fallback before `activeAssignments` query

## Impact

- Unblocks v0.2 specialization routing (which depends on `specializationLabelCounts`)
- All future self-selecting workers will have their issue tracked for specialization
- No change to coordinator logic, no new dependencies