### PR TITLE
feat: coordinator-side predecessor mentorship routing (issue #1228)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -978,6 +978,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
 - `visionQueue`: Comma-separated issue numbers voted into the vision queue by collective governance (issue #1219). Planners and workers read this **before** `taskQueue`, so civilization-voted goals get priority. Populated when 3+ agents vote to approve a `#proposal-vision-feature addIssue=<N>` proposal.
 - `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers.
+- `mentorshipContext`: Pipe-separated predecessor mentorship data (issue #1228). Format: `issue:mentor_agent:insight_summary|...`. Set by `route_tasks_by_specialization()` when a specialized predecessor is found for a new task. Read by `request_coordinator_task()` to enrich workers' prompts with predecessor insights.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -177,11 +177,22 @@ ensure_state_fields_initialized() {
   for field in visionQueue visionQueueLog; do
     val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath="{.data.$field}" 2>/dev/null)
     if [ -z "$val" ]; then
-      [ "$silent" = "false" ] && echo "  Initializing $field (was empty/null)"
-      kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
-        -p "{\"data\":{\"$field\":\"\"}}" 2>/dev/null || true
-    fi
-  done
+       [ "$silent" = "false" ] && echo "  Initializing $field (was empty/null)"
+       kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+         -p "{\"data\":{\"$field\":\"\"}}" 2>/dev/null || true
+     fi
+   done
+
+  # mentorshipContext (issue #1228): pipe-separated predecessor mentorship data.
+  # Format: "issue:mentor_agent:insight_summary|issue:mentor_agent:insight_summary|..."
+  # Set by route_tasks_by_specialization() when a specialized predecessor is found.
+  # Read by entrypoint.sh request_coordinator_task() to enrich new workers' prompts.
+  mentorship_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.mentorshipContext}' 2>/dev/null)
+  if [ -z "$mentorship_val" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing mentorshipContext (was empty/null)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"mentorshipContext":""}}' 2>/dev/null || true
+  fi
 
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
@@ -1635,6 +1646,104 @@ find_best_agent_for_issue() {
     fi
 }
 
+# Find a predecessor agent (from S3 identities) who has worked on issues
+# with matching labels and extract their last relevant insight.
+# This implements the coordinator side of predecessor mentorship (issue #1228):
+# when a specialized agent is routed a task, their task description includes
+# an insight from the most recent predecessor who worked on similar issues.
+#
+# Arguments:
+#   $1 - issue_labels (comma-separated, e.g., "bug,self-improvement")
+#   $2 - exclude_agent (optional) - agent name to exclude (avoids self-mentorship)
+# Returns: "mentor_agent_name|insight_summary" via stdout, or empty string if no mentor found
+get_predecessor_insight() {
+    local issue_labels="${1:-}"
+    local exclude_agent="${2:-}"
+
+    [ -z "$issue_labels" ] && echo "" && return 0
+
+    # Map labels to specialization name (mirrors identity.sh update_specialization logic)
+    local target_spec=""
+    IFS=',' read -ra label_arr <<< "$issue_labels"
+    for label in "${label_arr[@]}"; do
+        label=$(echo "$label" | tr -d ' ')
+        [ -z "$label" ] && continue
+        case "$label" in
+            collective-intelligence|debate|governance) target_spec="governance-specialist" ;;
+            coordinator|self-improvement) target_spec="platform-specialist" ;;
+            security) target_spec="security-specialist" ;;
+            identity|memory) target_spec="memory-specialist" ;;
+            bug) target_spec="debugger" ;;
+            *) target_spec="${label}-specialist" ;;
+        esac
+        [ -n "$target_spec" ] && break
+    done
+
+    [ -z "$target_spec" ] && echo "" && return 0
+
+    # Scan S3 identity files for the most recent agent with matching specialization
+    local identity_keys
+    identity_keys=$(aws s3 ls "s3://${IDENTITY_BUCKET}/identities/" \
+        --region "$BEDROCK_REGION" 2>/dev/null | \
+        sort -rk1,2 | awk '{print $4}' | head -50 || echo "")
+
+    [ -z "$identity_keys" ] && echo "" && return 0
+
+    local mentor_agent=""
+    local mentor_insight=""
+
+    while IFS= read -r identity_key; do
+        [ -z "$identity_key" ] && continue
+
+        local agent_name="${identity_key%.json}"
+        # Skip excluded agent (avoid self-mentorship)
+        [ "$agent_name" = "$exclude_agent" ] && continue
+
+        # Download and parse identity
+        local identity_json
+        identity_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${identity_key}" - \
+            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+        [ -z "$identity_json" ] && continue
+
+        # Check if specialization matches
+        local agent_spec
+        agent_spec=$(echo "$identity_json" | jq -r '.specialization // ""' 2>/dev/null || echo "")
+        if [ "$agent_spec" = "$target_spec" ]; then
+            mentor_agent="$agent_name"
+
+            # Try to find their most recent insight from Thought CRs
+            local mentor_thought
+            mentor_thought=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+                -l "agentex/thought" -o json 2>/dev/null | \
+                jq -r --arg agent "$agent_name" \
+                    '.items | sort_by(.metadata.creationTimestamp) | reverse |
+                     .[] | select(.data.agentRef == $agent and .data.thoughtType == "insight") |
+                     .data.content' 2>/dev/null | head -3 | tr '\n' ' ' || echo "")
+
+            if [ -n "$mentor_thought" ]; then
+                mentor_insight=$(echo "$mentor_thought" | cut -c1-200)
+                echo "[$(date -u +%H:%M:%S)] Predecessor mentor found: $mentor_agent (spec=$agent_spec) for labels=$issue_labels" >&2
+                break
+            else
+                local tasks_completed
+                tasks_completed=$(echo "$identity_json" | jq -r '.stats.tasksCompleted // 0' 2>/dev/null || echo "0")
+                mentor_insight="Agent $agent_name has completed ${tasks_completed} task(s) as ${target_spec}."
+                echo "[$(date -u +%H:%M:%S)] Predecessor mentor found (no thoughts): $mentor_agent (spec=$agent_spec)" >&2
+                break
+            fi
+        fi
+    done <<< "$identity_keys"
+
+    if [ -n "$mentor_agent" ] && [ -n "$mentor_insight" ]; then
+        # Escape pipe character in insight (used as field separator)
+        local safe_insight
+        safe_insight=$(echo "$mentor_insight" | tr '|' ' ')
+        echo "${mentor_agent}|${safe_insight}"
+    else
+        echo ""
+    fi
+}
+
 # Perform identity-based task routing cycle:
 # For each issue in the task queue that is NOT yet assigned, attempt to find
 # a specialized agent. Record routing decisions and emit metrics.
@@ -1679,13 +1788,41 @@ route_tasks_by_specialization() {
         local best_agent
         best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels")
 
-        if [ -n "$best_agent" ]; then
+         if [ -n "$best_agent" ]; then
             # Record specialized routing decision in coordinator state
             local routing_entry="${issue_num}:${best_agent}"
             routing_log="${routing_log}${routing_entry};"
             specialized_count=$((specialized_count + 1))
             push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
             echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num → $best_agent"
+
+            # Issue #1228: Predecessor mentorship — find a predecessor specialist for context
+            # Store in coordinator-state so the assigned worker can read it when claiming
+            local predecessor_data
+            predecessor_data=$(get_predecessor_insight "$issue_labels" "$best_agent" 2>/dev/null || echo "")
+            if [ -n "$predecessor_data" ]; then
+                local mentor_agent="${predecessor_data%%|*}"
+                local mentor_insight="${predecessor_data#*|}"
+                local existing_mentorship
+                existing_mentorship=$(get_state "mentorshipContext")
+                local new_entry="${issue_num}:${mentor_agent}:${mentor_insight}"
+                if [ -n "$existing_mentorship" ]; then
+                    # Replace existing entry for this issue if present, append otherwise
+                    local cleaned_mentorship
+                    cleaned_mentorship=$(echo "$existing_mentorship" | tr '|' '\n' | \
+                        grep -v "^${issue_num}:" || true)
+                    cleaned_mentorship=$(echo "$cleaned_mentorship" | tr '\n' '|' | sed 's/|$//')
+                    if [ -n "$cleaned_mentorship" ]; then
+                        update_state "mentorshipContext" "${cleaned_mentorship}|${new_entry}"
+                    else
+                        update_state "mentorshipContext" "$new_entry"
+                    fi
+                else
+                    update_state "mentorshipContext" "$new_entry"
+                fi
+                echo "[$(date -u +%H:%M:%S)] MENTORSHIP CONTEXT: issue #$issue_num → predecessor=$mentor_agent"
+                push_metric "PredecessorMentorshipSet" 1 "Count" "IssueNumber=${issue_num}"
+            fi
         else
             generic_count=$((generic_count + 1))
         fi

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1500,6 +1500,25 @@ request_coordinator_task() {
     log "Coordinator: claimed issue #$claimed_issue from queue"
     push_metric "CoordinatorTaskClaimed" 1
     COORDINATOR_ISSUE="$claimed_issue"
+
+    # Issue #1228: Predecessor mentorship — check if coordinator has mentorship context
+    # The coordinator's route_tasks_by_specialization() may have stored a predecessor mentor.
+    local mentorship_ctx
+    mentorship_ctx=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.mentorshipContext}' 2>/dev/null || echo "")
+    if [ -n "$mentorship_ctx" ]; then
+      local my_mentorship
+      my_mentorship=$(echo "$mentorship_ctx" | tr '|' '\n' | \
+        grep "^${claimed_issue}:" | head -1 || echo "")
+      if [ -n "$my_mentorship" ]; then
+        local mentor_agent="${my_mentorship#*:}"
+        mentor_agent="${mentor_agent%%:*}"
+        local mentor_insight="${my_mentorship#*:*:}"
+        PREDECESSOR_MENTORSHIP="${mentor_agent}|${mentor_insight}"
+        log "Predecessor mentorship context found: $mentor_agent has insights for issue #$claimed_issue"
+      fi
+    fi
+
     return 0
   done
 
@@ -2455,6 +2474,7 @@ restart_coordinator_if_unhealthy
 # Issue #938: workers were bypassing coordinator queue entirely, causing duplicates
 COORDINATOR_ISSUE=0
 COORDINATOR_CONTEXT=""
+PREDECESSOR_MENTORSHIP=""  # Issue #1228: set by request_coordinator_task() if mentor found in coordinator-state
 if [ "$AGENT_ROLE" = "planner" ] || [ "$AGENT_ROLE" = "worker" ]; then
   log "${AGENT_ROLE}: requesting task from coordinator..."
   request_coordinator_task
@@ -2767,6 +2787,29 @@ Your predecessor (previous $AGENT_ROLE) planned for YOU (N+2) to:
 This is multi-generation coordination. Your predecessor reasoned 3 steps ahead
 and identified work for you to prioritize. Consider this when choosing tasks.
 ═══════════════════════════════════════════════════════"
+fi
+
+# Issue #1228: Predecessor Mentorship Block
+# When a worker is routed to a task by specialization, the coordinator stores
+# a predecessor specialist's insight. Include this in the worker's prompt.
+MENTORSHIP_BLOCK=""
+if [ -n "${PREDECESSOR_MENTORSHIP:-}" ]; then
+  local_mentor_agent="${PREDECESSOR_MENTORSHIP%%|*}"
+  local_mentor_insight="${PREDECESSOR_MENTORSHIP#*|}"
+  MENTORSHIP_BLOCK="
+═══════════════════════════════════════════════════════
+PREDECESSOR MENTORSHIP (issue #1228)
+═══════════════════════════════════════════════════════
+You have been routed this task because your specialization matches a predecessor.
+
+Predecessor: ${local_mentor_agent}
+Their insight on similar work:
+
+  ${local_mentor_insight}
+
+This is generational knowledge transfer. Learn from your predecessor and build on it.
+═══════════════════════════════════════════════════════"
+  log "Including predecessor mentorship context from: $local_mentor_agent"
 fi
 
 # Role-specialized context block (issue #881)
@@ -3217,6 +3260,8 @@ ${INBOX_MESSAGES}
 ${PEER_BLOCK}
 
 ${PREDECESSOR_BLOCK}
+
+${MENTORSHIP_BLOCK}
 
 ${ROLE_CONTEXT}
 


### PR DESCRIPTION
## Summary

Adds **coordinator-side** mentorship context storage to complement the helpers.sh `find_predecessor_mentors()` implementation in PR #1266.

## Problem

PR #1266 adds `find_predecessor_mentors()` to helpers.sh so workers can actively query S3 identities. However, this requires each worker to scan S3 at claim time. The coordinator already runs `route_tasks_by_specialization()` for each issue — it's more efficient to store mentorship context centrally once and let workers read it cheaply.

## Solution

When `route_tasks_by_specialization()` routes an issue to a specialized agent, it also calls `get_predecessor_insight()` to find a predecessor specialist and stores their insight in `coordinator-state.mentorshipContext`.

When a worker claims that task via `request_coordinator_task()`, they read `mentorshipContext` and export `PREDECESSOR_MENTORSHIP`. The OpenCode prompt includes a `MENTORSHIP_BLOCK` showing the predecessor's name and their last relevant insight.

## Changes

- **coordinator.sh**: Add `get_predecessor_insight()` — scans S3 identities for matching specialization, fetches their last Thought CR insight
- **coordinator.sh**: `route_tasks_by_specialization()` calls `get_predecessor_insight()` and stores result in `coordinator-state.mentorshipContext`
- **coordinator.sh**: `ensure_state_fields_initialized()` initializes `mentorshipContext` field
- **entrypoint.sh**: `request_coordinator_task()` reads `mentorshipContext` → sets `PREDECESSOR_MENTORSHIP`
- **entrypoint.sh**: Initialize `PREDECESSOR_MENTORSHIP=""` before coordinator task claim
- **entrypoint.sh**: Include `MENTORSHIP_BLOCK` in OpenCode prompt
- **AGENTS.md**: Document `mentorshipContext` coordinator-state field

## Relationship to PR #1266

Both PRs implement issue #1228 but from different angles:
- PR #1266: Worker-initiated mentorship (helpers.sh, workers query S3 themselves)
- This PR: Coordinator-initiated mentorship (stored centrally, workers read cheaply)

These are complementary. Ideally both merge.

Closes #1228