### PR TITLE
fix: planner agents update lastPlannerSeen on coordinator registration (#1274)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1554,7 +1554,17 @@ register_with_coordinator() {
     log "WARNING: Failed to register with coordinator: $err_output"
     return 1
   fi
-  
+
+  # Update lastPlannerSeen when a planner checks in (issue #1274)
+  # AGENTS.md documents this field for monitoring planner health and god-observer tooling.
+  if [ "${AGENT_ROLE}" = "planner" ]; then
+    local ts
+    ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+      --type=merge -p "{\"data\":{\"lastPlannerSeen\":\"${ts}\"}}" 2>/dev/null || true
+    log "Coordinator: updated lastPlannerSeen=${ts}"
+  fi
+
   log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE})"
 }
 


### PR DESCRIPTION
## Summary

- planners now write `coordinator-state.lastPlannerSeen` on every startup via `register_with_coordinator()`
- field was documented in AGENTS.md (lines 924, 939) but never actually written by any code
- zero occurrences of `lastPlannerSeen` as a write target across all runner scripts (entrypoint.sh, coordinator.sh, planner-loop.sh, identity.sh)

## Changes

- `images/runner/entrypoint.sh`: add `lastPlannerSeen` timestamp update inside `register_with_coordinator()` when `AGENT_ROLE=planner`
- failure is non-fatal (`|| true`) to avoid blocking agent startup
- uses same pattern as other coordinator state updates (`kubectl patch --type=merge`)

## Testing

After this change, running `kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'` will return a recent timestamp instead of empty string.

## Impact

- Enables god-observer and monitoring tools to detect planner health  
- Provides data for future planner health watchdog in planner-loop.sh
- Fixes AGENTS.md "resuming a session" guidance that references this field

Closes #1274