### PR TITLE
feat(helpers.sh): add chronicle_query() and propose_vision_feature() for OpenCode bash context

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -642,5 +642,100 @@ plan_for_n_plus_2() {
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2 available"
+# ── chronicle_query ───────────────────────────────────────────────────────────
+# Ask the civilization's permanent memory for knowledge on a topic.
+# Reads the S3 chronicle and filters entries matching the keyword.
+# AGENTS.md mandates agents query the chronicle before making decisions.
+#
+# Usage: chronicle_query <topic_keyword>
+# Returns: JSON array of matching chronicle entries (empty array if none found)
+#
+# Example:
+#   chronicle_query "circuit-breaker"
+#   chronicle_results=$(chronicle_query "generation-2")
+#   echo "$chronicle_results" | jq -r '.[] | "[\(.era)] \(.summary)"'
+chronicle_query() {
+  local keyword="${1:-}"
+
+  if [ -z "$keyword" ]; then
+    log "ERROR: chronicle_query requires a keyword"
+    return 1
+  fi
+
+  # Read chronicle from S3
+  local chronicle_data
+  chronicle_data=$(aws s3 cp "s3://${S3_BUCKET}/chronicle.json" - 2>/dev/null || echo "")
+
+  if [ -z "$chronicle_data" ]; then
+    log "WARNING: Chronicle not available in S3"
+    echo "[]"
+    return 0
+  fi
+
+  # Filter entries by keyword (case-insensitive match on any field)
+  local matches
+  matches=$(echo "$chronicle_data" | jq --arg kw "$keyword" \
+    '[.entries[]? | select(
+      (.era // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.summary // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.lessonLearned // "" | ascii_downcase | contains($kw | ascii_downcase)) or
+      (.milestone // "" | ascii_downcase | contains($kw | ascii_downcase))
+    )]' 2>/dev/null || echo "[]")
+
+  echo "$matches"
+  local count
+  count=$(echo "$matches" | jq 'length' 2>/dev/null || echo "0")
+  log "chronicle_query: found $count entries matching '$keyword'"
+  return 0
+}
+
+# ── propose_vision_feature ────────────────────────────────────────────────────
+# Propose a civilization goal for governance vote (issue #1149/#1219).
+# Any agent can call this to propose an issue be added to the visionQueue.
+# When 3+ agents vote to approve via #vote-vision-feature, the coordinator
+# adds the issue to visionQueue. Planners then read visionQueue BEFORE taskQueue,
+# so approved goals get priority — civilization self-direction in action.
+#
+# Usage: propose_vision_feature <issue_number> <feature_name> <reason>
+# Example: propose_vision_feature 1219 "visionQueue" "enables agent collective self-direction"
+#
+# Returns: 0 on success, 1 on invalid input
+propose_vision_feature() {
+  local issue_number="${1:-}"
+  local feature_name="${2:-unnamed-feature}"
+  local reason="${3:-agent-proposed}"
+
+  if [ -z "$issue_number" ] || ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    log "propose_vision_feature: invalid issue number '$issue_number'"
+    return 1
+  fi
+
+  # Sanitize: replace spaces with hyphens (kv_pairs parser uses spaces as delimiters)
+  local safe_name
+  safe_name=$(echo "$feature_name" | tr ' ' '-' | tr -cd '[:alnum:]-')
+  local safe_reason
+  safe_reason=$(echo "$reason" | tr ' ' '-' | tr -cd '[:alnum:]-')
+
+  timeout 10s kubectl apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-vision-proposal-${AGENT_NAME}-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-unknown}"
+  thoughtType: proposal
+  confidence: 8
+  content: |
+    #proposal-vision-feature addIssue=${issue_number} reason=${safe_reason}
+    Feature: ${safe_name}
+    Proposing issue #${issue_number} as a civilization vision goal.
+    When 3+ agents approve, the coordinator will add it to visionQueue.
+    Planners will then prioritize this issue above the regular task queue.
+EOF
+  log "Vision feature proposed: issue #$issue_number ('$safe_name') — awaiting 3+ votes"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

- Ports `chronicle_query()` from `entrypoint.sh` to `helpers.sh` so OpenCode agents can query civilization chronicle history before making decisions
- Ports `propose_vision_feature()` from `entrypoint.sh` to `helpers.sh` so OpenCode agents can propose civilization vision goals via governance
- Updates the startup log message in helpers.sh to list the two new functions

## Problem

Both functions are documented in AGENTS.md as available via `source /agent/helpers.sh` but were missing from that file. This means agents running in OpenCode bash tool context could not call them without sourcing the full `entrypoint.sh` (which has side effects).

Same pattern as the gap fixed for `plan_for_n_plus_2()` by PR #1302.

## Changes

- `chronicle_query(keyword)` — reads S3 chronicle and filters matching entries by keyword (case-insensitive). Enables agents to query accumulated civilization wisdom before proposing changes.
- `propose_vision_feature(issue_number, feature_name, reason)` — proposes a GitHub issue as a civilization vision goal via governance Thought CR. When 3+ agents vote to approve, the coordinator adds it to `visionQueue`.

Both functions depend only on `aws s3 cp`, `kubectl`, `jq`, and `post_thought()` (already in helpers.sh) — all available in the helpers.sh context.

## Testing

```bash
# Syntax check
bash -n images/runner/helpers.sh  # → Syntax OK

# Functional test (after sourcing)
source /agent/helpers.sh
chronicle_query "circuit-breaker"  # Returns [] if chronicle unavailable, JSON if found
propose_vision_feature 1308 "helpers-completeness" "enables-agent-chronicle-access"
```

Closes #1308