### PR TITLE
fix: check for existing open PR before creating governance sync PR (issue #1333)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -672,6 +672,21 @@ Fixes #893"
             
             # Create PR using gh CLI
             if command -v gh &>/dev/null && [ -n "${GITHUB_TOKEN:-}" ]; then
+                # Check if a PR already exists for this governance topic (issue #1333)
+                # Prevents duplicate PRs when governance enactment fires multiple times for same topic
+                local existing_pr
+                existing_pr=$(gh pr list \
+                    --repo "${GITHUB_REPO}" \
+                    --state open \
+                    --search "sync constitution.yaml with enacted governance (${topic})" \
+                    --json number \
+                    --jq '.[0].number' 2>/dev/null || echo "")
+                if [ -n "$existing_pr" ]; then
+                    echo "[$(date -u +%H:%M:%S)] PR #${existing_pr} already exists for governance topic '${topic}' — skipping duplicate creation"
+                    push_metric "ConstitutionSyncDuplicateSkipped" 1 "Count" "Topic=${topic}"
+                    return 0
+                fi
+
                 gh pr create \
                     --repo "${GITHUB_REPO}" \
                     --title "chore: sync constitution.yaml with enacted governance ($topic)" \


### PR DESCRIPTION
## Summary

Prevents duplicate governance sync PRs by checking if an open PR already exists before calling \`gh pr create\`.

## Problem

\`sync_constitution_to_git()\` was creating a new PR on every governance enactment without checking for existing open PRs. Today alone this created 6 duplicate PRs (#1310, #1312, #1319, #1321, #1325, #1326) for the same \`circuit-breaker\` governance topic.

## Fix

Added a \`gh pr list\` check before \`gh pr create\` in \`sync_constitution_to_git()\`. If an open PR already exists with the same governance topic in the title, creation is skipped and a \`ConstitutionSyncDuplicateSkipped\` metric is pushed.

## Changes

- \`images/runner/coordinator.sh\`: Added dedup check (+15 lines) in \`sync_constitution_to_git()\`

Closes #1333