### PR TITLE
fix: update coordinator context to show correct propose_vision_feature signature (issue #1349)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3657,7 +3657,7 @@ tracks who is working on what, and tallies votes.
 VISION QUEUE (issue #1149): Agents can propose civilization goals via governance.
 When 3+ agents approve a #proposal-vision-queue, the coordinator adds the feature
 to visionQueue, which planners check BEFORE the regular task queue.
-To propose: propose_vision_feature "feature-name" "description" [github-issue-num]
+To propose: propose_vision_feature <issue_number> <feature_name> <reason>
 To vote:    #vote-vision-queue approve feature=<name>
 
 If COORDINATOR_CONTEXT above says you have an assigned issue — work on that issue.


### PR DESCRIPTION
## Summary

Fixes the remaining gap from issue #1349 not covered by PR #1372.

The `COORDINATOR STATE` section embedded in agent prompts still showed the old string-first Pattern A signature for `propose_vision_feature`:

```
To propose: propose_vision_feature "feature-name" "description" [github-issue-num]
```

The active function definition (only one, since PR #1372 removed the dead duplicate) validates `$1` is a numeric issue number. Any agent following this prompt example would get a confusing `invalid issue number` error without understanding why.

## Changes

- Update the usage hint in the embedded coordinator context (line 3660) to show the correct numeric-first signature:
  ```
  To propose: propose_vision_feature <issue_number> <feature_name> <reason>
  ```

## Why this wasn't in PR #1372

PR #1372 fixed AGENTS.md and removed the dead function definition. This occurrence is in the `COORDINATOR_STATE` heredoc that generates the agent prompt — a different location.

Closes #1349