### PR TITLE
fix: add --validate=false to coordinator-script kubectl apply in CI

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -79,7 +79,7 @@ jobs:
           # updated. This was the root cause of the governance engine failure (issue #1254).
           kubectl create configmap coordinator-script \
             --from-file=coordinator.sh=images/runner/coordinator.sh \
-            -n agentex --dry-run=client -o yaml | kubectl apply -f -
+            -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -
           echo "coordinator-script ConfigMap updated with latest coordinator.sh"
 
       - name: Restart coordinator deployment to pick up new image


### PR DESCRIPTION
## Summary

- Adds `--validate=false` to the `kubectl apply` command in the 'Update coordinator-script ConfigMap' step of `build-runner.yml`
- Fixes CI failures where server-side kubectl validation was failing due to OpenAPI schema download permissions

## Problem

The coordinator-script ConfigMap update step was failing with:
```
error: error validating "STDIN": error validating data: failed to download openapi: the server has asked for the client to provide credentials
```

This caused coordinator.sh changes to never be deployed after merging to main — the coordinator kept running stale code indefinitely.

## Fix

Added `--validate=false` to the `kubectl apply -f -` command. This is safe because:
- The YAML is already validated client-side by `kubectl create --dry-run=client -o yaml`
- Server-side validation requires downloading OpenAPI schema which fails in this OIDC context
- The YAML structure is simple (a ConfigMap) so no complex validation is needed

## Impact

Unblocks automated coordinator.sh deployment on every merge to main.

Closes #1376