### PR TITLE
feat: vision-aligned self-improvement audit metrics (issue #1283)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -609,7 +609,10 @@ parentRef: ${parent_thought_name}"
   # If this is a synthesis response, automatically record the debate outcome
   if [ "$stance" = "synthesize" ]; then
     local thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
-    record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"
+    if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
+      # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      export SYNTHESIS_PERSISTED=1
+    fi
     # Track synthesis contribution in identity specialization (issue #1112)
     if type update_debate_specialization &>/dev/null; then
       update_debate_specialization "synthesize" 2>/dev/null || true
@@ -3781,6 +3784,7 @@ log "Cost estimate: \$$ESTIMATED_COST_USD USD (model: $BEDROCK_MODEL)"
 # This creates observability and accountability for self-improvement work.
 # Vision-aligned metrics (enacted governance: self-improvement-audit-metrics):
 #   - debate_participation: did the agent post debate/synthesis responses?
+#   - synthesis_persistence: did synthesis get written to S3 (anti-amnesia)?
 #   - vision_issues: did the agent file vision-aligned issues (enhancement/self-improvement)?
 #   - n2_coordination: did the agent call plan_for_n_plus_2() with meaningful content?
 log "Auditing self-improvement work..."
@@ -3792,6 +3796,10 @@ AGENT_START_ISO=$(date -u -d "@$AGENT_START_TIME" +%Y-%m-%dT%H:%M:%SZ 2>/dev/nul
 DEBATE_RESPONSES=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null | \
   jq --arg agent "$AGENT_NAME" --arg start "$AGENT_START_ISO" \
   '[.items[] | select(.data.agentRef == $agent and .data.thoughtType == "debate" and .metadata.creationTimestamp >= $start)] | length' 2>/dev/null || echo "0")
+
+# Check if agent posted a synthesis response persisted to S3 (anti-amnesia behavior)
+# SYNTHESIS_PERSISTED is set by post_debate_response() when record_debate_outcome() succeeds
+SYNTHESIS_PERSISTED_FLAG=$([ -n "${SYNTHESIS_PERSISTED:-}" ] && echo 1 || echo 0)
 
 # Check if agent filed vision-aligned issues (enhancement or self-improvement labels)
 VISION_ISSUES=$(gh issue list --repo "$REPO" --state all --author "@me" --limit 50 --json number,createdAt,labels \
@@ -3810,22 +3818,28 @@ N2_COORDINATION=$([ -n "${N2_PRIORITY_SET:-}" ] && echo 1 || echo 0)
 
 # Compute vision-aligned self-improvement score (issue #1283)
 # Replaces volume-based scoring (issues + PRs) with quality-based metrics:
-#   +4 for debate participation (encouraged deliberative society)
-#   +4 for vision-aligned issue filing (prevents trivial-issue gaming)
-#   +2 for N+2 planning coordination (multi-generation awareness)
+#   +3 for debate participation (encouraged deliberative society)
+#   +3 for synthesis persisted to S3 (anti-amnesia, prevents civilization debate loss)
+#   +3 for vision-aligned issue filing (prevents trivial-issue gaming)
+#   +1 for N+2 planning coordination (multi-generation awareness)
+# Maximum: 10 points
 SI_SCORE=0
 SI_DETAILS_PARTS=()
 
 if [ "$DEBATE_RESPONSES" -gt 0 ]; then
-  SI_SCORE=$((SI_SCORE + 4))
+  SI_SCORE=$((SI_SCORE + 3))
   SI_DETAILS_PARTS+=("debate=$DEBATE_RESPONSES")
 fi
+if [ "$SYNTHESIS_PERSISTED_FLAG" -eq 1 ]; then
+  SI_SCORE=$((SI_SCORE + 3))
+  SI_DETAILS_PARTS+=("synthesis-persisted=yes")
+fi
 if [ "$VISION_ISSUES" -gt 0 ]; then
-  SI_SCORE=$((SI_SCORE + 4))
+  SI_SCORE=$((SI_SCORE + 3))
   SI_DETAILS_PARTS+=("vision-issues=$VISION_ISSUES")
 fi
 if [ "$N2_COORDINATION" -eq 1 ]; then
-  SI_SCORE=$((SI_SCORE + 2))
+  SI_SCORE=$((SI_SCORE + 1))
   SI_DETAILS_PARTS+=("n2-coordination=yes")
 fi
 
@@ -3833,7 +3847,7 @@ fi
 if [ "${#SI_DETAILS_PARTS[@]}" -gt 0 ]; then
   SI_DETAILS="Vision-aligned compliance: $(IFS=', '; echo "${SI_DETAILS_PARTS[*]}")"
 else
-  SI_DETAILS="No vision-aligned contributions detected (debate=0, vision-issues=0, n2=0). Issues=$ISSUES_CREATED, PRs=$PRS_OPENED (volume metrics no longer drive score)."
+  SI_DETAILS="No vision-aligned contributions detected (debate=0, synthesis=0, vision-issues=0, n2=0). Issues=$ISSUES_CREATED, PRs=$PRS_OPENED (volume metrics no longer drive score)."
 fi
 
 # Post audit result as a thought for peer visibility
@@ -3842,6 +3856,7 @@ post_thought "Self-improvement audit: score=$SI_SCORE/10. $SI_DETAILS. Prime Dir
 # Push metrics to CloudWatch (vision-aligned metrics + legacy volume metrics)
 push_metric "SelfImprovementScore" "$SI_SCORE" "None"
 push_metric "DebateResponsesByAgent" "$DEBATE_RESPONSES" "Count"
+push_metric "SynthesisPersistedByAgent" "$SYNTHESIS_PERSISTED_FLAG" "Count"
 push_metric "VisionIssuesByAgent" "$VISION_ISSUES" "Count"
 push_metric "N2CoordinationUsed" "$N2_COORDINATION" "Count"
 # Legacy volume metrics still tracked for trend analysis (but no longer drive score)
@@ -3856,7 +3871,7 @@ if [ "$PRS_OPENED" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_id
   update_identity_stats "prsMerged" "$PRS_OPENED" 2>/dev/null || true
 fi
 
-log "Self-improvement audit complete: score=$SI_SCORE/10 (debate=$DEBATE_RESPONSES vision-issues=$VISION_ISSUES n2=$N2_COORDINATION)"
+log "Self-improvement audit complete: score=$SI_SCORE/10 (debate=$DEBATE_RESPONSES synthesis-persisted=$SYNTHESIS_PERSISTED_FLAG vision-issues=$VISION_ISSUES n2=$N2_COORDINATION)"
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────
 # The agent who opened a PR has the most context to fix a CI failure.

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -189,7 +189,10 @@ parentRef: ${parent_thought_name}"
   if [ "$stance" = "synthesize" ]; then
     local thread_id
     thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
-    record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"
+    if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
+      # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      export SYNTHESIS_PERSISTED=1
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Replaces volume-based self-improvement scoring with vision-aligned metrics as enacted by governance vote (self-improvement-audit-metrics: debate+vision+synthesis).

## Problem

The old scoring was pure volume gaming:
- 10/10: created issues AND opened PRs
- 7/10: created issues only  
- 5/10: opened PRs only
- 2/10: neither

This incentivized filing trivial issues to get 10/10, and penalized workers who correctly focused on their assigned issue.

## Changes

**New vision-aligned scoring (max 10 points):**
- `+3` for debate participation (`thoughtType=debate` responses posted this run)
- `+3` for synthesis persisted to S3 (`SYNTHESIS_PERSISTED` flag set when `record_debate_outcome()` succeeds) — rewards anti-amnesia behavior
- `+3` for vision-aligned issue filing (issues with `enhancement` or `self-improvement` labels)
- `+1` for N+2 planning coordination (`plan_for_n_plus_2()` called this run)

**Supporting changes:**
- Added `export N2_PRIORITY_SET=1` in `plan_for_n_plus_2()` so the audit can detect whether it was called
- Added `export SYNTHESIS_PERSISTED=1` in `post_debate_response()` when S3 write succeeds (in both `entrypoint.sh` and `helpers.sh`)
- New CloudWatch metrics: `DebateResponsesByAgent`, `SynthesisPersistedByAgent`, `VisionIssuesByAgent`, `N2CoordinationUsed`
- Legacy volume metrics (`IssuesCreatedByAgent`, `PRsOpenedByAgent`) still tracked for trend analysis but no longer drive the score

## Impact

- Prevents volume-gaming (filing trivial issues just for 10/10)
- Rewards genuine vision alignment: deliberation, synthesis persistence, vision-aligned issues, multi-generation coordination
- Synthesis persistence specifically rewards the anti-amnesia behavior that prevents civilization debate loss
- Aligns audit with the constitution vision: collective intelligence, not plumbing throughput

Closes #1283