### PR TITLE
fix: make CI coordinator update non-blocking when EKS auth fails (issue #1421)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -66,8 +66,19 @@ jobs:
 
       - name: Update coordinator-script ConfigMap with new code
         if: github.ref == 'refs/heads/main'
+        id: update-coordinator-configmap
+        continue-on-error: true
         run: |
           # Configure kubectl with EKS cluster
+          # NOTE: This step requires EKS access entry for the agentex-github-actions IAM role.
+          # If this fails with "Access denied" or "no configuration", see issue #1421:
+          #   aws eks create-access-entry --cluster-name agentex \
+          #     --principal-arn arn:aws:iam::569190534191:role/agentex-github-actions \
+          #     --region ${{ env.AWS_REGION }}
+          #   aws eks associate-access-policy --cluster-name agentex \
+          #     --principal-arn arn:aws:iam::569190534191:role/agentex-github-actions \
+          #     --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
+          #     --access-scope type=cluster --region ${{ env.AWS_REGION }}
           aws eks update-kubeconfig \
             --name agentex \
             --region ${{ env.AWS_REGION }} \
@@ -82,8 +93,17 @@ jobs:
             -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -
           echo "coordinator-script ConfigMap updated with latest coordinator.sh"
 
+      - name: Warn if coordinator update failed (issue #1421)
+        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'failure'
+        run: |
+          echo "::warning::⚠️ coordinator-script ConfigMap update FAILED (issue #1421)."
+          echo "::warning::The agentex-github-actions IAM role likely lacks EKS access entry."
+          echo "::warning::coordinator.sh changes in this merge will NOT take effect until manually applied."
+          echo "::warning::Fix (god only): aws eks create-access-entry + associate-access-policy for arn:aws:iam::569190534191:role/agentex-github-actions"
+          echo "::warning::Workaround: kubectl create configmap coordinator-script --from-file=coordinator.sh=images/runner/coordinator.sh -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -"
+
       - name: Restart coordinator deployment to pick up new image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
         run: |
           # Rolling restart — coordinator picks up new :latest image AND updated ConfigMap
           # This ensures fixes to coordinator.sh take effect immediately after merge.
@@ -95,7 +115,7 @@ jobs:
           echo "Coordinator restarted successfully — running latest image and script"
 
       - name: Restart planner-loop to pick up new image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
         run: |
           echo "Triggering planner-loop rollout to pick up updated runner image..."
           kubectl rollout restart deployment/planner-loop -n agentex


### PR DESCRIPTION
## Summary

CI build-runner.yml currently fails the entire workflow when the EKS coordinator update step fails (issue #1421: agentex-github-actions IAM role lacks EKS access entry). This causes CI builds to appear failed even though the Docker image was successfully built and pushed to ECR.

## Changes

- Add `continue-on-error: true` to the 'Update coordinator-script ConfigMap' step
- Add a warning annotation step that runs when the update fails, with exact remediation commands for god
- Gate the coordinator and planner-loop restart steps on successful ConfigMap update

## Effect

- CI builds succeed even when EKS auth fails (ECR push is the critical path)
- GitHub warning annotations clearly indicate when manual intervention is needed
- Provides exact AWS CLI commands for god to create the EKS access entry

## Root Cause Fix (for god)

The actual fix requires running from AWS console or CLI with admin access:
```bash
aws eks create-access-entry \
  --cluster-name agentex \
  --principal-arn arn:aws:iam::569190534191:role/agentex-github-actions \
  --region us-west-2

aws eks associate-access-policy \
  --cluster-name agentex \
  --principal-arn arn:aws:iam::569190534191:role/agentex-github-actions \
  --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
  --access-scope type=cluster \
  --region us-west-2
```

Closes #1421