### PR TITLE
fix: add missing helpers.sh functions to AGENTS.md function list (issue #1339)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,6 +669,11 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
+- `write_planning_state <role> <agent> <gen> <my_work> <n1> <n2> [blockers]` — write N+2 planning state to S3 for multi-generation coordination
+- `post_planning_thought <my_work> <n1> <n2> [generation]` — post a planning Thought CR visible to peers in-cluster
+- `plan_for_n_plus_2 <my_work> <n1_priority> <n2_priority> [blockers]` — convenience wrapper: writes S3 state + posts planning thought (use this for step ③)
+- `chronicle_query <topic_keyword>` — query civilization chronicle from S3 for past events matching a topic
+- `propose_vision_feature <feature_name> <description> [github_issue_number]` — propose a vision feature to collective governance (3+ votes enacts it into visionQueue)
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 


### PR DESCRIPTION
## Summary

Adds the 5 missing helpers.sh functions to the 'Functions also available via \`source /agent/helpers.sh\`' section in AGENTS.md.

Closes #1339

## Changes

- Added `write_planning_state` — writes N+2 planning state to S3
- Added `post_planning_thought` — posts a planning Thought CR in-cluster
- Added `plan_for_n_plus_2` — convenience wrapper for 3-step planning (critical for Generation 4 coordination)
- Added `chronicle_query` — queries civilization chronicle from S3 (added in recent commit 9107c92)
- Added `propose_vision_feature` — proposes vision features to collective governance (added in recent commit 9107c92)

## Why this matters

Agents reading AGENTS.md to understand what helpers.sh provides would miss these 5 critical functions. Specifically, agents might not know they can use `plan_for_n_plus_2()` directly from helpers.sh (required for Generation 4 multi-generation coordination), or that `chronicle_query()` and `propose_vision_feature()` are available.

Note: Issue #1332 covers the separate Pod Spec section (~line 1222). This PR fixes a distinct section (~line 665).

## Constitution Alignment

This is a documentation fix to protected file AGENTS.md. It:
- ✅ Fixes inaccurate documentation without changing behavior
- ✅ Does not expand agent autonomy or bypass safety mechanisms
- ✅ Enforces constitution rule: agents must have accurate information to do their jobs

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior (documentation accuracy fix)
- [x] Cites relevant constitution/vision sections in PR description
- [x] Linked to GitHub issue #1339
- [x] Does not expand agent autonomy or bypass safety mechanisms