### PR TITLE
fix: normalize decision_key whitespace to stop governance re-enactment loop (issue #1398)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -934,7 +934,13 @@ tally_and_enact_votes() {
         enacted=$(get_state "enactedDecisions")
         # Issue #940: null guard - treat empty/null as empty string
         [ -z "$enacted" ] && enacted=""
-        local decision_key="${topic}_${kv_pairs// /_}"  # unique key for this exact proposal
+        # Issue #1398: kv_pairs may contain newlines (one per key=value from grep -oE).
+        # ${kv_pairs// /_} only replaces spaces, not newlines, so decision_key can contain
+        # embedded newlines that corrupt the JSON patch in update_state() and cause
+        # grep -qF to silently fail — resulting in infinite re-enactment + duplicate PRs.
+        # Fix: normalize ALL whitespace (spaces AND newlines) to underscores.
+        local decision_key
+        decision_key="${topic}_$(echo "$kv_pairs" | tr '[:space:]' '_' | tr -s '_')"
         
         if echo "$enacted" | grep -qF "$decision_key"; then
             echo "[$(date -u +%H:%M:%S)] $topic already enacted, skipping"


### PR DESCRIPTION
## Summary

Fixes the root cause of duplicate governance sync PRs (#1330, #1331, #1366, #1370, #1373, #1374, #1382, #1383, #1387, #1388, #1393, #1394).

## Root Cause

The `decision_key` in `tally_and_enact_votes()` was built with:
```bash
local decision_key="${topic}_${kv_pairs// /_}"
```

The `kv_pairs` variable is produced by `grep -oE '[a-zA-Z0-9_]+=[a-zA-Z0-9_.-]+'` which returns one `key=value` per **line** (newline-separated, not space-separated). The `${kv_pairs// /_}` substitution only replaces **spaces** with underscores, not **newlines**.

This means `decision_key` contains embedded newlines like:
```
circuit-breaker_circuitBreakerLimit=12
reason=observed-load-rarely-exceeds-10
```

Consequences:
1. `update_state("enactedDecisions", "${enacted_entry}")` produces malformed JSON (embedded newline in JSON string) → silently fails with `|| true`
2. `enactedDecisions` never gets the `circuit-breaker` entry
3. Every coordinator tally cycle re-enacts → calls `sync_constitution_to_git()` → creates a new branch → opens a new PR
4. Result: 10+ duplicate `governance-enacted-circuit-breaker-*` PRs

## Fix

Replace the newline-unsafe substitution with `tr '[:space:]' '_' | tr -s '_'` which normalizes ALL whitespace (spaces AND newlines) to underscores:

```bash
# Before (broken):
local decision_key="${topic}_${kv_pairs// /_}"

# After (fixed):
local decision_key
decision_key="${topic}_$(echo "$kv_pairs" | tr '[:space:]' '_' | tr -s '_')"
```

## Immediate Mitigation

Also manually patched `coordinator-state.enactedDecisions` in the running cluster to add the `circuit-breaker` entries — immediately stopping the re-enactment loop without waiting for this PR to merge and the coordinator image to rebuild.

## Testing

The fix ensures:
- `decision_key` is a single-line string with no embedded newlines
- `grep -qF` can match it reliably against `enactedDecisions`
- `update_state()` JSON patch succeeds
- Once the circuit-breaker is enacted, it stays enacted across coordinator restarts

Closes #1398