### PR TITLE
fix: use temp files for subprocess-safe audit metric detection (issue #1449)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -611,7 +611,9 @@ parentRef: ${parent_thought_name}"
     local thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
     if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
       # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      # Issue #1449: Also write temp file for subprocess-safe detection (OpenCode bash tool calls)
       export SYNTHESIS_PERSISTED=1
+      touch /tmp/agentex-synthesis-persisted 2>/dev/null || true
     fi
     # Track synthesis contribution in identity specialization (issue #1112)
     if type update_debate_specialization &>/dev/null; then
@@ -1057,7 +1059,9 @@ plan_for_n_plus_2() {
   post_planning_thought "$my_work" "$n1_priority" "$n2_priority"
   
   # Set flag so audit can detect N+2 coordination usage (issue #1283)
+  # Issue #1449: Also write temp file for subprocess-safe detection (OpenCode bash tool calls)
   export N2_PRIORITY_SET=1
+  touch /tmp/agentex-n2-priority-set 2>/dev/null || true
   
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
@@ -3785,8 +3789,11 @@ DEBATE_RESPONSES=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l age
   '[.items[] | select(.data.agentRef == $agent and .data.thoughtType == "debate" and .metadata.creationTimestamp >= $start)] | length' 2>/dev/null || echo "0")
 
 # Check if agent posted a synthesis response persisted to S3 (anti-amnesia behavior)
-# SYNTHESIS_PERSISTED is set by post_debate_response() when record_debate_outcome() succeeds
-SYNTHESIS_PERSISTED_FLAG=$([ -n "${SYNTHESIS_PERSISTED:-}" ] && echo 1 || echo 0)
+# SYNTHESIS_PERSISTED is set by post_debate_response() when record_debate_outcome() succeeds.
+# Issue #1449: Use BOTH env var AND temp file to handle subprocess isolation.
+# OpenCode bash tool calls run in subprocesses — export doesn't propagate to entrypoint.sh.
+# Temp file /tmp/agentex-synthesis-persisted survives subprocess isolation.
+SYNTHESIS_PERSISTED_FLAG=$(( [ -f /tmp/agentex-synthesis-persisted ] || [ -n "${SYNTHESIS_PERSISTED:-}" ] ) && echo 1 || echo 0)
 
 # Check if agent filed vision-aligned issues (enhancement or self-improvement labels)
 VISION_ISSUES=$(gh issue list --repo "$REPO" --state all --author "@me" --limit 50 --json number,createdAt,labels \
@@ -3801,7 +3808,10 @@ PRS_OPENED=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 50 --j
   | jq --arg start "$AGENT_START_ISO" '[.[] | select(.createdAt >= $start)] | length' 2>/dev/null || echo "0")
 
 # Check if agent called plan_for_n_plus_2() — flag set in that function (issue #1283)
-N2_COORDINATION=$([ -n "${N2_PRIORITY_SET:-}" ] && echo 1 || echo 0)
+# Issue #1449: Use BOTH env var AND temp file to handle subprocess isolation.
+# OpenCode bash tool calls run in subprocesses — export doesn't propagate to entrypoint.sh.
+# Temp file /tmp/agentex-n2-priority-set survives subprocess isolation.
+N2_COORDINATION=$(( [ -f /tmp/agentex-n2-priority-set ] || [ -n "${N2_PRIORITY_SET:-}" ] ) && echo 1 || echo 0)
 
 # Compute vision-aligned self-improvement score (issue #1283)
 # Replaces volume-based scoring (issues + PRs) with quality-based metrics:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -191,7 +191,11 @@ parentRef: ${parent_thought_name}"
     thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
     if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
       # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      # Use BOTH env var export AND temp file to handle subprocess isolation (issue #1449):
+      # - env var: works when called within entrypoint.sh bash process directly
+      # - temp file: works when called from OpenCode bash tool subprocess (export doesn't propagate)
       export SYNTHESIS_PERSISTED=1
+      touch /tmp/agentex-synthesis-persisted 2>/dev/null || true
     fi
   fi
 }
@@ -641,6 +645,13 @@ plan_for_n_plus_2() {
   
   # Post thought for immediate peer visibility
   post_planning_thought "$my_work" "$n1_priority" "$n2_priority" "$generation"
+  
+  # Set flag for audit: N+2 coordination was used (issue #1449: subprocess-safe via temp file)
+  # Use BOTH env var export AND temp file to handle subprocess isolation:
+  # - env var: works when called within entrypoint.sh bash process directly
+  # - temp file: works when called from OpenCode bash tool subprocess (export doesn't propagate)
+  export N2_PRIORITY_SET=1
+  touch /tmp/agentex-n2-priority-set 2>/dev/null || true
   
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }


### PR DESCRIPTION
## Summary

Fixes two broken vision-aligned audit metrics in the self-improvement audit (PR #1283).

## Problem

The vision-aligned self-improvement audit introduced two metrics:
- **`SYNTHESIS_PERSISTED`**: tracks if agent synthesized debate and persisted to S3
- **`N2_PRIORITY_SET`**: tracks if agent called `plan_for_n_plus_2()`

Both metrics use `export VAR=1` to signal to the audit code. However, **OpenCode bash tool calls run in subprocesses**, and exported variables from subprocesses do NOT propagate back to the parent `entrypoint.sh` process. This is fundamental Unix process isolation.

Result: Both metrics are permanently 0 for all agents, making 4/10 of the maximum vision audit score unattainable.

## Fix

Use temp files alongside env var exports — the same pattern established by `/tmp/agentex-worked-issue` (issue #1252).

**Changes in 4 locations:**
1. `entrypoint.sh` `post_debate_response()` — add `touch /tmp/agentex-synthesis-persisted`
2. `entrypoint.sh` `plan_for_n_plus_2()` — add `touch /tmp/agentex-n2-priority-set`
3. `helpers.sh` `post_debate_response()` — add `touch /tmp/agentex-synthesis-persisted` (for OpenCode context)
4. `helpers.sh` `plan_for_n_plus_2()` — add `export N2_PRIORITY_SET=1` + `touch /tmp/agentex-n2-priority-set` (helpers.sh was missing the export entirely)

**Audit check updates** (lines ~3789, ~3808):
```bash
# Before (broken — subprocess env vars never propagate):
SYNTHESIS_PERSISTED_FLAG=$([ -n "${SYNTHESIS_PERSISTED:-}" ] && echo 1 || echo 0)

# After (temp file OR env var — works in both contexts):
SYNTHESIS_PERSISTED_FLAG=$(( [ -f /tmp/agentex-synthesis-persisted ] || [ -n "${SYNTHESIS_PERSISTED:-}" ] ) && echo 1 || echo 0)
```

## Impact

Without this fix: agents calling `plan_for_n_plus_2()` and `post_debate_response(... synthesize)` from OpenCode bash tool never get credit in the vision audit — even when they correctly perform multi-generation planning and debate synthesis.

With this fix: vision audit correctly rewards agents for these high-value coordination behaviors.

Closes #1449