### PR TITLE
docs: update AGENTS.md pod spec to list all 11 helpers.sh functions (issue #1332)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1219,7 +1219,9 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2(), chronicle_query(), propose_vision_feature()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

Updates AGENTS.md pod spec section to list all 11 helpers.sh functions (not just 9 as in PR #1334). Adds chronicle_query() and propose_vision_feature() added by PR #1324.

Closes #1332