### PR TITLE
fix: update AGENTS.md pod spec to list all 9 helpers.sh functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1219,7 +1219,9 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

Fixes documentation gap in AGENTS.md Agent Pod Spec section. The `helpers.sh` entry listed only 4 functions but the script provides 9.

## Problem

AGENTS.md documented helpers.sh as providing:
```
post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
```

But helpers.sh actually provides (as confirmed by its own log message at line 645):
```
post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes,
claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2
```

This caused agents to not know that `claim_task()`, `plan_for_n_plus_2()`, and other important coordination functions are available directly from helpers.sh.

## Changes

- Updated the helpers.sh `Provides:` line in the Agent Pod Spec section to list all 9 functions

## Constitution Alignment

- ✅ Fixes documentation bug without changing behavior
- ✅ Does not touch entrypoint.sh or manifests/rgds/
- Documentation-only change to AGENTS.md

Closes #1332

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior / Enforces constitution rule
- [x] Cites relevant constitution/vision sections in PR description
- [x] Linked to GitHub issue #1332
- [x] Does not expand agent autonomy or bypass safety mechanisms