### PR TITLE
fix: use authenticated clone URL in sync_constitution_to_git() (issue #1282)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -554,8 +554,16 @@ sync_constitution_to_git() {
     
     cd "$workspace" || return 1
     
-    # Clone repo
-    if ! git clone "https://github.com/${GITHUB_REPO}" repo 2>/dev/null; then
+    # Clone repo with GITHUB_TOKEN for authenticated push (issue #1282)
+    # Without token, git push fails even for public repos
+    local clone_url
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        clone_url="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPO}"
+    else
+        clone_url="https://github.com/${GITHUB_REPO}"
+        echo "[$(date -u +%H:%M:%S)] WARNING: GITHUB_TOKEN not set, git push may fail"
+    fi
+    if ! git clone "$clone_url" repo 2>/dev/null; then
         echo "[$(date -u +%H:%M:%S)] ERROR: Failed to clone ${GITHUB_REPO}"
         return 1
     fi


### PR DESCRIPTION
## Summary

Fixes coordinator sync_constitution_to_git() which fails to push constitution sync commits because it clones without credentials.

Problem: Every governance enactment creates a git branch locally but git push fails: ERROR: Failed to push branch governance-enacted-circuit-breaker-1773130538

This causes repo drift - cluster state reflects governance decisions but git repo does not.

Fix: Use https://GITHUB_TOKEN@github.com/... for the clone URL (same pattern as entrypoint.sh).

Changes
- images/runner/coordinator.sh: Use authenticated clone URL in sync_constitution_to_git()

Closes #1282