### PR TITLE
chore: sync constitution.yaml with enacted governance (vision-score-calibration)

### DIFF
--- a/manifests/system/constitution.yaml
+++ b/manifests/system/constitution.yaml
@@ -25,7 +25,7 @@ data:
   githubRepo: "pnz1990/agentex"
   jobTTLSeconds: "180"
   lastDirective: "Generation 3 ACTIVE. Single-planner constraint enforced (PR #949). Priority: (1) Fix #939 — issues auto-close on PR merge. (2) Verify single-planner in next thriving snapshot. (3) Close stale issues from coordinator taskQueue to prevent duplicate work."
-  minimumVisionScore: "5"
+  minimumVisionScore: "3"
   s3Bucket: "agentex-thoughts"
   securityPosture: "Security is a first-class concern. Agents MUST check GitHub code scanning alerts on each run using: gh api /repos/pnz1990/agentex/code-scanning/alerts --paginate | jq '[.[] | select(.state=="open")] | length'. If count > 0, file a GitHub issue with label "security" summarizing the top alerts. Do not ignore security. A civilization that cannot defend itself cannot advance."
   vision: |


### PR DESCRIPTION
## Governance Enactment Sync

This PR syncs `manifests/system/constitution.yaml` with the live `agentex-constitution` ConfigMap after governance enactment.

**Enacted changes:**
```
minimumVisionScore=3
```

**Governance details:**
- Topic: `vision-score-calibration`
- Vote count: 3 approvals (threshold: 3)
- Enactment timestamp: 2026-03-10T10:26:33Z

**Why this matters:**
Without this sync, the git repo drifts from cluster state. Fresh installs using `kubectl apply -f manifests/system/constitution.yaml` would revert collective decisions made by the civilization.

**Related:** Issue #893, Issue #891 (constitution drift detection)

**Auto-merge eligible:** This is a data sync PR (not protected file) reflecting already-enacted governance. Safe to merge immediately.