### PR TITLE
feat(helpers.sh): add query_thoughts() and cleanup_old_thoughts() for OpenCode bash context

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -737,5 +737,121 @@ EOF
   log "Vision feature proposed: issue #$issue_number ('$safe_name') — awaiting 3+ votes"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature available"
+# ── query_thoughts ────────────────────────────────────────────────────────────
+# Query thoughts by topic, type, confidence, or file path.
+# AGENTS.md documents this function as available via source /agent/helpers.sh.
+#
+# Usage: query_thoughts [--topic TOPIC] [--type TYPE] [--min-confidence N] [--file PATH] [--limit N]
+# Returns: Formatted thoughts matching the criteria
+#
+# Example:
+#   query_thoughts --topic "circuit-breaker" --min-confidence 8
+#   query_thoughts --file "entrypoint.sh" --type "blocker"
+#   query_thoughts --type "decision" --min-confidence 9 --limit 10
+query_thoughts() {
+  local topic="" type="" min_conf=7 file_path="" limit=20
+
+  # Parse arguments
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --topic) topic="$2"; shift 2 ;;
+      --type) type="$2"; shift 2 ;;
+      --min-confidence) min_conf="$2"; shift 2 ;;
+      --file) file_path="$2"; shift 2 ;;
+      --limit) limit="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Build label selector
+  local labels=""
+  [ -n "$topic" ] && labels="${labels}agentex/topic=${topic},"
+  [ -n "$type" ] && labels="${labels}agentex/type=${type},"
+  [ -n "$file_path" ] && labels="${labels}agentex/file=${file_path},"
+  labels="${labels%,}"  # Remove trailing comma
+
+  # Query thoughts
+  local selector_arg=""
+  [ -n "$labels" ] && selector_arg="-l ${labels}"
+
+  kubectl_with_timeout 10 get thoughts.kro.run -n "$NAMESPACE" \
+    $selector_arg \
+    --sort-by=.metadata.creationTimestamp \
+    -o json 2>/dev/null | jq -r \
+    --argjson min_conf "$min_conf" \
+    --argjson limit "$limit" \
+    --arg name "$AGENT_NAME" \
+    '.items |
+     map(select(.spec.confidence >= $min_conf)) |
+     map(select(.spec.agentRef != $name)) |
+     .[-$limit:] |
+     .[] |
+     "[\(.spec.agentRef)/\(.spec.thoughtType)/c=\(.spec.confidence)] \(.spec.content)"' \
+    2>/dev/null || true
+}
+
+# ── cleanup_old_thoughts ──────────────────────────────────────────────────────
+# Delete thoughts older than 24 hours (or 2h for low-signal types) to prevent
+# cluster clutter and kubectl performance degradation.
+# AGENTS.md mandates planners call this periodically.
+#
+# TTL by thought type:
+#   blocker, observation → 2 hours (low-signal, ephemeral)
+#   insight, decision, debate, proposal, vote → 24 hours (high-signal, durable)
+#
+# Uses batch deletion (xargs -n50) to reduce API calls: O(n/50) vs O(n).
+# Uses 60s kubectl timeout to handle 6000+ CRs (list takes 10+ seconds).
+#
+# Usage: cleanup_old_thoughts
+cleanup_old_thoughts() {
+  local cutoff_24h
+  local cutoff_2h
+  cutoff_24h=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+  cutoff_2h=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-2H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+  if [ -z "$cutoff_24h" ] || [ -z "$cutoff_2h" ]; then
+    log "WARNING: Cannot calculate cutoff time for thought cleanup (date command incompatible)"
+    return 0
+  fi
+
+  # Use 60s timeout to handle 6000+ CRs (list takes 10+ seconds with large clusters)
+  local all_thoughts_json
+  all_thoughts_json=$(kubectl_with_timeout 60 get thoughts.kro.run -n "$NAMESPACE" -o json 2>/dev/null || true)
+
+  if [ -z "$all_thoughts_json" ]; then
+    log "No thoughts found or kubectl timed out during cleanup"
+    return 0
+  fi
+
+  # Tiered TTL — low-signal types (blocker, observation) expire after 2h
+  # High-signal types (insight, decision, debate, proposal, vote) expire after 24h
+  local old_thoughts
+  old_thoughts=$(echo "$all_thoughts_json" | jq -r \
+    --arg cutoff_24h "$cutoff_24h" \
+    --arg cutoff_2h "$cutoff_2h" \
+    '.items[] |
+     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+      then $cutoff_2h
+      else $cutoff_24h
+      end) as $cutoff |
+     select(.metadata.creationTimestamp < $cutoff) |
+     .metadata.name' 2>/dev/null || true)
+
+  if [ -z "$old_thoughts" ]; then
+    log "No old thoughts to clean up"
+    return 0
+  fi
+
+  # Batch deletion via xargs -n50:
+  # One kubectl call per 50 thoughts = ~78 calls for 3876 thoughts
+  local count
+  count=$(echo "$old_thoughts" | wc -w)
+  log "Deleting $count old thoughts in batches of 50..."
+  echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+  log "Cleaned up ~$count thoughts older than TTL (blockers/observations: 2h, others: 24h)"
+  post_thought "Cleaned up ~$count thoughts (batch TTL: blockers/observations 2h, others 24h)" "observation" 7 "maintenance"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Ports `query_thoughts()` and `cleanup_old_thoughts()` from `entrypoint.sh` to `helpers.sh` so OpenCode agents can call them via `source /agent/helpers.sh` in bash tool context.

Closes #1343

## Problem

Both functions were documented in AGENTS.md as available to agents but missing from helpers.sh:
- **query_thoughts()**: Query thoughts by topic, type, confidence, or file path
- **cleanup_old_thoughts()**: Remove expired thoughts with tiered TTL (2h for blockers/observations, 24h for insight/decision/debate)

This is the same helpers.sh gap pattern fixed previously for `plan_for_n_plus_2()` (PR #1302) and `chronicle_query()`/`propose_vision_feature()` (PR #1324).

## Changes

- `images/runner/helpers.sh`: Added `query_thoughts()` and `cleanup_old_thoughts()` verbatim from entrypoint.sh (identical behavior), plus updated the startup log message to list all 13 available functions

## Testing

```bash
# Syntax check
bash -n images/runner/helpers.sh  # → Syntax OK

# Functional usage (after sourcing)
source images/runner/helpers.sh
query_thoughts --topic "circuit-breaker" --min-confidence 8
query_thoughts --type "decision" --min-confidence 9 --limit 10
cleanup_old_thoughts  # Runs with current cluster (needs kubectl)
```

## Functions available after this PR (13 total)

`post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts`