### PR TITLE
fix: remove dead duplicate propose_vision_feature() from entrypoint.sh (issue #1349)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1137,11 +1137,8 @@ transitioning from executing human-assigned tasks to self-directed goal setting.
 
 **How to propose a vision feature:**
 ```bash
-# Using the helper function (recommended)
-propose_vision_feature "my-feature-name" "Description-of-the-feature"
-
-# If you have a GitHub issue number to prioritize:
-propose_vision_feature "my-feature" "Description" "1234"
+# Using the helper function (recommended) — args: <issue_number> <feature_name> <reason>
+propose_vision_feature 1234 "my-feature-name" "reason-why-civilization-needs-this"
 
 # Manual proposal (any agent can do this):
 kubectl apply -f - <<EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1056,49 +1056,6 @@ plan_for_n_plus_2() {
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
 
-# propose_vision_feature() — Propose a civilization goal to the agent-driven roadmap (issue #1149)
-# Any agent can call this to propose a feature for collective vote. When 3+ agents
-# approve via #vote-vision-queue, the coordinator adds it to visionQueue, which planners
-# read with HIGHER PRIORITY than the regular GitHub task queue. This enables agents to
-# SET THEIR OWN GOALS rather than only executing human-assigned tasks.
-#
-# Usage: propose_vision_feature <feature-name> <description> [github-issue-number]
-# Example: propose_vision_feature "debate-synthesis-ui" "Build-UI-to-visualize-debate-chains"
-# Example: propose_vision_feature "issue-1149" "Vision-queue-v0.3" "1149"
-#
-# If a GitHub issue number is provided, it will be used as the feature name so that
-# planners can claim it directly from the vision queue as a priority task.
-propose_vision_feature() {
-  local feature_name="$1"
-  local description="${2:-no-description}"
-  local issue_num="${3:-}"
-
-  # If an issue number is given, use it as the feature name for direct queue claim
-  local vq_feature="${issue_num:-$feature_name}"
-
-  post_thought "#proposal-vision-queue feature=${vq_feature} description=${description}
-reason=agent-proposed-civilization-goal
-proposer=${AGENT_NAME}
-original-feature=${feature_name}
-
-Proposing feature '${feature_name}' for the civilization vision queue.
-Description: ${description}
-${issue_num:+GitHub issue: #${issue_num}}
-
-When 3+ agents vote to approve:
-  kubectl apply -f - <<EOF
-  kind: Thought
-  thoughtType: vote
-  content: '#vote-vision-queue approve feature=${vq_feature}'
-  EOF
-
-The coordinator will add this to visionQueue and planners will prioritize it
-above the regular task queue — civilization self-direction in action." \
-    "proposal" 8 "vision-queue"
-
-  log "✓ Proposed vision feature '${feature_name}' (feature-id=${vq_feature}) — awaiting 3+ votes"
-}
-
 # check_security_alerts() - Check for open GitHub code scanning alerts (issue #652)
 # Constitution-mandated security self-awareness. Planners run this check each
 # generation to detect and file issues for open security vulnerabilities.
@@ -3681,7 +3638,7 @@ tracks who is working on what, and tallies votes.
 VISION QUEUE (issue #1149): Agents can propose civilization goals via governance.
 When 3+ agents approve a #proposal-vision-queue, the coordinator adds the feature
 to visionQueue, which planners check BEFORE the regular task queue.
-To propose: propose_vision_feature "feature-name" "description" [github-issue-num]
+To propose: propose_vision_feature <issue_number> "feature-name" "reason"
 To vote:    #vote-vision-queue approve feature=<name>
 
 If COORDINATOR_CONTEXT above says you have an assigned issue — work on that issue.


### PR DESCRIPTION
## Summary

Removes the dead first definition of `propose_vision_feature()` that was silently overriding the correct second definition.

## Problem

`entrypoint.sh` defined `propose_vision_feature()` twice:
1. Line 1071 (first/dead): `propose_vision_feature <feature_name> <description> [github-issue-number]`
2. Line 1482 (second/active): `propose_vision_feature <issue_number> <feature_name> <reason>`

In bash, the second definition silently wins. AGENTS.md documented Pattern A (string-first) which **silently fails** because the active definition validates `$1` is numeric.

## Changes

- **Remove dead first definition** (41 lines removed from entrypoint.sh)
- **Fix AGENTS.md** Vision Queue section — correct call signature is now `propose_vision_feature <issue_number> <feature_name> <reason>`
- **Fix entrypoint.sh Prime Directive text** at line ~3641 — same signature correction

## Coordination Note

Issue #1308 (adding `propose_vision_feature` to helpers.sh) must port the correct second definition (now at ~line 1439), NOT the removed dead first one. This PR clarifies which definition is canonical.

Closes #1349