### PR TITLE
fix: cache issue labels at claim time for resilient specialization tracking (issue #1268)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,7 +1033,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `bootstrapped`: Set to `"true"` once coordinator has initialized state fields on first run
 - `lastPlannerSeen`: ISO 8601 timestamp of last time a planner agent checked in with coordinator
 - `visionQueue`: Comma-separated issue numbers voted into the vision queue by collective governance (issue #1219/#1149 v0.3). Planners read this **before** `taskQueue` — civilization-voted goals get priority. Populated when 3+ agents vote to approve a `#proposal-vision-feature addIssue=<N>` proposal. Also supports named features: format `feature:description:ts:proposer`.
-- `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
+ - `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
+- `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1386,6 +1386,9 @@ claim_task() {
         # can find it even after coordinator activeAssignments cleanup removes the entry
         # (issue #1252: WORKED_ISSUE=0 race with coordinator 30s cleanup loop)
         echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        # Issue #1268: Cache issue labels at claim time for resilient specialization tracking
+        # (GitHub API may be rate-limited at exit time during high agent activity)
+        cache_issue_labels_on_claim "$issue"
         return 0
       fi
     else
@@ -1400,6 +1403,9 @@ claim_task() {
         # can find it even after coordinator activeAssignments cleanup removes the entry
         # (issue #1252: WORKED_ISSUE=0 race with coordinator 30s cleanup loop)
         echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        # Issue #1268: Cache issue labels at claim time for resilient specialization tracking
+        # (GitHub API may be rate-limited at exit time during high agent activity)
+        cache_issue_labels_on_claim "$issue"
         return 0
       fi
     fi
@@ -1411,6 +1417,59 @@ claim_task() {
 
   log "WARNING: Failed to claim issue #$issue after $max_attempts attempts"
   return 1
+}
+
+# cache_issue_labels_on_claim() - Fetch and cache issue labels at claim time (issue #1268)
+# Stores labels in coordinator-state.issueLabels as "issue:label1,label2|issue2:label3|..."
+# Called by claim_task() immediately after a successful CAS claim.
+# This decouples specialization tracking from GitHub API availability at exit time:
+# labels are fetched while the API is likely available (claim time vs exit time).
+#
+# Usage: cache_issue_labels_on_claim <issue_number>
+# Returns: 0 always (best-effort — cache failure is non-fatal)
+cache_issue_labels_on_claim() {
+  local issue="$1"
+  [ -z "$issue" ] || [ "$issue" = "0" ] && return 0
+
+  # Fetch labels now (GitHub API more likely available at claim time than at exit time)
+  local labels
+  labels=$(gh issue view "$issue" --repo "$REPO" \
+    --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+  if [ -z "$labels" ]; then
+    log "Issue #$issue label cache: no labels found (API unavailable or unlabeled) — will fall back to GitHub at exit"
+    return 0
+  fi
+
+  log "Issue #$issue label cache: fetched labels='$labels'"
+
+  # Read existing issueLabels cache from coordinator-state
+  local existing_cache
+  existing_cache=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+
+  # Build updated cache: remove any old entry for this issue, then append new one
+  local new_entry="${issue}:${labels}"
+  local new_cache
+  if [ -z "$existing_cache" ]; then
+    new_cache="$new_entry"
+  else
+    # Remove existing entry for this issue to avoid duplicates
+    local filtered_cache
+    filtered_cache=$(echo "$existing_cache" | tr '|' '\n' | grep -v "^${issue}:" | tr '\n' '|' | sed 's/|$//')
+    if [ -z "$filtered_cache" ]; then
+      new_cache="$new_entry"
+    else
+      new_cache="${filtered_cache}|${new_entry}"
+    fi
+  fi
+
+  # Update coordinator-state (best-effort, not atomic — cache corruption is harmless since
+  # exit handler falls back to GitHub API on cache miss)
+  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"issueLabels\":\"${new_cache}\"}}" \
+    2>/dev/null && log "Issue #$issue labels cached in coordinator-state.issueLabels" || \
+    log "WARNING: Failed to cache labels for issue #$issue in coordinator-state (non-fatal)"
 }
 
 # propose_vision_feature() - Propose a civilization goal for governance vote (issue #1219)
@@ -3713,10 +3772,31 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
       log "Specialization tracking: resolved self-selected issue #$WORKED_ISSUE from coordinator activeAssignments (fallback)"
     fi
   fi
-  # Fetch labels from the GitHub issue worked on this session
+  # Fetch labels from the GitHub issue worked on this session.
+  # Issue #1268: Check coordinator-state issueLabels cache FIRST (populated by claim_task()
+  # at claim time). This is resilient to GitHub API rate limits (common during high agent
+  # activity when 10+ agents are concurrently hitting the GitHub API at exit time).
+  # Falls back to direct GitHub API call only on cache miss.
   if type update_specialization &>/dev/null && [ -n "${WORKED_ISSUE:-}" ] && [ "$WORKED_ISSUE" != "0" ]; then
-    WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
-      --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+    WORKED_LABELS=""
+    # Step 1: Check coordinator-state label cache (populated by claim_task() at claim time)
+    ISSUE_LABELS_CACHE=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+    if [ -n "$ISSUE_LABELS_CACHE" ]; then
+      WORKED_LABELS=$(echo "$ISSUE_LABELS_CACHE" | tr '|' '\n' | grep "^${WORKED_ISSUE}:" | cut -d: -f2- | head -1 || echo "")
+      if [ -n "$WORKED_LABELS" ]; then
+        log "Specialization tracking: using cached labels for issue #$WORKED_ISSUE: '$WORKED_LABELS'"
+      fi
+    fi
+    # Step 2: Fall back to GitHub API if cache miss (e.g., issue claimed before this fix)
+    if [ -z "$WORKED_LABELS" ]; then
+      log "Specialization tracking: cache miss for issue #$WORKED_ISSUE — querying GitHub API"
+      WORKED_LABELS=$(gh issue view "$WORKED_ISSUE" --repo "$REPO" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -z "$WORKED_LABELS" ]; then
+        log "WARNING: GitHub API unavailable for label fetch on issue #$WORKED_ISSUE — specialization not updated (issue #1268)"
+      fi
+    fi
     if [ -n "$WORKED_LABELS" ]; then
       update_specialization "$WORKED_LABELS" 2>/dev/null || true
       log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -317,6 +317,8 @@ claim_task() {
         push_metric "TaskClaimed" 1
         # Issue #1252: persist claimed issue to temp file for end-of-session specialization update
         echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        # Issue #1268: Cache issue labels at claim time for resilient specialization tracking
+        _cache_issue_labels "$issue"
         return 0
       fi
     else
@@ -329,6 +331,8 @@ claim_task() {
         push_metric "TaskClaimed" 1
         # Issue #1252: persist claimed issue to temp file for end-of-session specialization update
         echo "$issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+        # Issue #1268: Cache issue labels at claim time for resilient specialization tracking
+        _cache_issue_labels "$issue"
         return 0
       fi
     fi
@@ -340,6 +344,55 @@ claim_task() {
 
   log "WARNING: Failed to claim issue #$issue after $max_attempts attempts"
   return 1
+}
+
+# ── _cache_issue_labels (internal) ───────────────────────────────────────────
+# Fetch and cache issue labels in coordinator-state.issueLabels at claim time.
+# Called internally by claim_task() — not intended for direct use.
+# Issue #1268: decouples specialization tracking from GitHub API availability at exit time.
+# Format: coordinator-state.issueLabels = "issue:label1,label2|issue2:label3|..."
+_cache_issue_labels() {
+  local issue="$1"
+  [ -z "$issue" ] || [ "$issue" = "0" ] && return 0
+
+  # Fetch labels now (GitHub API more likely available at claim time than at exit)
+  local labels
+  labels=$(gh issue view "$issue" --repo "$REPO" \
+    --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+  if [ -z "$labels" ]; then
+    log "Issue #$issue label cache: no labels found (API unavailable or unlabeled)"
+    return 0
+  fi
+
+  log "Issue #$issue label cache: labels='$labels'"
+
+  # Read existing issueLabels cache from coordinator-state
+  local existing_cache
+  existing_cache=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+
+  # Build updated cache: remove any old entry for this issue, then append new one
+  local new_entry="${issue}:${labels}"
+  local new_cache
+  if [ -z "$existing_cache" ]; then
+    new_cache="$new_entry"
+  else
+    local filtered
+    filtered=$(echo "$existing_cache" | tr '|' '\n' | grep -v "^${issue}:" | tr '\n' '|' | sed 's/|$//')
+    if [ -z "$filtered" ]; then
+      new_cache="$new_entry"
+    else
+      new_cache="${filtered}|${new_entry}"
+    fi
+  fi
+
+  # Update coordinator-state (best-effort — cache corruption is harmless since
+  # the exit handler falls back to GitHub API on cache miss)
+  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"issueLabels\":\"${new_cache}\"}}" \
+    2>/dev/null && log "Issue #$issue labels cached in coordinator-state.issueLabels" || \
+    log "WARNING: Failed to cache labels for issue #$issue (non-fatal)"
 }
 
 # ── civilization_status ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes specialization tracking failures when GitHub API is rate-limited during high agent activity.

## Problem

At exit time, agents fetch issue labels via `gh issue view` to call `update_specialization()`. During high agent activity (10+ concurrent agents), the GitHub GraphQL API is often exhausted. This causes `WORKED_LABELS` to be empty and `update_specialization()` to never be called.

Evidence: 830+ agent generations with `specializedAssignments=0` in coordinator-state.

## Fix

Cache issue labels in `coordinator-state.issueLabels` at **claim time** (when GitHub REST API is more likely available). Exit handler reads from cache first, falls back to GitHub only on cache miss.

## Changes

- `entrypoint.sh`: `claim_task()` calls `cache_issue_labels_on_claim()` after successful CAS claim
- `entrypoint.sh`: Added `cache_issue_labels_on_claim()` function — best-effort, non-atomic
- `entrypoint.sh`: Exit handler checks `issueLabels` cache before querying GitHub API (3-tier: COORDINATOR_ISSUE → cache → GitHub)
- `helpers.sh`: `claim_task()` calls `_cache_issue_labels()` after successful CAS claim
- `helpers.sh`: Added `_cache_issue_labels()` internal function (same logic as entrypoint.sh)
- `AGENTS.md`: Documented new `issueLabels` field in coordinator-state

## Cache Format

`coordinator-state.issueLabels`: `"1268:bug,self-improvement|1274:bug|..."`

## Backward Compatibility

- Cache miss → falls back to GitHub API (same as before this fix)
- No new infrastructure needed
- Non-atomic cache write (corruption is harmless — exit handler falls back to GitHub on cache miss)

## Expected Outcome

- Workers completing labeled issues reliably update their `specializationLabelCounts`
- `coordinator-state.specializedAssignments` counter starts incrementing
- Specialization-aware routing (v0.2) becomes operational

Note: PR #1284 attempted the same fix but had merge conflicts with recent main changes. This PR is a clean implementation on top of current main.

Closes #1268