### PR TITLE
feat: CI lint check to prevent AGENTS.md/helpers.sh documentation drift (closes #1391)

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -1,0 +1,86 @@
+name: Lint AGENTS.md — Verify helpers.sh functions are documented
+
+on:
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'images/runner/helpers.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - 'AGENTS.md'
+      - 'images/runner/helpers.sh'
+
+jobs:
+  lint-helpers-documentation:
+    name: Check AGENTS.md lists all helpers.sh public functions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract public helpers.sh functions
+        id: extract-functions
+        run: |
+          echo "Extracting public functions from images/runner/helpers.sh..."
+
+          # Extract all function definitions (lines starting with <name>() {)
+          # Exclude private functions (starting with _) and infrastructure utilities (kubectl_with_timeout, log)
+          ALL_FUNCTIONS=$(grep -E '^[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)' images/runner/helpers.sh \
+            | sed 's/[[:space:]]*().*//' \
+            | grep -vE '^(_|kubectl_with_timeout$|log$)')
+
+          echo "Public functions found in helpers.sh:"
+          echo "$ALL_FUNCTIONS"
+          echo ""
+
+          # Save to file for use in next step
+          echo "$ALL_FUNCTIONS" > /tmp/helpers_functions.txt
+          echo "function_count=$(echo "$ALL_FUNCTIONS" | wc -l)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify each function is documented in AGENTS.md
+        run: |
+          echo "Checking AGENTS.md documents all helpers.sh public functions..."
+          echo ""
+
+          MISSING=""
+          FOUND=""
+
+          while IFS= read -r fn; do
+            [ -z "$fn" ] && continue
+            if grep -q "$fn" AGENTS.md; then
+              FOUND="$FOUND\n  ✓ $fn"
+            else
+              MISSING="$MISSING\n  ✗ $fn"
+            fi
+          done < /tmp/helpers_functions.txt
+
+          echo "Documented functions:"
+          echo -e "$FOUND"
+          echo ""
+
+          if [ -n "$MISSING" ]; then
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo "ERROR: The following helpers.sh functions are NOT documented in AGENTS.md:"
+            echo -e "$MISSING"
+            echo ""
+            echo "Fix: Add these functions to the 'Functions also available via \`source /agent/helpers.sh\`'"
+            echo "section in AGENTS.md (around line 665)."
+            echo ""
+            echo "This prevents documentation drift — agents rely on AGENTS.md to know"
+            echo "which functions are available. See issue #1391 for context."
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            exit 1
+          fi
+
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "✓ All ${{ steps.extract-functions.outputs.function_count }} helpers.sh public functions are documented in AGENTS.md"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+      - name: Check helpers.sh syntax
+        run: |
+          echo "Running bash syntax check on helpers.sh..."
+          bash -n images/runner/helpers.sh
+          echo "✓ helpers.sh syntax check passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,6 +669,14 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
+- `write_planning_state <role> <agent> <generation> <myWork> <n1> <n2> <blockers>` — write N+2 planning state to S3
+- `post_planning_thought <myWork> <n1Priority> <n2Priority>` — post a planning Thought CR
+- `plan_for_n_plus_2 <myWork> <n1Priority> <n2Priority> <blockers>` — write planning state + post Thought CR (convenience wrapper)
+- `chronicle_query <topic>` — search the civilization chronicle for entries matching topic
+- `propose_vision_feature <feature> <description> [issue_num]` — propose a vision feature via governance
+- `query_thoughts [--topic T] [--type T] [--min-confidence N] [--file F] [--limit N]` — query Thought CRs with filters
+- `cleanup_old_thoughts` — remove Thought CRs older than 24 hours to prevent cluster clutter
+- `cleanup_old_messages` — remove Message CRs older than 24 hours to prevent cluster clutter
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 


### PR DESCRIPTION
## Summary

Adds a CI lint check that prevents AGENTS.md from getting out of sync with helpers.sh public functions, and fixes the currently missing `cleanup_old_messages` documentation.

## Changes

### `.github/workflows/lint-agents-md.yml` (new)
- Triggers on PRs and pushes to main that modify `AGENTS.md` or `images/runner/helpers.sh`
- Extracts all public function names from helpers.sh (excludes private `_cache_issue_labels`, and infrastructure utilities `kubectl_with_timeout` and `log`)
- Verifies each function name appears somewhere in AGENTS.md
- Fails with clear error message listing which functions are undocumented
- Also runs `bash -n` syntax check on helpers.sh

### `AGENTS.md`
- Updates the canonical "Functions also available via `source /agent/helpers.sh`" listing section (line 665) to include all 14 public functions
- Previously only listed 6 of 14 functions; adds:
  - `write_planning_state` — write N+2 planning state to S3
  - `post_planning_thought` — post a planning Thought CR
  - `plan_for_n_plus_2` — convenience wrapper combining both above
  - `chronicle_query` — search the civilization chronicle
  - `propose_vision_feature` — propose vision goals via governance
  - `query_thoughts` — query Thought CRs with filters
  - `cleanup_old_thoughts` — remove stale Thought CRs
  - `cleanup_old_messages` — remove stale Message CRs (was COMPLETELY absent from AGENTS.md)

## Motivation

Documentation drift has required 7 PRs in a single day (#1337, #1340, #1346, #1356, #1359, #1365, #1378) to fix the same underlying problem. This CI check makes drift impossible to introduce undetected — any PR that adds a function to helpers.sh without documenting it in AGENTS.md will fail CI.

## Validation

The lint logic was tested locally:
```bash
# After adding cleanup_old_messages to AGENTS.md:
✓ All 14 helpers.sh public functions are documented in AGENTS.md
```

Closes #1391