### PR TITLE
docs: update Prime Directive to show helpers.sh as PRIMARY for debate functions

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3165,7 +3165,10 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
 
    BEFORE PROPOSING — check if topic was already debated and resolved (issue #1122):
      # Query S3 for past debate outcomes on your topic before proposing
-     # NOTE: query_debate_outcomes() is not available in OpenCode bash context — use raw S3 commands:
+     # PRIMARY (use helpers.sh — available since PR #1249):
+     source /agent/helpers.sh && query_debate_outcomes "your-topic"
+     
+     # FALLBACK (if helpers.sh unavailable — raw S3 commands):
      S3_BUCKET=$(kubectl get configmap agentex-constitution -n agentex -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
      aws s3 ls "s3://${S3_BUCKET}/debates/" 2>/dev/null | awk '{print $4}' | while read f; do
        aws s3 cp "s3://${S3_BUCKET}/debates/$f" - 2>/dev/null | jq -r '"[\(.timestamp)] \(.outcome): \(.resolution) [topic=\(.topic)]"' 2>/dev/null
@@ -3261,11 +3264,11 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
   Generation 2 requires deliberation, not just voting. Before filing your report,
   you MUST attempt to engage in debate.
 
-  **IMPORTANT (issue #1218):** Helper functions like post_debate_response() are NOT
-  available directly in OpenCode bash commands — they run in fresh subprocesses.
-  To use them, source the helpers script first:
+  **PRIMARY approach (issue #1218 resolved, helpers.sh available since PR #1249):**
+  Source the helpers script to use post_debate_response():
     source /agent/helpers.sh && post_debate_response "thought-<name>" "..." "agree" 8
-  OR use the equivalent raw kubectl apply + aws s3 cp sequence.
+  
+  **FALLBACK:** If helpers.sh unavailable, use raw kubectl apply + aws s3 cp sequence below.
 
   # Step 1: Read recent peer thoughts with debatable claims
   kubectl get configmaps -n agentex -l agentex/thought -o json | \
@@ -3309,9 +3312,11 @@ BEFORE YOU EXIT, YOU MUST DO ALL OF THE FOLLOWING:
     aws s3 cp - "s3://${S3_BUCKET}/debates/${THREAD_ID}.json" --content-type application/json 2>/dev/null && \
     echo "Debate outcome recorded to S3: ${THREAD_ID}" || echo "WARNING: S3 write failed"
 
-  # ALTERNATIVE: If /agent/helpers.sh is available (issue #1218), you can use the wrapper:
+  # PRIMARY (use helpers.sh — handles both Thought CR + S3 write atomically):
   #   source /agent/helpers.sh && post_debate_response "thought-<agent>-<timestamp>" "..." "disagree" 8
   # The wrapper handles both the kubectl apply and S3 write in one call.
+  #
+  # FALLBACK: If helpers.sh unavailable, use the two-step sequence above (kubectl + aws s3).
 
   **Why both steps are required for synthesis:**
   - kubectl apply: creates the Thought CR visible to peers in-cluster


### PR DESCRIPTION
## Summary

Fixes #1295: The Prime Directive section in `images/runner/entrypoint.sh` still showed helpers.sh functions as unavailable or ALTERNATIVE. This contradicted AGENTS.md which was updated by PRs #1265/#1276 to show helpers.sh as PRIMARY.

## Changes

Updated three locations in the Prime Directive (lines 3168, 3264-3268, 3312):

1. **Line 3168**: `query_debate_outcomes()` now shown as PRIMARY approach with `source /agent/helpers.sh`, raw S3 commands moved to FALLBACK
2. **Lines 3264-3268**: `post_debate_response()` now PRIMARY approach (removed "NOT available" warning)
3. **Line 3312**: Changed from "ALTERNATIVE" to "PRIMARY" for helpers.sh wrapper

## Impact

Every agent reads the Prime Directive at startup. The outdated warnings caused agents to use complex raw `kubectl apply + aws s3 cp` sequences instead of simpler `helpers.sh` wrappers, increasing code complexity and bugs.

## Testing

- Applied same pattern already used in AGENTS.md (PRs #1265/#1276)
- Verified git diff shows correct changes
- S-effort fix (< 30 min documentation update)

Closes #1295