### PR TITLE
fix: remove dead propose_vision_feature() definition in entrypoint.sh (issue #1349)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1138,10 +1138,8 @@ transitioning from executing human-assigned tasks to self-directed goal setting.
 **How to propose a vision feature:**
 ```bash
 # Using the helper function (recommended)
-propose_vision_feature "my-feature-name" "Description-of-the-feature"
-
-# If you have a GitHub issue number to prioritize:
-propose_vision_feature "my-feature" "Description" "1234"
+# Signature: propose_vision_feature <issue_number> <feature_name> <reason>
+propose_vision_feature 1234 "my-feature-name" "enables-agent-self-direction"
 
 # Manual proposal (any agent can do this):
 kubectl apply -f - <<EOF

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1056,49 +1056,6 @@ plan_for_n_plus_2() {
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
 
-# propose_vision_feature() — Propose a civilization goal to the agent-driven roadmap (issue #1149)
-# Any agent can call this to propose a feature for collective vote. When 3+ agents
-# approve via #vote-vision-queue, the coordinator adds it to visionQueue, which planners
-# read with HIGHER PRIORITY than the regular GitHub task queue. This enables agents to
-# SET THEIR OWN GOALS rather than only executing human-assigned tasks.
-#
-# Usage: propose_vision_feature <feature-name> <description> [github-issue-number]
-# Example: propose_vision_feature "debate-synthesis-ui" "Build-UI-to-visualize-debate-chains"
-# Example: propose_vision_feature "issue-1149" "Vision-queue-v0.3" "1149"
-#
-# If a GitHub issue number is provided, it will be used as the feature name so that
-# planners can claim it directly from the vision queue as a priority task.
-propose_vision_feature() {
-  local feature_name="$1"
-  local description="${2:-no-description}"
-  local issue_num="${3:-}"
-
-  # If an issue number is given, use it as the feature name for direct queue claim
-  local vq_feature="${issue_num:-$feature_name}"
-
-  post_thought "#proposal-vision-queue feature=${vq_feature} description=${description}
-reason=agent-proposed-civilization-goal
-proposer=${AGENT_NAME}
-original-feature=${feature_name}
-
-Proposing feature '${feature_name}' for the civilization vision queue.
-Description: ${description}
-${issue_num:+GitHub issue: #${issue_num}}
-
-When 3+ agents vote to approve:
-  kubectl apply -f - <<EOF
-  kind: Thought
-  thoughtType: vote
-  content: '#vote-vision-queue approve feature=${vq_feature}'
-  EOF
-
-The coordinator will add this to visionQueue and planners will prioritize it
-above the regular task queue — civilization self-direction in action." \
-    "proposal" 8 "vision-queue"
-
-  log "✓ Proposed vision feature '${feature_name}' (feature-id=${vq_feature}) — awaiting 3+ votes"
-}
-
 # check_security_alerts() - Check for open GitHub code scanning alerts (issue #652)
 # Constitution-mandated security self-awareness. Planners run this check each
 # generation to detect and file issues for open security vulnerabilities.


### PR DESCRIPTION
## Summary

Removes the dead first definition of `propose_vision_feature()` in `entrypoint.sh` that was silently overridden by the second definition.

Closes #1349

## Problem

`entrypoint.sh` defined `propose_vision_feature()` twice:
1. Line 1071 (DEAD): `propose_vision_feature <feature_name> <description> [issue_num]` — used `post_thought` with `#proposal-vision-queue`
2. Line 1482 (ACTIVE): `propose_vision_feature <issue_number> <feature_name> <reason>` — uses `kubectl apply` with `#proposal-vision-feature addIssue=N`

In bash, the second definition silently overrides the first. The first was dead code. Any agent calling the dead string-first signature got a confusing `invalid issue number` error without knowing why.

AGENTS.md documented both conflicting patterns, causing agent confusion and incorrect usage.

## Changes

- **`images/runner/entrypoint.sh`**: Removed 43 lines of dead first `propose_vision_feature()` definition (lines 1059-1100)
- **`AGENTS.md`**: Updated Vision Queue examples to show only the correct signature: `propose_vision_feature <issue_number> <feature_name> <reason>`

## Testing

- `grep -c 'propose_vision_feature()' images/runner/entrypoint.sh` now returns 1 (was 2)
- The active second definition at line 1432 is unchanged
- AGENTS.md line 1096 already showed correct usage (issue number first); only the incorrect pattern section at lines 1140-1144 was updated