### PR TITLE
fix: add issueLabels field initialization to coordinator.sh (issue #1316)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -152,6 +152,15 @@ ensure_state_fields_initialized() {
     fi
   done
 
+  # issueLabels: label cache for claimed issues (issue #1268, PR #1298, issue #1316)
+  # Format: "issue:label1,label2|issue2:label3|..."
+  issuelabels_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.issueLabels}' 2>/dev/null)
+  if [ -z "$issuelabels_val" ] && ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("issueLabels")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing issueLabels (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"issueLabels":""}}' 2>/dev/null || true
+  fi
+
   # unresolvedDebates: comma-separated thread IDs for debates needing synthesis (issue #1111)
   unresolved_debates_val=$(kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null)
   if [ -z "$unresolved_debates_val" ]; then


### PR DESCRIPTION
## Summary

Fixes issue #1316 by adding the `issueLabels` field initialization to the `ensure_state_fields_initialized()` function in `coordinator.sh`.

Closes #1316

## Changes

- Added `issueLabels` field initialization at lines 155-162 of `coordinator.sh`
- Placed alongside other identity-based routing fields (after `specializedAssignments`, `genericAssignments`, etc.)
- Follows the same defensive pattern: check if field is absent using `jq -e '.data | has("issueLabels")'`, then patch if missing
- Initializes to empty string `""` (same as the lazy initialization in `claim_task()`)

## Context

PR #1298 (issue #1268) added the `issueLabels` field for label caching to prevent GitHub API rate-limit failures. The field was added to:
- `helpers.sh` in `_cache_issue_labels()`
- `entrypoint.sh` in `cache_issue_labels_on_claim()` and the exit handler

But it was **NOT** added to `coordinator.sh`'s `ensure_state_fields_initialized()` function, meaning:
1. On a fresh coordinator start, the field is absent from coordinator-state
2. The field only gets created when the first `claim_task()` call writes to it
3. This creates inconsistent bootstrap state

## Impact

- Low immediate impact since the field is created lazily on first claim
- But correct initialization ensures the field appears in coordinator-state for observability from the start
- Prevents edge cases where jsonpath returns different values for absent vs empty fields
- Makes the bootstrap state consistent and complete

## Effort: S (15 min)