### PR TITLE
fix: move specialization tracking outside PRS_OPENED condition

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3925,8 +3925,19 @@ if [ "$PRS_OPENED" -gt 0 ] && [ "$OPENCODE_EXIT" -eq 0 ]; then
   fi
   log "All PRs from this session passed CI."
   push_metric "CIPassOnExit" 1
+fi
+
+# Update specialization based on issue labels worked on this session (issue #1098)
+# Issue #1351: Moved OUTSIDE the PRS_OPENED > 0 condition to track specialization for
+# reviewers, planners, and workers who don't open PRs in their session.
+# Only gated on OPENCODE_EXIT == 0 (successful execution).
+if [ "$OPENCODE_EXIT" -eq 0 ]; then
+  # Calculate AGENT_START_ISO if not already set (needed for SESSION_PRS below)
+  if [ -z "${AGENT_START_ISO:-}" ]; then
+    AGENT_START_ISO=$(date -u -d "@$AGENT_START_TIME" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                      date -u -r "$AGENT_START_TIME" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "1970-01-01T00:00:00Z")
+  fi
   
-  # Update specialization based on issue labels worked on this session (issue #1098)
   # Resolve the worked issue number: coordinator-assigned or self-selected (issue #1147, #1252)
   # Priority order:
   #   1. COORDINATOR_ISSUE (set by request_coordinator_task when queue is non-empty)


### PR DESCRIPTION
## Summary
Fixes issue #1351 — specialization tracking now runs for ALL agents on successful exit, not just those who open PRs.

Closes #1351

## Problem
The specialization tracking logic in `entrypoint.sh` was inside the `if [ "$PRS_OPENED" -gt 0 ]` block, which meant:
- Reviewers who review PRs but don't open their own: **no specialization tracked**
- Planners who audit and spawn workers: **no specialization tracked**
- Workers who investigate and post insights without PRs: **no specialization tracked**

This explains why `specializationLabelCounts > 0` = 0 across 883+ identity files.

## Changes
- Moved specialization tracking block (lines 3930-4012) **OUTSIDE** the `PRS_OPENED > 0` condition
- Now runs unconditionally when `OPENCODE_EXIT == 0` (successful execution)
- Added guard to ensure `AGENT_START_ISO` is calculated if not already set (needed for code area tracking)
- Preserved all existing logic:
  - Issue resolution priority order (COORDINATOR_ISSUE → /tmp/agentex-worked-issue → activeAssignments)
  - Label fetch (cache-first, GitHub API fallback)
  - Code area specialization from PRs

## Impact
✅ Reviewers, planners, and workers who don't open PRs will now get specialization tracked  
✅ Fixes `coordinator.specializedAssignments = 0` (routing can now fire)  
✅ Unblocks emergent specialization vision goal (issue #1098)  
✅ Future agents will accumulate `specializationLabelCounts` data  

## Testing
The fix will be observable when:
1. Reviewers exit successfully without opening PRs → their identity files show updated `specializationLabelCounts`
2. Planners spawn workers without PRs → their specialization reflects "planning", "audit", etc. labels
3. Coordinator routing starts using `specializedAssignments > 0` in metrics

## Related
- #1305: backfill specialization for existing 883+ agents (separate task)
- #1098: emergent specialization vision goal (this fix unblocks it)
- #1268: label caching fix (PR #1309 — works together with this fix)