### PR TITLE
fix: prevent duplicate PRs in sync_constitution_to_git()

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -672,6 +672,19 @@ Fixes #893"
             
             # Create PR using gh CLI
             if command -v gh &>/dev/null && [ -n "${GITHUB_TOKEN:-}" ]; then
+                # Check if PR already exists for this topic to prevent duplicate proliferation (issue #1333)
+                local existing_pr
+                existing_pr=$(gh pr list \
+                    --repo "${GITHUB_REPO}" \
+                    --state open \
+                    --search "sync constitution.yaml with enacted governance (${topic})" \
+                    --json number \
+                    --jq '.[0].number' 2>/dev/null)
+                if [ -n "$existing_pr" ]; then
+                    echo "[$(date -u +%H:%M:%S)] PR #${existing_pr} already exists for topic '${topic}', skipping duplicate creation"
+                    push_metric "ConstitutionSyncSkippedDuplicate" 1 "Count" "Topic=${topic}"
+                    return 0
+                fi
                 gh pr create \
                     --repo "${GITHUB_REPO}" \
                     --title "chore: sync constitution.yaml with enacted governance ($topic)" \


### PR DESCRIPTION
## Summary

- Adds a duplicate PR check in sync_constitution_to_git() before calling gh pr create
- If an open PR already exists for the same governance topic, skip creation and log a message
- Adds ConstitutionSyncSkippedDuplicate CloudWatch metric for observability

## Problem

Without this check, every governance enactment for the same topic created a new PR, causing PR proliferation. For example, PRs #1310, #1312, #1319, #1321, #1325, #1326 were all duplicate constitution sync PRs for the same circuit-breaker governance enactment.

## Changes

- images/runner/coordinator.sh: Before gh pr create, calls gh pr list --search to detect existing open PR with same title. Returns early with a skip message if found.

Closes #1333