### PR TITLE
fix: normalize visionQueue separator to semicolon in vision-feature handler (closes #1444)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -474,13 +474,15 @@ refresh_task_queue() {
 
         # Issue #1149: Prepend visionQueue items BEFORE taskQueue so agent-voted issues get priority
         # visionQueue contains issues that 3+ agents voted to prioritize via governance
-        # Format: "issueNumber:voteCount" pairs; extract just the issue numbers
+        # Issue #1444: visionQueue uses ";" separator (consistent with vision-queue topic and
+        # request_coordinator_task() which parses with cut -d';' -f1)
         local vision_queue
         vision_queue=$(get_state "visionQueue")
         if [ -n "$vision_queue" ]; then
-            # Extract issue numbers from "issueNumber:voteCount" pairs
+            # Extract issue numbers from semicolon-separated entries (each entry may be just a number
+            # or a feature:description:ts:proposer tuple; extract the first field before ":")
             local vision_issues
-            vision_issues=$(echo "$vision_queue" | tr ',' '\n' | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+            vision_issues=$(echo "$vision_queue" | tr ';' '\n' | cut -d: -f1 | grep -E '^[0-9]+$' | tr '\n' ',' | sed 's/,$//')
             if [ -n "$vision_issues" ]; then
                 # Prepend vision issues, then deduplicate (vision issues appear first)
                 sorted_issues="${vision_issues},${sorted_issues}"
@@ -1188,10 +1190,12 @@ NUDGE_EOF
                         -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
 
                     # Deduplication: only add if not already present
-                    if echo "$current_vq" | tr ',' '\n' | grep -q "^${add_issue}$"; then
+                    # Issue #1444: Use semicolon separator (consistent with vision-queue topic
+                    # and request_coordinator_task() which parses with cut -d';' -f1)
+                    if echo "$current_vq" | tr ';' '\n' | grep -q "^${add_issue}$"; then
                         echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already present, skipping"
                     else
-                        local new_vq="${current_vq:+$current_vq,}${add_issue}"
+                        local new_vq="${current_vq:+$current_vq;}${add_issue}"
                         kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" \
                             --type=merge \
                             -p "{\"data\":{\"visionQueue\":\"$new_vq\"}}" \


### PR DESCRIPTION
## Summary

Fixes visionQueue format inconsistency between the governance handler that adds issue numbers and the code that reads/parses them.

Closes #1444

## Problem

Two different separators were used for `visionQueue` in `coordinator-state`:
- `vision-feature` topic handler: used **comma** (`"1248,1149"`)  
- `vision-queue` topic handler: used **semicolon** (`"feature:desc:ts:agent;..."`)

`request_coordinator_task()` in `entrypoint.sh` always parses with semicolon (`cut -d';' -f1`), so comma-format entries from `vision-feature` votes were processed incorrectly:
- Single item `"1248"`: matched by accident but cleanup code (`grep -q ";"`) silently failed, emptying the full queue on closed-item removal instead of just removing the first item
- Multiple items `"1248,1149"`: `vq_feature="1248,1149"`, failed the `^[0-9]+$` regex, neither issue was ever claimed via the vision-queue priority path

## Changes

- **`tally_and_enact_votes()`** (vision-feature handler): Change comma separator to semicolon when adding issue numbers to `visionQueue`
- **`refresh_task_queue()`**: Update visionQueue parsing to use `tr ';' '\n'` instead of `tr ',' '\n'`, adding a numeric-only filter (`grep -E '^[0-9]+$'`) to skip feature-name entries that aren't issue numbers

## Why This Is Safe

The existing `vision-queue` topic handler already uses semicolon (unchanged). After this fix, both paths write the same format. The `request_coordinator_task()` in `entrypoint.sh` already reads with semicolon separator — no changes needed there.

## Effort

S — 4 lines changed in coordinator.sh