### PR TITLE
fix: add --validate=false to coordinator-script ConfigMap update (issue #1376)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -79,7 +79,7 @@ jobs:
           # updated. This was the root cause of the governance engine failure (issue #1254).
           kubectl create configmap coordinator-script \
             --from-file=coordinator.sh=images/runner/coordinator.sh \
-            -n agentex --dry-run=client -o yaml | kubectl apply -f -
+            -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -
           echo "coordinator-script ConfigMap updated with latest coordinator.sh"
 
       - name: Restart coordinator deployment to pick up new image


### PR DESCRIPTION
## Problem

The 'Update coordinator-script ConfigMap with new code' step in \`.github/workflows/build-runner.yml\` fails with:
```
error: error validating "STDIN": error validating data: failed to download openapi: 
the server has asked for the client to provide credentials
```

CI runs 22895441991 and 22895406326 both fail at step 9:
- ✅ Push image: success
- ❌ **Update coordinator-script ConfigMap: FAILURE**
- ⏭️ Restart coordinator deployment: skipped (because step 9 failed)
- ⏭️ Restart planner-loop: skipped

## Root Cause

`kubectl apply` runs server-side validation by default, which requires downloading the OpenAPI schema from the EKS API server. The GitHub Actions OIDC role may lack `api-resources`/discovery permissions, or there's a transient auth handshake issue with the EKS endpoint.

## Impact — CRITICAL

This means **coordinator.sh changes merged to main are NEVER deployed to the cluster**. The coordinator-script ConfigMap stays on an old version, the coordinator deployment restart is skipped, and the coordinator continues running stale code indefinitely.

Confirmed: PR #1317 merged 7+ hours before this discovery; ConfigMap still had the old `head -16` version.

## Fix

Add `--validate=false` to skip server-side schema validation. Safe because:
1. We're applying kubectl-generated dry-run output (not user-authored YAML)
2. The ConfigMap structure is simple and verified by `--dry-run=client`
3. Same pattern already used in EKS deployments where discovery permissions are restricted

## Changes

- `.github/workflows/build-runner.yml`: Add `--validate=false` to `kubectl apply` in step 9

Closes #1376