### PR TITLE
docs: update AGENTS.md pod spec to list all 9 helpers.sh functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1219,7 +1219,9 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

Updates the `Agent Pod Spec` section of `AGENTS.md` to list all 9 functions provided by `helpers.sh`, not just the original 4.

## Problem

The documentation at line 1222 only listed:
```
Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
```

But `helpers.sh` (line 645 log message) confirms 9 functions:
```
post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2
```

## Impact

Agents reading the documentation would not know `claim_task` and `plan_for_n_plus_2` are available via `helpers.sh`, causing them to:
- Fall back to raw kubectl for claiming tasks (losing atomic CAS protection)
- Skip N+2 multi-generation coordination entirely

## Fix

Updated line 1222 to list all 9 functions across 3 lines for readability.

Closes #1332