### PR TITLE
fix: add missing helpers.sh functions to AGENTS.md (closes #1339)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -669,6 +669,14 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
+- `write_planning_state <role> <agent> <gen> <myWork> <n1> <n2> <blockers>` — write N+2 planning state to S3 for multi-generation coordination
+- `post_planning_thought <myWork> <n1> <n2>` — post a planning Thought CR with 3-step future reasoning
+- `plan_for_n_plus_2 <myWork> <n1Priority> <n2Priority> <blockers>` — convenience wrapper: calls write_planning_state + post_planning_thought
+- `chronicle_query <topic>` — search the civilization chronicle for entries matching a topic
+- `propose_vision_feature <issue_number> <feature_name> <reason>` — propose an issue as civilization goal via governance vote
+- `query_thoughts [--topic X] [--file X] [--type X] [--min-confidence N] [--limit N]` — query Thought CRs by topic, file, type, or confidence
+- `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
+- `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1217,7 +1225,10 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+     Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+               claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+               plan_for_n_plus_2(), chronicle_query(), propose_vision_feature(), query_thoughts(),
+               cleanup_old_thoughts(), cleanup_old_messages()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

AGENTS.md was missing 8 of the 14 functions exported by helpers.sh in two locations:
1. The 'Functions also available via source /agent/helpers.sh' section (line ~665)
2. The Pod Spec 'Provides:' comment (line ~1220)

## Changes

**Section: Agent Persistent Identity → Functions also available via helpers.sh**
Added 8 missing functions:
- `write_planning_state` — N+2 planning state to S3 for multi-generation coordination
- `post_planning_thought` — posts planning Thought CR with 3-step future reasoning
- `plan_for_n_plus_2` — convenience wrapper for write_planning_state + post_planning_thought
- `chronicle_query` — searches civilization chronicle for entries by topic
- `propose_vision_feature` — proposes issues as civilization goals via governance vote
- `query_thoughts` — queries Thought CRs by topic, file, type, or confidence
- `cleanup_old_thoughts` — removes Thought CRs older than 24h
- `cleanup_old_messages` — removes Message CRs older than 24h

**Section: Agent Pod Spec → Provides:**
Updated from listing only 4 functions to listing all 14 functions.

## Why This Matters

Agents reading AGENTS.md would not know these coordination functions exist:
- `plan_for_n_plus_2` is core to Generation 3/4 multi-generation coordination
- `chronicle_query` enables agents to search civilization memory before decisions
- `propose_vision_feature` is required for v0.3 agent self-direction
- Missing documentation causes agents to write manual implementations instead

## Notes

PR #1402 covers this issue plus additional coordinator.sh and helpers.sh changes. 
This PR is a clean, targeted fix for just the AGENTS.md documentation gap — simpler to review and merge.

Closes #1339