### PR TITLE
fix: validate visionQueue issues are OPEN before claiming (issue #1362)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1551,7 +1551,26 @@ request_coordinator_task() {
     if [[ "$vq_feature" =~ ^[0-9]+$ ]]; then
       # Feature is a GitHub issue number — claim it with priority
        log "Coordinator: vision-queue priority item is GitHub issue #$vq_feature"
-       if claim_task "$vq_feature" 2>/dev/null; then
+
+       # Issue #1362: Validate the issue is still OPEN before claiming
+       # (mirrors the closed-issue check in the regular queue path at issue #1015)
+       local vq_issue_state
+       vq_issue_state=$(gh issue view "$vq_feature" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+       if [ "$vq_issue_state" != "OPEN" ]; then
+         log "Coordinator: vision-queue issue #$vq_feature is $vq_issue_state — removing from visionQueue"
+         # Remove this closed item from visionQueue to prevent future agents from hitting it
+         local remaining_vq_closed
+         if echo "$vision_queue" | grep -q ";"; then
+           remaining_vq_closed=$(echo "$vision_queue" | sed 's/^[^;]*;//')
+         else
+           remaining_vq_closed=""
+         fi
+         kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+           --type=merge \
+           -p "{\"data\":{\"visionQueue\":\"${remaining_vq_closed}\"}}" 2>/dev/null || true
+         log "Coordinator: removed closed issue #$vq_feature from visionQueue — falling through to task queue"
+         # Fall through to regular task queue
+       elif claim_task "$vq_feature" 2>/dev/null; then
          # Remove from vision queue — handle single-item case (no semicolon)
          local remaining_vq
          if echo "$vision_queue" | grep -q ";"; then


### PR DESCRIPTION
## Summary

The visionQueue code path in `request_coordinator_task()` was skipping the closed-issue validation that exists in the regular task queue path.

## Root Cause

Two code paths exist in `request_coordinator_task()`:
1. **Vision queue path** (line ~1543): Claimed numeric issue numbers from visionQueue WITHOUT checking if they're still OPEN
2. **Regular queue path** (line ~1673): Already validated issue state via `gh issue view` (added in issue #1015)

## Impact

**Current state:** visionQueue contains `1308` (CLOSED after PR #1324 merged). Any planner checking visionQueue would waste a full agent session working on an already-resolved issue.

## Changes

- Added `gh issue view` state check before `claim_task()` in visionQueue numeric-issue path
- If issue is CLOSED/NOT_FOUND: removes it from visionQueue and falls through to regular taskQueue
- If OPEN: proceeds with claim as before (no behavior change for the happy path)
- Mirrors the existing logic in the regular queue path (issue #1015)

## Testing

Manually verified with visionQueue="1308" that:
1. The state check fires and detects issue #1308 is CLOSED
2. The item is removed from visionQueue
3. Processing falls through to the regular task queue

Closes #1362