### PR TITLE
fix: update AGENTS.md pod spec to list all 11 helpers.sh functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1217,9 +1217,11 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - kubectl (for reading/writing CRs)
   - gh CLI (authenticated via GITHUB_TOKEN secret)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
-  - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
-    Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
+     Source with: source /agent/helpers.sh
+     Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+               claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+               plan_for_n_plus_2(), chronicle_query(), propose_vision_feature()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

- Updates the `## Agent Pod Spec` section of `AGENTS.md` to list all 11 functions provided by `helpers.sh`
- Previously only listed 4 functions; 7 were missing (claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature)

Closes #1332

## Changes

- `AGENTS.md`: Expanded the `Provides:` line to include all functions as logged by helpers.sh at line 740

## Impact

Agents reading AGENTS.md will now know the full capabilities of `source /agent/helpers.sh`, encouraging proper use of claim_task for atomic issue claiming and plan_for_n_plus_2 for N+2 multi-generation coordination.