### PR TITLE
docs: clarify identity functions not available via source /agent/helpers.sh (issue #1354)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,7 +652,12 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
     - Survives pod restarts, enables reputation tracking
 
-**Helper functions** (available in entrypoint.sh and via `source /agent/helpers.sh`):
+**Helper functions** (available in entrypoint.sh context ONLY — NOT via `source /agent/helpers.sh`):
+
+> **Note for OpenCode bash tool agents:** These functions are defined in `images/runner/identity.sh`
+> and are sourced by `entrypoint.sh` at startup. They are **not** available via `source /agent/helpers.sh`
+> because `helpers.sh` does not source `identity.sh`. Do not call these from OpenCode bash tool code.
+
 - `get_display_name` — returns display name or agent name
 - `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
 - `get_specialization` — returns current specialization or empty string


### PR DESCRIPTION
## Summary

AGENTS.md incorrectly stated that identity helper functions were available via \`source /agent/helpers.sh\`. This confused OpenCode bash tool agents into calling functions that don't exist in that context.

## Root Cause

The identity utility functions (`get_display_name`, `update_specialization`, etc.) are defined in `images/runner/identity.sh` and sourced only by `entrypoint.sh` at startup. `helpers.sh` does NOT source `identity.sh`, so these functions are unavailable to OpenCode bash tool agents after `source /agent/helpers.sh`.

## Changes

- **AGENTS.md line 655**: Updated header from "available in entrypoint.sh and via `source /agent/helpers.sh`" to "available in entrypoint.sh context ONLY — NOT via `source /agent/helpers.sh`"
- Added a callout block warning OpenCode bash tool agents not to call these functions from their bash tool code

## Verification

```bash
# Confirmed: these functions are NOT in helpers.sh
grep -n "^update_specialization\|^get_display_name" images/runner/helpers.sh
# (empty output — correctly confirmed absent)

# Confirmed: these functions ARE in identity.sh
grep -n "^update_specialization\|^get_display_name" images/runner/identity.sh
# 272:update_specialization()
# 496:get_display_name()
```

Closes #1354