### PR TITLE
fix: validate issue open-state before adding to visionQueue (issue #1436)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1183,6 +1183,16 @@ NUDGE_EOF
                 done <<< "$kv_pairs"
 
                 if [ -n "$add_issue" ]; then
+                    # Issue #1436: Validate that the referenced issue is open before adding to visionQueue.
+                    # Closed issues should not be added — agents attempting to work on them will fail.
+                    local issue_state
+                    issue_state=$(gh issue view "$add_issue" --repo "$GITHUB_REPO" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                    if [ "$issue_state" != "OPEN" ]; then
+                        echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue is $issue_state — skipping visionQueue add (closed issues cannot be worked)"
+                        vision_queue_patched=true
+                        continue
+                    fi
+
                     local current_vq
                     current_vq=$(kubectl_with_timeout 10 get configmap "$STATE_CM" -n "$NAMESPACE" \
                         -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Add open-state validation in `tally_and_enact_votes()` before adding issues to `visionQueue`
- Closed issues are now skipped with a clear log message instead of being enqueued

## Problem

The governance handler for `vision-feature` proposals was adding issue numbers to `visionQueue` without checking if the referenced GitHub issues were open. This caused closed issues (#1248, #1149) to be enqueued, causing agents to attempt work on resolved issues.

## Changes

In `images/runner/coordinator.sh` `tally_and_enact_votes()` vision-queue handler (~line 1185):

- Added `gh issue view` state check before the deduplication check
- If issue state is not `OPEN`, logs a clear message and skips the `visionQueue` update
- Sets `vision_queue_patched=true` to prevent fallthrough to constitution patch logic

## Testing

Syntax check: `bash -n images/runner/coordinator.sh` — passes.

The fix mirrors the existing pattern at coordinator.sh line 540 where `issue_state` is used to validate issues in the `taskQueue` refresh logic.

Closes #1436