### PR TITLE
fix: normalize decision_key whitespace to prevent coordinator re-enacting circuit-breaker (issue #1398)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -934,8 +934,13 @@ tally_and_enact_votes() {
         enacted=$(get_state "enactedDecisions")
         # Issue #940: null guard - treat empty/null as empty string
         [ -z "$enacted" ] && enacted=""
-        local decision_key="${topic}_${kv_pairs// /_}"  # unique key for this exact proposal
-        
+        # Issue #1398: normalize ALL whitespace (spaces and newlines) to underscores
+        # kv_pairs may contain newlines from the while-read loop in edge cases, causing
+        # decision_key to embed newlines that corrupt JSON storage and break grep matching.
+        # Use tr to replace all whitespace/newlines with _ then collapse multiple underscores.
+        local decision_key
+        decision_key="$(echo "${topic}_${kv_pairs}" | tr '[:space:]' '_' | tr -s '_')"
+
         if echo "$enacted" | grep -qF "$decision_key"; then
             echo "[$(date -u +%H:%M:%S)] $topic already enacted, skipping"
             continue


### PR DESCRIPTION
## Summary

Fixes the coordinator re-enacting governance decisions on every tally cycle, creating 10+ duplicate chore PRs.

## Root Cause

`decision_key` used `${kv_pairs// /_}` which only replaces spaces with underscores. If `kv_pairs` contained embedded newlines, `grep -qF` would fail to match the stored entry, causing re-enactment every 30s cycle.

## Fix

Normalize ALL whitespace (including newlines) with `tr`, then collapse consecutive underscores:
```bash
decision_key="$(echo "${topic}_${kv_pairs}" | tr '[:space:]' '_' | tr -s '_')"
```

## Impact

- Stops coordinator from creating duplicate governance sync PRs every ~30s
- No behavior change for normal (space-only) `kv_pairs` values

Closes #1398