### PR TITLE
feat: worker-side predecessor mentorship at claim time (issue #1228)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,39 @@ and identified work for you to prioritize. Consider this when choosing tasks.
 
 **No manual code needed** — just check the OpenCode prompt for the PREDECESSOR_BLOCK section.
 
+**Predecessor Mentorship (issue #1228 — generational knowledge transfer)**:
+
+When a worker is assigned an issue via the coordinator queue, `entrypoint.sh` automatically
+looks up predecessor agents whose specialization matches the issue's labels. If a match is found,
+a `MENTORSHIP_BLOCK` is injected into the OpenCode prompt with the mentor's last insight thought.
+
+**What you receive (workers only, when coordinator assigns an issue):**
+- `MENTORSHIP_BLOCK` — mentor identity + their last insight thought, injected after `PREDECESSOR_BLOCK`
+- Mentor is found by scanning recent S3 identity files for label count matches
+
+**Example MENTORSHIP_BLOCK in prompt:**
+```
+═══════════════════════════════════════════════════════
+PREDECESSOR MENTORSHIP (issue #1228 — generational knowledge transfer)
+═══════════════════════════════════════════════════════
+A specialist predecessor worked on issues of this type before you.
+
+  Mentor: ada (worker-1773030000)
+  Specialization: debugger
+
+  Their last insight:
+  What I did: Fixed circuit breaker false positive. What I found: ...
+
+Apply their experience to your implementation.
+═══════════════════════════════════════════════════════
+```
+
+**How mentor matching works:**
+1. Get the GitHub issue's labels
+2. Scan recent S3 identities (newest 50) for label count matches
+3. Score: exact `specialization` match = 10, `specializationLabelCounts` label match = count score
+4. Pick highest-scoring agent; find their most recent `insight` Thought CR
+
 **④ MARK YOUR TASK DONE** — `kubectl_with_timeout 10 patch configmap ${TASK_CR_NAME}-spec -n agentex --type=merge -p '{"data":{"phase":"Done","completedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}}'`
 
 **⑤ PARTICIPATE IN COLLECTIVE GOVERNANCE (CRITICAL FOR VISION)** — The civilization must make collective decisions to advance. The coordinator tallies votes and enacts changes when 3+ agents approve.

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1707,6 +1707,127 @@ register_with_coordinator() {
   log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE})"
 }
 
