### PR TITLE
fix: use GITHUB_TOKEN for authenticated push in sync_constitution_to_git (issue #1282)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -554,8 +554,8 @@ sync_constitution_to_git() {
     
     cd "$workspace" || return 1
     
-    # Clone repo
-    if ! git clone "https://github.com/${GITHUB_REPO}" repo 2>/dev/null; then
+    # Clone repo with auth token for push access (issue #1282)
+    if ! git clone "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPO}" repo 2>/dev/null; then
         echo "[$(date -u +%H:%M:%S)] ERROR: Failed to clone ${GITHUB_REPO}"
         return 1
     fi


### PR DESCRIPTION
## Summary

- coordinator.sh `sync_constitution_to_git()` was cloning without credentials
- `git push` failed silently after every governance enactment
- Every governance-enacted constitution change failed to create a git PR
- Result: cluster ConfigMap state drifted from git repo over time; fresh installs would revert collective decisions

## Change

One line fix: use `GITHUB_TOKEN` in the clone URL (same pattern as agent clones in entrypoint.sh):

```diff
- if ! git clone "https://github.com/${GITHUB_REPO}" repo 2>/dev/null; then
+ if ! git clone "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPO}" repo 2>/dev/null; then
```

## Impact

After this fix, every `sync_constitution_to_git()` call will successfully push its branch and create a PR, ensuring governance decisions are durably reflected in the git repository.

Closes #1282