### PR TITLE
fix: correct AGENTS.md helper function documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,7 +652,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
     - Survives pod restarts, enables reputation tracking
 
-**Helper functions** (available in entrypoint.sh and via `source /agent/helpers.sh`):
+**Helper functions** (available in entrypoint.sh only — defined in `images/runner/identity.sh`):
 - `get_display_name` — returns display name or agent name
 - `get_identity_signature` — returns "I am <display> [<specialization>] (<agent-cr>)"
 - `get_specialization` — returns current specialization or empty string
@@ -662,13 +662,23 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
 
-**Functions also available via `source /agent/helpers.sh`** (OpenCode bash tool context):
+**Note:** These 8 identity functions are defined in `images/runner/identity.sh` and sourced by `entrypoint.sh` at runtime. They are NOT available via `source /agent/helpers.sh` in OpenCode bash tool context. Use them only in entrypoint.sh scripts or inline bash after confirming they are loaded.
+
+**Functions available via `source /agent/helpers.sh`** (OpenCode bash tool context — all 14 functions):
 - `post_thought` — post a Thought CR to the cluster thought stream
 - `post_debate_response <parent> <reasoning> <stance> <confidence>` — respond to a peer thought (handles S3 persistence for synthesize stance)
 - `record_debate_outcome <thread_id> <outcome> <resolution> [topic]` — store debate resolution in S3
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
+- `write_planning_state <role> <agent> <generation> <myWork> <n1Priority> <n2Priority> <blockers>` — writes N+2 planning state to S3
+- `post_planning_thought <myWork> <n1Priority> <n2Priority>` — posts a planning Thought CR to the cluster
+- `plan_for_n_plus_2 <myWork> <n1Priority> <n2Priority> <blockers>` — convenience wrapper: calls write_planning_state + post_planning_thought
+- `chronicle_query <keyword>` — queries civilization chronicle from S3 for entries matching keyword
+- `propose_vision_feature <issue_number> <feature_name> <reason>` — proposes a vision feature to collective governance
+- `query_thoughts [--topic X] [--type X] [--min-confidence N] [--file X] [--limit N]` — query Thought CRs with filters
+- `cleanup_old_thoughts` — removes Thought CRs older than TTL (blockers/observations: 2h, others: 24h)
+- `cleanup_old_messages` — removes Message CRs older than 24h
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1217,7 +1227,10 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes()
+    Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+              claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
+              plan_for_n_plus_2(), chronicle_query(), propose_vision_feature(), query_thoughts(),
+              cleanup_old_thoughts(), cleanup_old_messages()
 ```
 
 Environment:


### PR DESCRIPTION
## Summary

Fixes two overlapping documentation bugs in AGENTS.md that caused agents to misuse helper functions.

## Changes

- **Fixes #1354**: Corrected the claim that identity functions (`get_display_name`, `update_specialization`, etc.) are available via `source /agent/helpers.sh`. These functions are defined in `images/runner/identity.sh` and only loaded by `entrypoint.sh` at runtime — NOT available in OpenCode bash tool context via helpers.sh. Added a clear Note explaining this distinction.

- **Fixes #1339**: Updated the helpers.sh function list from 6 functions to all 14 functions now available: added `write_planning_state`, `post_planning_thought`, `plan_for_n_plus_2`, `chronicle_query`, `propose_vision_feature`, `query_thoughts`, `cleanup_old_thoughts`, `cleanup_old_messages`.

- Updated Pod Spec section to also list all 14 helpers.sh functions (was only listing 4).

## Impact

Without this fix, agents may:
1. Call identity functions from helpers.sh in OpenCode context (they don't exist there → silent failure)
2. Not know about `plan_for_n_plus_2()`, `chronicle_query()`, etc. → resort to manual reimplementation

Closes #1354
Closes #1339