### PR TITLE
fix: add retry logic for gh auth login to handle GitHub API rate limits (closes #1447)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -91,23 +91,41 @@ echo "Minimum vision score (from constitution): $MINIMUM_VISION_SCORE"
 
 # ── Configure GitHub Authentication (issue #6) ───────────────────────────────
 # Read GitHub token from read-only file mount instead of environment variable
+# Issue #1447: gh auth login --with-token uses GraphQL to validate the token.
+# When the GitHub GraphQL rate limit is exceeded at pod startup, auth fails even
+# though the token itself is valid. Fix: retry with exponential backoff.
+gh_auth_with_retry() {
+  local token="$1"
+  local max_attempts=3
+  local delay=30
+  for attempt in $(seq 1 "$max_attempts"); do
+    if echo "$token" | gh auth login --with-token 2>/dev/null; then
+      echo "gh CLI authenticated successfully (attempt $attempt)"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      echo "WARNING: gh auth login failed (attempt $attempt/$max_attempts) — retrying in ${delay}s (GitHub API rate limit may be exceeded)"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+  echo "WARNING: gh auth login failed after $max_attempts attempts - gh commands may not work"
+  return 1
+}
+
 if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
   echo "GitHub token loaded from read-only file mount"
   # Authenticate gh CLI with the token (issue #coordinator-gh-auth)
   # gh auth status checks fail even with GITHUB_TOKEN exported - need explicit login
   if command -v gh &>/dev/null; then
-    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null && \
-      echo "gh CLI authenticated successfully" || \
-      echo "WARNING: gh auth login failed - gh commands may not work"
+    gh_auth_with_retry "$GITHUB_TOKEN" || true
   fi
 elif [ -n "${GITHUB_TOKEN:-}" ]; then
   echo "GitHub token loaded from environment variable (legacy)"
   # Authenticate gh CLI with the token
   if command -v gh &>/dev/null; then
-    echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null && \
-      echo "gh CLI authenticated successfully" || \
-      echo "WARNING: gh auth login failed - gh commands may not work"
+    gh_auth_with_retry "$GITHUB_TOKEN" || true
   fi
 else
   echo "WARNING: No GitHub token available - gh CLI commands will fail"
@@ -2412,6 +2430,19 @@ while true; do
     # NOTE (issue #867): Planner-chain liveness check removed.
     # The planner-loop Deployment now handles planner perpetuation with zero-downtime
     # and no TOCTOU races. Coordinator no longer needs to spawn recovery planners.
+
+    # Every 20 iterations (~10 min): verify gh CLI is still authenticated (issue #1447)
+    # GitHub GraphQL rate limits can expire and cause auth failures mid-run.
+    # Periodic re-auth ensures the coordinator recovers without a pod restart.
+    if [ $((iteration % 20)) -eq 0 ]; then
+        if ! gh auth status &>/dev/null 2>&1; then
+            echo "[$(date -u +%H:%M:%S)] gh CLI auth check FAILED — attempting re-authentication (issue #1447)"
+            if [ -n "${GITHUB_TOKEN:-}" ]; then
+                gh_auth_with_retry "$GITHUB_TOKEN" || \
+                    echo "[$(date -u +%H:%M:%S)] WARNING: gh re-authentication failed — gh commands may not work until next retry"
+            fi
+        fi
+    fi
 
     sleep "$HEARTBEAT_INTERVAL"
 done


### PR DESCRIPTION
## Summary

- Add `gh_auth_with_retry()` function with exponential backoff (3 attempts, 30s/60s delays)
- Replace single-shot `gh auth login` calls at startup with the retry wrapper
- Add periodic re-authentication health check every 20 iterations (~10 min) in main loop

## Problem

The coordinator pod's `gh auth login --with-token` at startup makes a GraphQL API call to validate the token. When GitHub's GraphQL rate limit is exceeded (as happens during high-activity periods with 4000+ agents), this call fails even though the token itself is valid.

This caused the coordinator to run without GitHub CLI access, silently skipping:
- Task queue refresh from GitHub
- PR deduplication checks
- Governance sync PR creation

## Changes

1. **`gh_auth_with_retry()`** — New helper function that retries `gh auth login --with-token` up to 3 times with 30s/60s exponential backoff, giving the rate limit time to reset.

2. **Startup auth** — Both `GITHUB_TOKEN_FILE` and `GITHUB_TOKEN` paths now use `gh_auth_with_retry()`.

3. **Periodic re-auth** — Every 20 iterations (~10 min) in the main loop, checks `gh auth status` and re-authenticates if needed. This allows the coordinator to self-recover after a rate limit resets without requiring a pod restart.

## Testing

Syntax check: `bash -n images/runner/coordinator.sh` — passes.

Closes #1447