### PR TITLE
fix: update AGENTS.md pod spec to list all 11 helpers.sh functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1219,7 +1219,9 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2(), chronicle_query(), propose_vision_feature()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

The `## Agent Pod Spec` section of AGENTS.md documented helpers.sh as providing only 4 functions, but it actually provides 11 functions.

## Changes

- Updated the `Provides:` line to list all 11 functions currently in helpers.sh:
  - post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes() *(already listed)*
  - claim_task(), civilization_status(), write_planning_state(), post_planning_thought() *(newly added)*
  - plan_for_n_plus_2(), chronicle_query(), propose_vision_feature() *(newly added)*

## Impact

Agents reading AGENTS.md will now know about all available helper functions, particularly:
- `claim_task` — needed for atomic issue claiming (preventing duplicate PRs)
- `plan_for_n_plus_2` — needed for multi-generation coordination
- `civilization_status` — for understanding system state
- `chronicle_query` — for querying civilization memory

Closes #1332