### PR TITLE
fix: use issueLabels cache in specialization routing (issue #1431)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1934,6 +1934,11 @@ route_tasks_by_specialization() {
     local generic_count=0
     local routing_log=""
 
+    # Issue #1430: Pre-fetch issueLabels cache to avoid per-issue GitHub API calls
+    # Cache format: "issue:label1,label2|issue2:label3|..."
+    local labels_cache
+    labels_cache=$(get_state "issueLabels" 2>/dev/null || echo "")
+
     IFS=',' read -ra queue_issues <<< "$task_queue"
     for issue_num in "${queue_issues[@]}"; do
         [ -z "$issue_num" ] && continue
@@ -1946,10 +1951,16 @@ route_tasks_by_specialization() {
             continue
         fi
 
-        # Get issue labels for scoring
-        local issue_labels
-        issue_labels=$(gh issue view "$issue_num" --repo "${GITHUB_REPO}" \
-            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        # Get issue labels for scoring — use cache first (issue #1430: rate-limit resilient)
+        local issue_labels=""
+        if [ -n "$labels_cache" ]; then
+            issue_labels=$(echo "$labels_cache" | tr '|' '\n' | grep "^${issue_num}:" | cut -d: -f2- | head -1 || echo "")
+        fi
+        # Fall back to GitHub API on cache miss
+        if [ -z "$issue_labels" ]; then
+            issue_labels=$(gh issue view "$issue_num" --repo "${GITHUB_REPO}" \
+                --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        fi
 
         # Find best specialized agent
         local best_agent

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1602,11 +1602,22 @@ request_coordinator_task() {
       esac
       
       # Scan queue for a matching issue
+      # Issue #1430: Use issueLabels cache first to avoid GitHub API calls (rate-limit resilient)
+      local labels_cache
+      labels_cache=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
       for candidate in $(echo "$queue" | tr ',' ' '); do
         [ -z "$candidate" ] && continue
-        local issue_labels
-        issue_labels=$(gh issue view "$candidate" --repo "$REPO" \
-          --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        local issue_labels=""
+        # Check issueLabels cache first (avoids GitHub API calls when rate-limited)
+        if [ -n "$labels_cache" ]; then
+          issue_labels=$(echo "$labels_cache" | tr '|' '\n' | grep "^${candidate}:" | cut -d: -f2- | head -1 || echo "")
+        fi
+        # Fall back to GitHub API on cache miss
+        if [ -z "$issue_labels" ]; then
+          issue_labels=$(gh issue view "$candidate" --repo "$REPO" \
+            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        fi
         if echo "$issue_labels" | grep -qi "$spec_label"; then
           claimed_issue="$candidate"
           log "Coordinator: specialization-matched issue #$claimed_issue (spec=$my_specialization, labels=$issue_labels)"


### PR DESCRIPTION
## Summary

Use the `coordinator-state.issueLabels` cache as primary label lookup in specialization-aware task routing, falling back to GitHub API only on cache miss.

## Problem

- `request_coordinator_task()` calls `gh issue view` for every queue candidate when matching specialization
- `route_tasks_by_specialization()` does the same in the coordinator
- When GitHub API is rate-limited, these calls fail → specialization routing silently falls back to first-available → v0.2 milestone (specializedAssignments > 0) never fires

## Changes

- **entrypoint.sh**: `request_coordinator_task()` reads `issueLabels` cache from coordinator-state before calling `gh issue view` for each queue candidate
- **coordinator.sh**: `route_tasks_by_specialization()` pre-fetches `issueLabels` cache and uses it instead of per-issue GitHub API calls

## Benefits

- Specialization routing works during GitHub API rate limits (common during high agent activity)
- Reduces GitHub API calls per routing cycle (cache hit avoids HTTP request)
- Directly supports v0.2 milestone: `specializedAssignments > 0` in coordinator-state

Closes #1431