+# get_mentor_insight() - Find predecessor mentor for an issue (issue #1228)
+# Predecessor mentorship: when an agent claims an issue, we look up S3 identities
+# for agents whose specialization (or specializationLabelCounts) matches the issue labels.
+# Returns: sets MENTOR_DISPLAY_NAME, MENTOR_AGENT_NAME, MENTOR_INSIGHT vars.
+# The caller builds MENTORSHIP_BLOCK from these values and injects into OpenCode prompt.
+#
+# Algorithm:
+#   1. Get labels for the GitHub issue
+#   2. List S3 identities and sample up to 50 (most recent) for matching
+#   3. Score each: exact specialization match = 10, label count match = count score
+#   4. Pick highest-scoring agent with score > 0
+#   5. Find their most recent insight Thought CR
+#
+# Gracefully degrades: returns empty strings if S3/cluster unavailable.
+get_mentor_insight() {
+  local issue_num="${1:-}"
+  MENTOR_DISPLAY_NAME=""
+  MENTOR_AGENT_NAME=""
+  MENTOR_INSIGHT=""
+  MENTOR_SPECIALIZATION=""
+
+  [ -z "$issue_num" ] || [ "$issue_num" = "0" ] && return 0
+
+  log "Mentorship: looking up predecessor mentor for issue #$issue_num..."
+
+  # Step 1: Get labels for the issue
+  local issue_labels
+  issue_labels=$(gh issue view "$issue_num" --repo "$REPO" \
+    --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  if [ -z "$issue_labels" ]; then
+    log "Mentorship: no labels found for issue #$issue_num — skipping mentor lookup"
+    return 0
+  fi
+  log "Mentorship: issue #$issue_num labels: $issue_labels"
+
+  # Step 2: List S3 identities (newest first, sample up to 30 to stay fast)
+  # Limit: 30 identities × ~200ms/S3-read = ~6s max. Graceful degradation if slow.
+  local identity_keys
+  identity_keys=$(timeout 10s aws s3 ls "s3://${S3_BUCKET}/identities/" \
+    --region "$BEDROCK_REGION" 2>/dev/null | \
+    sort -k1,2 -r | awk '{print $4}' | head -30 || echo "")
+  if [ -z "$identity_keys" ]; then
+    log "Mentorship: no identity files found in S3 — skipping"
+    return 0
+  fi
+
+  # Step 3: Score identities for label match
+  local best_agent="" best_display="" best_score=0 best_spec=""
+  while IFS= read -r identity_key; do
+    [ -z "$identity_key" ] && continue
+    # Skip own identity
+    [[ "$identity_key" == "${AGENT_NAME}.json" ]] && continue
+
+    local identity_json
+    identity_json=$(aws s3 cp "s3://${S3_BUCKET}/identities/${identity_key}" - \
+      --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+    [ -z "$identity_json" ] && continue
+
+    local agent_name display_name spec label_counts
+    agent_name=$(echo "$identity_json" | jq -r '.agentName // ""' 2>/dev/null || echo "")
+    display_name=$(echo "$identity_json" | jq -r '.displayName // .agentName // ""' 2>/dev/null || echo "")
+    spec=$(echo "$identity_json" | jq -r '.specialization // ""' 2>/dev/null || echo "")
+    label_counts=$(echo "$identity_json" | jq -r '.specializationLabelCounts // {}' 2>/dev/null || echo "{}")
+
+    [ -z "$agent_name" ] && continue
+
+    local score=0
+    # Exact specialization match (highest priority)
+    if [ -n "$spec" ] && echo "$issue_labels" | grep -qi "$spec"; then
+      score=10
+    fi
+
+    # Label count match: sum counts for labels that appear in issue_labels
+    if [ "$score" -eq 0 ] && [ "$label_counts" != "{}" ]; then
+      local label_score
+      label_score=$(echo "$label_counts" | jq -r \
+        --arg issue_labels "$issue_labels" \
+        '[to_entries[] | . as $e | select(($issue_labels | split(",") | map(ascii_downcase)) | contains([$e.key | ascii_downcase])) | .value] | add // 0' \
+        2>/dev/null || echo "0")
+      # Truncate to integer (jq may output floats)
+      score=$(echo "${label_score:-0}" | cut -d. -f1)
+      score="${score:-0}"
+    fi
+
+    if [ "$score" -gt "$best_score" ]; then
+      best_score="$score"
+      best_agent="$agent_name"
+      best_display="$display_name"
+      best_spec="${spec:-$issue_labels}"
+    fi
+  done <<< "$identity_keys"
+
+  if [ -z "$best_agent" ] || [ "$best_score" -eq 0 ]; then
+    log "Mentorship: no matching specialist found for issue #$issue_num labels ($issue_labels)"
+    return 0
+  fi
+
+  log "Mentorship: found mentor $best_display ($best_agent) with score=$best_score spec=$best_spec"
+
+  # Step 4: Find their most recent insight Thought CR
+  local mentor_thought
+  mentor_thought=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+    -l agentex/thought -o json 2>/dev/null | \
+    jq -r --arg agent "$best_agent" \
+    '.items | sort_by(.metadata.creationTimestamp) | reverse |
+     map(select(.data.agentRef == $agent and (.data.thoughtType == "insight" or .data.thoughtType == "decision"))) |
+     first | .data.content // ""' 2>/dev/null | head -c 500 || echo "")
+
+  if [ -z "$mentor_thought" ]; then
+    log "Mentorship: mentor $best_agent found but no insight thoughts in cluster"
+    # Still export the mentor identity so the agent knows who the specialist is
+  fi
+
+  MENTOR_DISPLAY_NAME="$best_display"
+  MENTOR_AGENT_NAME="$best_agent"
+  MENTOR_INSIGHT="$mentor_thought"
+  MENTOR_SPECIALIZATION="$best_spec"
+  log "Mentorship: predecessor mentor identified: $MENTOR_DISPLAY_NAME ($MENTOR_AGENT_NAME)"
+  return 0
+}
+
 patch_task_status() {
   local phase="$1" outcome="${2:-}"
   local completed_at=""
@@ -2607,6 +2728,11 @@ if [ "$AGENT_ROLE" = "planner" ] || [ "$AGENT_ROLE" = "worker" ]; then
       COORDINATOR_CONTEXT="The coordinator has assigned you issue #${COORDINATOR_ISSUE} to work on. Implement it and open a PR. When done, call release_coordinator_task ${COORDINATOR_ISSUE}."
     fi
     push_metric "CoordinatorAssignment" 1
+    # Issue #1228: Predecessor mentorship — look up a specialist mentor for this issue.
+    # Only for workers (not planners) and only when coordinator assigned a specific issue.
+    if [ "$AGENT_ROLE" = "worker" ]; then
+      get_mentor_insight "$COORDINATOR_ISSUE"
+    fi
   else
     log "Coordinator queue empty or unavailable — ${AGENT_ROLE} will self-select from GitHub"
     COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue.
@@ -2916,6 +3042,43 @@ Your predecessor (previous $AGENT_ROLE) planned for YOU (N+2) to:
 This is multi-generation coordination. Your predecessor reasoned 3 steps ahead
 and identified work for you to prioritize. Consider this when choosing tasks.
 ═══════════════════════════════════════════════════════"
+fi
+
+# Issue #1228: Predecessor Mentorship Block — specialist context for assigned issues
+# When get_mentor_insight() found a mentor (called in step 3.8 above), inject their
+# identity and last insight so this agent can learn from prior specialists.
+MENTORSHIP_BLOCK=""
+if [ -n "${MENTOR_AGENT_NAME:-}" ]; then
+  if [ -n "${MENTOR_INSIGHT:-}" ]; then
+    MENTORSHIP_BLOCK="
+═══════════════════════════════════════════════════════
+PREDECESSOR MENTORSHIP (issue #1228 — generational knowledge transfer)
+═══════════════════════════════════════════════════════
+A specialist predecessor worked on issues of this type before you.
+
+  Mentor: ${MENTOR_DISPLAY_NAME} (${MENTOR_AGENT_NAME})
+  Specialization: ${MENTOR_SPECIALIZATION}
+
+  Their last insight:
+  ${MENTOR_INSIGHT}
+
+Apply their experience to your implementation. If their approach was wrong,
+note it in your own insight thought so future agents can learn.
+═══════════════════════════════════════════════════════"
+  else
+    MENTORSHIP_BLOCK="
+═══════════════════════════════════════════════════════
+PREDECESSOR MENTORSHIP (issue #1228 — generational knowledge transfer)
+═══════════════════════════════════════════════════════
+A specialist predecessor worked on issues of this type:
+
+  Mentor: ${MENTOR_DISPLAY_NAME} (${MENTOR_AGENT_NAME})
+  Specialization: ${MENTOR_SPECIALIZATION}
+
+  No recent insight thoughts found for this mentor in the cluster.
+  Check their identity in S3: s3://${S3_BUCKET}/identities/${MENTOR_AGENT_NAME}.json
+═══════════════════════════════════════════════════════"
+  fi
 fi
 
 # Role-specialized context block (issue #881)
@@ -3422,6 +3585,8 @@ ${INBOX_MESSAGES}
 ${PEER_BLOCK}
 
 ${PREDECESSOR_BLOCK}
+
+${MENTORSHIP_BLOCK}
 
 ${ROLE_CONTEXT}
 


### PR DESCRIPTION
## Summary

Implements predecessor mentorship for workers by enriching the OpenCode prompt at coordinator task claim time (rebased on latest main, resolves conflicts in PRs #1266 and #1294).

Closes #1228

## Approach

This implementation adds mentorship context **at agent startup** (when the coordinator assigns an issue), rather than in `spawn_task_and_agent()` (PR #1266) or coordinator routing (PR #1294).

**Why this approach:**
- Runs in the worker's context, where S3 and GitHub credentials are available
- Does not slow down `spawn_task_and_agent()` (which is called by planners too)
- MENTOR vars are directly usable in the OpenCode prompt template
- Graceful degradation: no blocking, no retries, silently skips if S3/GitHub unavailable

## Changes

- **`images/runner/entrypoint.sh`**: Added `get_mentor_insight()` function + called it after coordinator issue assignment for workers + built `MENTORSHIP_BLOCK` variable + injected into OpenCode prompt
- **`AGENTS.md`**: Documented the mentorship feature including example block

## Algorithm

1. Get issue's GitHub labels
2. Scan newest 30 S3 identity files for label count matches (timeout=10s to stay fast)
3. Score each agent: exact `specialization` match = 10, `specializationLabelCounts` label sum otherwise
4. Find highest-scoring agent's most recent insight Thought CR
5. Build `MENTORSHIP_BLOCK` and inject after `PREDECESSOR_BLOCK` in prompt

## Note on existing PRs

PRs #1266 and #1294 both implement aspects of this feature but have conflicts with main. This PR provides a clean, rebased implementation that can be merged directly. If gods prefer the coordinator-side approach (PR #1294), that can be implemented as a follow-up.