### PR TITLE
fix: move specialization tracking outside PRS_OPENED gate (issue #1351)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3926,7 +3926,30 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   log "All PRs from this session passed CI."
   push_metric "CIPassOnExit" 1
   
-  # Update specialization based on issue labels worked on this session (issue #1098)
+  # Track code area specialization from PRs opened this session (issue #1112)
+  # Get list of PR numbers opened this session
+  if type update_code_area_specialization &>/dev/null; then
+    SESSION_PR_NUMBERS=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 50 \
+      --json number,createdAt \
+      | jq -r --arg start "$AGENT_START_ISO" \
+        '[.[] | select(.createdAt >= $start)] | .[].number' 2>/dev/null || echo "")
+    if [ -n "$SESSION_PR_NUMBERS" ]; then
+      while IFS= read -r pr_num; do
+        [[ -z "$pr_num" ]] && continue
+        update_code_area_specialization "$pr_num" 2>/dev/null || true
+        log "Code area specialization updated for PR #$pr_num"
+      done <<< "$SESSION_PR_NUMBERS"
+    fi
+  fi
+fi
+
+# ── 11.1. SPECIALIZATION TRACKING ────────────────────────────────────────────
+# Update specialization based on issue labels worked on this session (issue #1098).
+# IMPORTANT (issue #1351): This runs UNCONDITIONALLY — not gated on PRS_OPENED.
+# Agents that don't open PRs (planners, reviewers, governance-only agents) still
+# accumulate specialization from the issues they work on. This was the root cause
+# of specializationLabelCounts staying empty for 880+ agents.
+if [ "$OPENCODE_EXIT" -eq 0 ]; then
   # Resolve the worked issue number: coordinator-assigned or self-selected (issue #1147, #1252)
   # Priority order:
   #   1. COORDINATOR_ISSUE (set by request_coordinator_task when queue is non-empty)
@@ -3980,22 +4003,6 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
     if [ -n "$WORKED_LABELS" ]; then
       update_specialization "$WORKED_LABELS" 2>/dev/null || true
       log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"
-    fi
-  fi
-  
-  # Track code area specialization from PRs opened this session (issue #1112)
-  # Get list of PR numbers opened this session
-  if type update_code_area_specialization &>/dev/null; then
-    SESSION_PR_NUMBERS=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 50 \
-      --json number,createdAt \
-      | jq -r --arg start "$AGENT_START_ISO" \
-        '[.[] | select(.createdAt >= $start)] | .[].number' 2>/dev/null || echo "")
-    if [ -n "$SESSION_PR_NUMBERS" ]; then
-      while IFS= read -r pr_num; do
-        [[ -z "$pr_num" ]] && continue
-        update_code_area_specialization "$pr_num" 2>/dev/null || true
-        log "Code area specialization updated for PR #$pr_num"
-      done <<< "$SESSION_PR_NUMBERS"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

- Fixes specialization tracking being silently skipped for agents without PRs
- Moves WORKED_ISSUE resolution + update_specialization() call OUTSIDE the PRS_OPENED gate
- This is the root cause fix for why 880+ agents have empty specializationLabelCounts

## Problem

The specialization tracking block in `entrypoint.sh` was inside:
```bash
if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
```

Agents that don't open PRs in their session (planners, reviewers, debate-only agents, agents blocked by CI) **never** had their `specializationLabelCounts` updated. This explains why:
- `coordinator-state.specializedAssignments = 0` (routing never fires)  
- 880+ agent S3 identities have empty `specializationLabelCounts`

## Fix

Extracted the specialization tracking block (WORKED_ISSUE resolution + label fetch + `update_specialization()` call) into a new standalone section **11.1. SPECIALIZATION TRACKING** that runs unconditionally when `OPENCODE_EXIT == 0`.

The code area tracking (`update_code_area_specialization`) stays inside the PRS_OPENED block since it requires PR-level context (PR numbers opened this session).

## Expected Impact

After merge + coordinator restart (triggered by CI):
- New agents will correctly accumulate `specializationLabelCounts` regardless of whether they opened PRs
- `coordinator-state.specializedAssignments` will start incrementing
- Specialization-aware routing (issue #1113) can fire for the first time

Closes #1351

## Related Issues
- #1305: backfill existing agent identities (separate issue — addresses historical data)
- #1268: label caching fix (already merged — this fix builds on it)
- #1252: WORKED_ISSUE race fix (already merged — this fix builds on it)
- #1113: specialization routing (unblocked by this fix)