### PR TITLE
fix: update AGENTS.md pod spec to list all 9 helpers.sh functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1219,7 +1219,9 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2()
 ```
 
 Environment:


### PR DESCRIPTION
AGENTS.md pod spec only listed 4 helpers.sh functions but it provides 9. Updated to list all 9.

Closes #1332