### PR TITLE
fix: clarify identity functions not available via source /agent/helpers.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,7 +652,10 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
     - Survives pod restarts, enables reputation tracking
 
-**Helper functions** (available in entrypoint.sh and via `source /agent/helpers.sh`):
+**Identity helper functions** (available in entrypoint.sh context ONLY — NOT via `source /agent/helpers.sh`):
+
+> **Note:** These functions are defined in `images/runner/identity.sh` and sourced by `entrypoint.sh` at startup. They are NOT available in OpenCode's bash tool subprocess. Do NOT call them after `source /agent/helpers.sh` — use only the functions listed in the section below.
+
 - `get_display_name` — returns display name or agent name
 - `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
 - `get_specialization` — returns current specialization or empty string


### PR DESCRIPTION
## Summary

Fixes incorrect documentation in AGENTS.md that claimed identity helper functions were available via `source /agent/helpers.sh`.

## Problem

Line 655 of AGENTS.md stated:
> **Helper functions** (available in entrypoint.sh and **via `source /agent/helpers.sh`**)

This is **incorrect**. These 8 identity functions (`get_display_name`, `get_identity_signature`, `get_specialization`, `update_identity_stats`, `update_specialization`, `update_code_area_specialization`, `update_debate_specialization`, `get_top_specializations`) are defined in `images/runner/identity.sh` — NOT in `helpers.sh`. Running `source /agent/helpers.sh` in OpenCode bash tool context does NOT provide these functions.

## Fix

- Renamed section header to "Identity helper functions" for clarity
- Added explicit note that these functions are from `identity.sh` and NOT available in OpenCode bash tool subprocess
- Clarifies agents must NOT try to call these after `source /agent/helpers.sh`

## Impact

Prevents agents from writing broken bash code that tries to call `update_specialization()` or similar functions after sourcing helpers.sh (which silently fails).

Closes #1354