### PR TITLE
docs: update AGENTS.md to reflect helpers.sh availability for debate pipeline (issue #1227)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,8 +345,9 @@ spec:
 EOF
 
 # Step 3: FOR SYNTHESIS ONLY — also write to S3 to enable anti-amnesia lookups:
-# (This step is what post_debate_response() would do automatically in entrypoint.sh context,
-# but post_debate_response() is NOT available in OpenCode's Bash tool subprocess context.)
+# RECOMMENDED: Use helpers.sh (handles both Thought CR + S3 in one call):
+#   source /agent/helpers.sh && post_debate_response "${PARENT}" "your synthesis..." "synthesize" 8
+# FALLBACK (if helpers.sh unavailable): two-step approach below
 S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
 AGENT_NAME_VAL="${AGENT_NAME:-<your-agent-name>}"
 THREAD_ID=$(echo "$PARENT" | sha256sum | cut -d' ' -f1 | cut -c1-16)
@@ -788,7 +789,10 @@ printf '{"threadId":"%s","topic":"circuit-breaker","outcome":"consensus-agree","
 **Querying past debates** before proposing changes:
 
 ```bash
-# Check if this topic was already debated (raw S3 commands — query_debate_outcomes() not available in OpenCode context)
+# Check if this topic was already debated
+# RECOMMENDED: Use helpers.sh (simplest):
+source /agent/helpers.sh && query_debate_outcomes "circuit-breaker"
+# FALLBACK: Raw S3 commands (if helpers.sh unavailable):
 S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
 aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
   aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | \


### PR DESCRIPTION
## Summary

Removes two remaining outdated 'NOT available in OpenCode context' warnings from AGENTS.md about `post_debate_response()` and `query_debate_outcomes()`. These functions were added to `helpers.sh` (PR #1249), which is installed at `/agent/helpers.sh` in the runner image.

## Changes

1. **Debate step ⑤.5 synthesis comment** (line 347-349): Replaces warning about unavailability with `source /agent/helpers.sh` as PRIMARY approach, raw S3/kubectl as FALLBACK.

2. **Querying past debates section** (line 791): Replaces "not available in OpenCode context" comment with `source /agent/helpers.sh && query_debate_outcomes "topic"` as RECOMMENDED approach, raw S3 as FALLBACK.

## Why This Matters

AGENTS.md is the prime directive read by every agent. When it says functions "are NOT available", agents use the manual two-step approach (kubectl + raw S3) instead of the simpler helpers.sh wrapper. This creates unnecessary complexity and increases the chance of bugs in the synthesis pipeline.

Now that helpers.sh has these functions, AGENTS.md should reflect that.

## Testing

Verified `/workspace/repo/images/runner/helpers.sh` contains `post_debate_response()`, `record_debate_outcome()`, and `query_debate_outcomes()`. Verified Dockerfile installs it at `/agent/helpers.sh`.

Closes #1227

## Constitution Alignment

- ✅ Fixes documentation inconsistency without changing behavior
- ✅ Enforces existing constitution guidance (civilization must debate, use proper tools)
- ✅ Does not expand agent autonomy or bypass safety mechanisms

Ready for god review - constitution alignment verified (touches AGENTS.md — protected file)

Constitution alignment checklist:
- [x] Fixes documentation without changing behavior
- [x] Cites relevant constitution/vision sections in PR description
- [x] Linked to GitHub issue #1227
- [x] Does not expand agent autonomy or bypass safety mechanisms