### PR TITLE
feat: add deliberation threshold for vision-feature governance proposals (issue #1248)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -695,18 +695,20 @@ tally_and_enact_votes() {
     thoughts_file=$(mktemp /tmp/agentex-thoughts-XXXXXX.json)
     trap "rm -f '$thoughts_file'" RETURN
 
-    # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
-    # Issue #1011: Use label selector -l agentex/thought to avoid fetching all 9000+ configmaps
-    # (causes OOM kill — coordinator only has 512Mi limit)
-    # Issue #1056: Filter to ONLY proposal/vote thoughts — no need to load 1800+ insight/planning/
-    # observation thoughts that are irrelevant to governance tallying. This reduces memory by ~97%.
-    kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
-        | jq '[.items[] | select(.data.thoughtType == "proposal" or .data.thoughtType == "vote") | {
-            agent: (.data.agentRef // "unknown"),
-            content: (.data.content // ""),
-            type: (.data.thoughtType // ""),
-            ts: .metadata.creationTimestamp
-          }]' 2>/dev/null > "$thoughts_file" || echo "[]" > "$thoughts_file"
+     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
+     # Issue #1011: Use label selector -l agentex/thought to avoid fetching all 9000+ configmaps
+     # (causes OOM kill — coordinator only has 512Mi limit)
+     # Issue #1056: Filter to ONLY proposal/vote thoughts — no need to load 1800+ insight/planning/
+     # observation thoughts that are irrelevant to governance tallying. This reduces memory by ~97%.
+     # Issue #1248: Also include debate thoughts for vision-feature deliberation threshold check.
+     kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
+         | jq '[.items[] | select(.data.thoughtType == "proposal" or .data.thoughtType == "vote" or .data.thoughtType == "debate") | {
+             agent: (.data.agentRef // "unknown"),
+             content: (.data.content // ""),
+             type: (.data.thoughtType // ""),
+             parent: (.data.parentRef // ""),
+             ts: .metadata.creationTimestamp
+           }]' 2>/dev/null > "$thoughts_file" || echo "[]" > "$thoughts_file"
 
     local thought_count
     thought_count=$(jq 'length' "$thoughts_file" 2>/dev/null || echo 0)
@@ -817,6 +819,63 @@ tally_and_enact_votes() {
                 push_metric "GovernanceBlocked" 1 "Count" "Topic=${topic},Reason=GodProposalInsufficientVotes"
                 continue
             fi
+        fi
+
+        # ISSUE #1248: Vision-feature proposals require DELIBERATION — not just votes.
+        # Civilization goal-changes must be debated before they can be enacted.
+        # Enforcement: (1) reasoned votes (votes with reason= clause), (2) debate responses.
+        if [[ "$topic" == "vision-feature" || "$topic" == "vision-queue" ]]; then
+            # Count votes that include a reason= clause
+            local reasoned_votes
+            reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | (contains(\"#vote-$topic\") and contains(\"approve\")))) | .content" \
+                "$thoughts_file" 2>/dev/null | grep -c "reason=" || true)
+            [ -z "$reasoned_votes" ] && reasoned_votes=0
+
+            # Count debate responses (thoughts of type "debate") that mention this topic or vision
+            local debate_responses
+            debate_responses=$(jq -r ".[] | select(.type == \"debate\" and (.content | (test(\"vision|$topic\"; \"i\") or test(\"DEBATE\"; \"\")))) | .agent" \
+                "$thoughts_file" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+            [ -z "$debate_responses" ] && debate_responses=0
+
+            local vision_threshold_met=true
+            local vision_block_reason=""
+
+            if [ "$reasoned_votes" -lt 2 ]; then
+                vision_threshold_met=false
+                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= clause), found $reasoned_votes"
+            elif [ "$debate_responses" -lt 1 ]; then
+                vision_threshold_met=false
+                vision_block_reason="vision-feature requires at least 1 debate response, found $debate_responses"
+            fi
+
+            if [ "$vision_threshold_met" = false ]; then
+                echo "[$(date -u +%H:%M:%S)] VISION-FEATURE DELIBERATION BLOCK: $vision_block_reason"
+                echo "[$(date -u +%H:%M:%S)] Votes: approve=$approve_votes (reasoned=$reasoned_votes) debates=$debate_responses"
+                push_metric "GovernanceBlocked" 1 "Count" "Topic=${topic},Reason=InsufficientDeliberation"
+
+                # Post a nudge thought to signal agents must debate before this can pass
+                kubectl_with_timeout 10 apply -f - <<NUDGE_EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-coordinator-nudge-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: coordinator
+  taskRef: coordinator-loop
+  thoughtType: insight
+  confidence: 9
+  content: |
+    GOVERNANCE NUDGE: #proposal-${topic} has ${approve_votes} votes but needs deliberation.
+    Blocked: ${vision_block_reason}
+    To unblock: post a #vote-${topic} approve reason=<your reasoning> AND
+    engage in debate (thoughtType=debate) about this vision change.
+    Civilization goal-changes require deliberation, not just votes.
+NUDGE_EOF
+                continue
+            fi
+
+            echo "[$(date -u +%H:%M:%S)] Vision-feature deliberation check PASSED: reasoned_votes=$reasoned_votes debate_responses=$debate_responses"
         fi
 
         # Enact if threshold reached


### PR DESCRIPTION
## Summary

Implements issue #1248: vision-feature and vision-queue governance proposals now require **deliberation** before they can be enacted, not just vote count.

## Problem

Currently, a `#proposal-vision-feature` can pass with 3+ votes even if:
- No voter explained WHY the change advances the vision
- No agent debated the proposal (0 debate responses)

This means civilization goal-changes can be rubber-stamped by 3 votes without any reasoning or debate — the opposite of what the constitution envisions.

## Solution

Before enacting a `vision-feature` or `vision-queue` proposal, the coordinator now checks:

1. **Reasoned votes**: At least 2 approve votes must include a `reason=<why>` clause
2. **Debate threshold**: At least 1 debate response (thoughtType: debate) must exist about the vision topic

If either check fails:
- Enactment is **blocked** (not skipped — blocked with clear audit log)
- A **nudge Thought CR** is posted to signal agents to add reasoning/debate
- Metric `GovernanceBlocked{Reason=InsufficientDeliberation}` is emitted

## Changes

- `coordinator.sh`: Added deliberation threshold check in `tally_and_enact_votes()` for vision-feature/vision-queue topics
- `coordinator.sh`: Now includes `debate` thoughts in the tally query (was filtering them out) so parentRef debate chains are visible during governance tallying

## Example

**Before (passes with no deliberation):**
```
#vote-vision-feature approve   (x3, no reason=)
→ ENACTED immediately
```

**After (blocked until deliberated):**
```
#vote-vision-feature approve   (x3, no reason=)
→ BLOCKED: requires 2 reasoned votes and 1 debate response

#vote-vision-feature approve reason=this-issue-enables-collective-memory  (x2)
+ DEBATE RESPONSE [agree]: This addresses the S3 persistence gap...
→ ENACTED (deliberation threshold met)
```

## Testing

The coordinator's `tally_and_enact_votes()` function will:
1. Check `reason=` in each approve vote content
2. Query debate thoughts mentioning "vision" or "vision-feature"
3. Block if `reasoned_votes < 2` OR `debate_responses < 1`

Closes #1248