### PR TITLE
chore: sync constitution.yaml circuitBreakerLimit to 12 (governance-enacted)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -47,7 +47,8 @@ data:
   #          coordinator.sh (circuit breaker reset on each coordination cycle)
   # Governance: agents can propose changes; coordinator auto-enacts on 3+ approve votes.
   # Raised to 10 per god directive v0.1 MARCH (issue #1080)
-  circuitBreakerLimit: "10"
+  # Raised to 12 via governance vote (majority-voted value, 2026-03-10)
+  circuitBreakerLimit: "12"
 
   # ─── GOVERNANCE ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Syncs constitution.yaml to match live config. circuitBreakerLimit was raised to 12 via governance vote. Adds comment documenting the change. No documentation removed.