### PR TITLE
feat: CI lint check to prevent AGENTS.md/helpers.sh documentation drift (issue #1391)

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -1,0 +1,40 @@
+name: Lint AGENTS.md
+
+on:
+  push:
+    paths:
+      - 'AGENTS.md'
+      - 'images/runner/helpers.sh'
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'images/runner/helpers.sh'
+
+jobs:
+  lint-agents-md:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check AGENTS.md lists all helpers.sh public functions
+        run: |
+          # Extract public function names from helpers.sh (skip private functions starting with _)
+          functions=$(grep -E '^[a-zA-Z][a-zA-Z0-9_]*\(\)' images/runner/helpers.sh | sed 's/().*//')
+
+          missing=""
+          for fn in $functions; do
+            if ! grep -q "$fn" AGENTS.md; then
+              missing="$missing\n  - $fn"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "ERROR: The following helpers.sh public functions are not documented in AGENTS.md:"
+            printf "%b\n" "$missing"
+            echo ""
+            echo "Fix: add documentation for these functions to AGENTS.md."
+            echo "They should be listed in the 'Functions also available via source /agent/helpers.sh' section."
+            exit 1
+          fi
+
+          echo "OK: All helpers.sh public functions are documented in AGENTS.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -967,7 +967,7 @@ source /agent/helpers.sh && post_thought "Circuit breaker false positive fixed i
 source /agent/helpers.sh && post_debate_response "thought-planner-abc-1234567" "My reasoning..." "disagree" 8
 ```
 
-**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter.
+**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter. Call `cleanup_old_messages` similarly to remove stale Message CRs (read messages >24h, unread messages >48h).
 
 ### Consensus Voting
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically validates AGENTS.md documents all public functions from `images/runner/helpers.sh`. Prevents the recurring documentation drift that required 7 separate PRs (#1337, #1340, #1346, #1356, #1359, #1365, #1378) to fix the same underlying problem.

## Changes

- **New file**: `.github/workflows/lint-agents-md.yml` — runs on changes to `AGENTS.md` or `images/runner/helpers.sh`; extracts all public function names (non-`_` prefixed) from `helpers.sh` and fails CI if any are absent from `AGENTS.md`
- **AGENTS.md**: Added missing `cleanup_old_messages()` documentation alongside `cleanup_old_thoughts()` (the only public function not yet documented)

## Verification

The lint check passes against the current state of the repository:
```bash
functions=$(grep -E '^[a-zA-Z][a-zA-Z0-9_]*\(\)' images/runner/helpers.sh | sed 's/().*//') 
# All listed: kubectl_with_timeout, log, post_thought, record_debate_outcome, post_debate_response,
#   query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought,
#   plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts,
#   cleanup_old_messages
# Result: OK - all documented in AGENTS.md
```

Private/internal functions starting with `_` (e.g., `_cache_issue_labels`) are intentionally excluded from the check.

## Impact

- Future PRs adding functions to `helpers.sh` without documenting them in `AGENTS.md` will fail CI immediately
- Zero false positives (only public API functions checked)
- Agents receive accurate function documentation going forward

Closes #1391