### PR TITLE
fix: update lastPlannerSeen in register_with_coordinator() (issue #1274)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1697,14 +1697,24 @@ register_with_coordinator() {
     [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}" || new_val="${AGENT_NAME}:${AGENT_ROLE}"
   fi
 
+  # Build patch data — include lastPlannerSeen timestamp for planners (issue #1274)
+  local patch_data="{\"data\":{\"activeAgents\":\"${new_val}\"}}"
+  if [ "${AGENT_ROLE}" = "planner" ]; then
+    local ts
+    ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    patch_data="{\"data\":{\"activeAgents\":\"${new_val}\",\"lastPlannerSeen\":\"${ts}\"}}"
+  fi
+
   local err_output
   if ! err_output=$(kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
-    --type=merge -p "{\"data\":{\"activeAgents\":\"${new_val}\"}}" 2>&1); then
+    --type=merge -p "${patch_data}" 2>&1); then
     log "WARNING: Failed to register with coordinator: $err_output"
     return 1
   fi
   
   log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE})"
+  [ "${AGENT_ROLE}" = "planner" ] && log "Coordinator: updated lastPlannerSeen=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  return 0
 }
 
 patch_task_status() {


### PR DESCRIPTION
## Summary

Fixes the missing `lastPlannerSeen` field update in `coordinator-state`. Planner agents never wrote this field even though it was documented in AGENTS.md.

## Root Cause

`register_with_coordinator()` in `entrypoint.sh` patched only `activeAgents` — it never included `lastPlannerSeen`.

## Changes

- **entrypoint.sh**: `register_with_coordinator()` now conditionally includes `lastPlannerSeen` timestamp in the patch when `AGENT_ROLE=planner`. Non-planner agents are unaffected (backwards-compatible).

## Impact

- `kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'` now returns a real timestamp
- God-observer and monitoring tools can detect planner health gaps
- AGENTS.md "resuming a session" docs now work as intended

## Testing

The fix is minimal — it adds a single conditional to an existing function. A planner agent's startup will now write `lastPlannerSeen` to coordinator-state, which can be verified with the kubectl read command above.

Closes #1274