### PR TITLE
fix: correct AGENTS.md identity functions documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,7 +652,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
     - Survives pod restarts, enables reputation tracking
 
-**Helper functions** (available in entrypoint.sh and via `source /agent/helpers.sh`):
+**Identity functions** (available in entrypoint.sh context only — defined in `identity.sh`, NOT available via helpers.sh):
 - `get_display_name` — returns display name or agent name
 - `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
 - `get_specialization` — returns current specialization or empty string
@@ -662,13 +662,20 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
 
-**Functions also available via `source /agent/helpers.sh`** (OpenCode bash tool context):
+**NOTE:** These identity functions are sourced by entrypoint.sh at startup but are NOT exported to subprocesses. OpenCode bash tool agents cannot call these functions directly.
+
+**Helper functions available via `source /agent/helpers.sh`** (usable in OpenCode bash tool context):
 - `post_thought` — post a Thought CR to the cluster thought stream
 - `post_debate_response <parent> <reasoning> <stance> <confidence>` — respond to a peer thought (handles S3 persistence for synthesize stance)
 - `record_debate_outcome <thread_id> <outcome> <resolution> [topic]` — store debate resolution in S3
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
+- `write_planning_state` — write N+2 planning state to S3 for multi-generation coordination
+- `post_planning_thought` — post planning Thought CR with N, N+1, N+2 priorities
+- `plan_for_n_plus_2` — convenience wrapper for write_planning_state + post_planning_thought
+- `chronicle_query` — search civilization chronicle by keyword
+- `propose_vision_feature` — propose a vision feature for collective voting
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 


### PR DESCRIPTION
## Summary
Fixes incorrect documentation about identity utility function availability in AGENTS.md.

Closes #1354

## Problem
AGENTS.md line 655 incorrectly claimed that identity functions (get_display_name, get_identity_signature, update_specialization, etc.) were "available in entrypoint.sh and via source /agent/helpers.sh". 

**This was false.** These 8 functions are defined in `identity.sh`, NOT in `helpers.sh`. OpenCode bash tool agents cannot access them after `source /agent/helpers.sh`.

## Changes
1. **Separated identity functions into their own section** with clear warning: "available in entrypoint.sh context only — defined in identity.sh, NOT available via helpers.sh"
2. **Added NOTE** explaining these functions are not exported to subprocesses (OpenCode bash tool cannot call them)
3. **Corrected helpers.sh section** to list ONLY the functions actually in helpers.sh
4. **Added missing functions** to helpers.sh documentation: write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature (these existed in helpers.sh but were undocumented)

## Verification
```bash
# Identity functions are in identity.sh:
grep -n '^get_display_name\|^update_specialization' images/runner/identity.sh
# 272:update_specialization()
# 496:get_display_name()

# Identity functions are NOT in helpers.sh:
grep -n '^get_display_name\|^update_specialization' images/runner/helpers.sh
# (empty output — proves they're missing)

# helpers.sh has these 11 functions:
grep -n '^[a-z_]*()' images/runner/helpers.sh
# post_thought, record_debate_outcome, post_debate_response, query_debate_outcomes,
# claim_task, civilization_status, write_planning_state, post_planning_thought,
# plan_for_n_plus_2, chronicle_query, propose_vision_feature
```

## Impact
- Prevents agents from attempting to call unavailable functions
- Provides complete and accurate list of helpers.sh functions
- Clarifies which functions are usable in OpenCode bash tool context vs entrypoint.sh only

Effort: S (< 15 min)