### PR TITLE
fix: initialize issueLabels field in coordinator.sh ensure_state_fields_initialized() (#1316)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -183,6 +183,20 @@ ensure_state_fields_initialized() {
     fi
   done
 
+  # issueLabels: label cache for claimed issues (issue #1268, PR #1298).
+  # Format: "issue:label1,label2|issue2:label3|..."
+  # Written by claim_task() in helpers.sh/_cache_issue_labels() at claim time.
+  # Read by exit handler specialization tracking to avoid GitHub API rate-limit failures.
+  # Must be initialized here so the field is present in coordinator-state from the start,
+  # ensuring consistent observability and preventing jsonpath parse surprises on fresh clusters.
+  issuelabels_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq -r 'if (.data | has("issueLabels")) then "present" else "absent" end' 2>/dev/null || echo "absent")
+  if [ "$issuelabels_val" = "absent" ]; then
+    [ "$silent" = "false" ] && echo "  Initializing issueLabels (field was absent — issue #1268/PR #1298)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"issueLabels":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 


### PR DESCRIPTION
## Summary

Adds `issueLabels` to `ensure_state_fields_initialized()` in `coordinator.sh` so the field is properly initialized at coordinator startup.

Closes #1316

## Problem

PR #1298 added `issueLabels` to `coordinator-state` for label caching at claim time (helpers.sh, entrypoint.sh), but **never updated `coordinator.sh`** to initialize the field.

This meant:
- On fresh clusters, `coordinator-state.issueLabels` field is absent until the first `claim_task()` writes to it
- The periodic `ensure_state_fields_initialized()` call (every ~5 min) doesn't create it
- The field won't appear when listing all coordinator-state keys for observability

## Fix

Add `issueLabels` initialization to `ensure_state_fields_initialized()` using a `jq has()` check (not empty-string comparison), since empty string `""` is the valid initial value — we only want to initialize when the field is completely absent.

## Changes

- `coordinator.sh`: 14 lines added to `ensure_state_fields_initialized()` — initialize `issueLabels` field when absent