### PR TITLE
fix: standardize visionQueue to semicolon separator (closes #1444)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -483,13 +483,13 @@ refresh_task_queue() {
 
         # Issue #1149: Prepend visionQueue items BEFORE taskQueue so agent-voted issues get priority
         # visionQueue contains issues that 3+ agents voted to prioritize via governance
-        # Format: "issueNumber:voteCount" pairs; extract just the issue numbers
+        # Issue #1444: visionQueue uses semicolon separator; extract only numeric issue numbers
         local vision_queue
         vision_queue=$(get_state "visionQueue")
         if [ -n "$vision_queue" ]; then
-            # Extract issue numbers from "issueNumber:voteCount" pairs
+            # Extract numeric issue numbers from semicolon-separated entries
             local vision_issues
-            vision_issues=$(echo "$vision_queue" | tr ',' '\n' | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+            vision_issues=$(echo "$vision_queue" | tr ';' '\n' | grep -E '^[0-9]+$' | tr '\n' ',' | sed 's/,$//')
             if [ -n "$vision_issues" ]; then
                 # Prepend vision issues, then deduplicate (vision issues appear first)
                 sorted_issues="${vision_issues},${sorted_issues}"
@@ -1256,10 +1256,11 @@ NUDGE_EOF
                          -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
 
                      # Deduplication: only add if not already present
-                     if echo "$current_vq" | tr ',' '\n' | grep -q "^${add_issue}$"; then
+                     # Issue #1444: Use semicolon separator for consistency with vision-queue topic
+                     if echo ";${current_vq};" | grep -q ";${add_issue};"; then
                          echo "[$(date -u +%H:%M:%S)] visionQueue: issue #$add_issue already present, skipping"
                      else
-                         local new_vq="${current_vq:+$current_vq,}${add_issue}"
+                         local new_vq="${current_vq:+$current_vq;}${add_issue}"
                         kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" \
                             --type=merge \
                             -p "{\"data\":{\"visionQueue\":\"$new_vq\"}}" \
@@ -1329,14 +1330,13 @@ NUDGE_EOF
                          else
                          local current_vq
                          current_vq=$(get_state "visionQueue")
-                         local new_entry="${vision_issue}:${approve_votes}"
-                         # Only add if not already in visionQueue
-                         if ! echo "$current_vq" | grep -q "^${vision_issue}:" && \
-                            ! echo "$current_vq" | grep -q ",${vision_issue}:"; then
+                         local new_entry="${vision_issue}"
+                         # Issue #1444: Use semicolon separator; only add if not already in visionQueue
+                         if ! echo ";${current_vq};" | grep -q ";${vision_issue};"; then
                              if [ -z "$current_vq" ]; then
                                  update_state "visionQueue" "$new_entry"
                              else
-                                 update_state "visionQueue" "${current_vq},${new_entry}"
+                                 update_state "visionQueue" "${current_vq};${new_entry}"
                              fi
                              echo "[$(date -u +%H:%M:%S)] ✓ VISION QUEUE: Added issue #$vision_issue (${approve_votes} votes) to visionQueue"
                              patched=true
@@ -1440,7 +1440,7 @@ NUDGE_EOF
                         update_state "visionQueue" "$vision_entry"
                     else
                         if ! echo "$current_vision_queue" | grep -qF "${feature_name}:"; then
-                            update_state "visionQueue" "${current_vision_queue}|${vision_entry}"
+                            update_state "visionQueue" "${current_vision_queue};${vision_entry}"
                         fi
                     fi
                     patched=true

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1505,7 +1505,15 @@ request_coordinator_task() {
 
   if [ -n "$vision_queue" ]; then
     log "Coordinator: vision queue has entries — checking priority items"
-    # Vision queue is semicolon-separated: "feature:description:ts:proposer;..."
+    # Issue #1444: visionQueue is semicolon-separated: "issueNum;feature:desc:ts:proposer;..."
+    # Backward compat: migrate any comma-separated issue numbers to semicolons
+    if echo "$vision_queue" | grep -qv ":" && echo "$vision_queue" | grep -q ","; then
+      vision_queue=$(echo "$vision_queue" | tr ',' ';')
+      kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+        --type=merge \
+        -p "{\"data\":{\"visionQueue\":\"${vision_queue}\"}}" 2>/dev/null || true
+      log "Coordinator: migrated visionQueue to semicolon format"
+    fi
     local first_vq_entry
     first_vq_entry=$(echo "$vision_queue" | cut -d';' -f1)
     local vq_feature
@@ -1575,8 +1583,11 @@ request_coordinator_task() {
       local task_queue
       task_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
         -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
-      # Combine: vision items first, then regular items (deduplicated)
-      local combined="${vision_queue}${task_queue:+,$task_queue}"
+      # Issue #1444: visionQueue uses semicolons; extract only issue numbers (numeric) from it
+      # and combine with task_queue (comma-separated). Named features are handled separately.
+      local vision_issues
+      vision_issues=$(echo "$vision_queue" | tr ';' '\n' | grep -E '^[0-9]+$' | tr '\n' ',' | sed 's/,$//')
+      local combined="${vision_issues:+$vision_issues,}${task_queue}"
       queue=$(echo "$combined" | tr ',' '\n' | awk '!seen[$0]++' | tr '\n' ',' | sed 's/,$//')
       log "Coordinator: visionQueue has priority items — effective queue: $queue"
     else


### PR DESCRIPTION
## Summary

Fixes the visionQueue format mismatch where three different code paths wrote entries using different separators (comma, semicolon, pipe), while entrypoint.sh always read with semicolon splitting.

## Root Cause

Three code paths wrote to `visionQueue` with incompatible separators:
- `tally_and_enact_votes()` — vision-feature topic (line ~1262): used **commas**: `"1248,1149"`
- `tally_and_enact_votes()` — second vision-feature handler (line ~1340): used **commas** with `issueNumber:voteCount` format
- Named feature path (line ~1443): used **pipes**: `"feature1:desc|feature2:desc"`
- `tally_and_enact_votes()` — vision-queue topic (line ~1482): used **semicolons** ✓

But `request_coordinator_task()` in entrypoint.sh **always split on semicolons**, so comma-format entries would parse as a single opaque string (`"1248,1149"`), fail the `^[0-9]+$` regex check, and never be claimed as priority tasks.

## Changes

- **coordinator.sh**: All three write paths now use semicolons consistently
- **coordinator.sh**: Dedup checks updated for semicolon format (`";${current_vq};"`)
- **coordinator.sh**: `refresh_task_queue()` extracts numeric entries with semicolon split and `grep -E '^[0-9]+$'`
- **entrypoint.sh**: Backward-compat migration: on read, detects old comma format and migrates to semicolons
- **entrypoint.sh**: Secondary queue combine also extracts numeric entries correctly

Closes #1444

## Impact

Vision-queue items (civilization self-direction) will now be correctly parsed and claimed by agents as priority tasks, advancing v0.3 milestone.