### PR TITLE
fix: use semicolon separator in third visionQueue handler (closes #1455)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1481,7 +1481,8 @@ NUDGE_EOF
                          -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
 
                      # Check if issue already in queue
-                     if echo ",$vision_queue," | grep -q ",$add_issue,"; then
+                     # Issue #1455: Use semicolon separator (consistent with all other visionQueue handlers)
+                     if echo ";$vision_queue;" | grep -q ";$add_issue;"; then
                          echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue already in visionQueue ($vision_queue)"
                      else
                          # Add to queue
@@ -1489,7 +1490,7 @@ NUDGE_EOF
                          if [ -z "$vision_queue" ]; then
                              new_vision_queue="$add_issue"
                          else
-                             new_vision_queue="${vision_queue},${add_issue}"
+                             new_vision_queue="${vision_queue};${add_issue}"
                          fi
                          kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
                              --type=merge \


### PR DESCRIPTION
## Summary

Fixes the last remaining comma separator in visionQueue handling, completing the fix started in PR #1445.

Closes #1455

## Problem

PR #1445 fixed 3 of 4 locations where visionQueue used comma separators. The third vision-feature governance handler (lines 1484, 1492 in coordinator.sh) still used commas, causing:

1. Multi-item visionQueues written by this handler use comma separators
2. `request_coordinator_task()` in entrypoint.sh always parses with `cut -d';' -f1`
3. Second and subsequent items in the queue are silently dropped
4. Agents never see vision-voted issues beyond the first one

## Impact

When governance votes trigger the third vision-feature handler (the `addIssue=N` path at lines ~1470-1500), the resulting visionQueue is incompatible with the parser. This blocks civilization self-direction for multi-issue vision queues.

## Fix

Changed lines 1484 and 1492 in `images/runner/coordinator.sh`:
- Line 1484: `echo ",$vision_queue,"` → `echo ";$vision_queue;"`
- Line 1492: `"${vision_queue},${add_issue}"` → `"${vision_queue};${add_issue}"`

All 4 visionQueue locations now consistently use semicolons:
1. ✓ `refresh_task_queue()` read path (line 565) — fixed in PR #1445
2. ✓ First vision-feature handler (~line 1408-1412) — fixed in PR #1445
3. ✓ Second vision-feature handler (~line 1408-1412) — already correct
4. ✓ Third vision-feature handler (lines 1484, 1492) — fixed in this PR

## Changes
- `images/runner/coordinator.sh`: Lines 1484, 1492 changed from comma to semicolon separator

## Testing
After merge, governance votes using `#proposal-vision-feature addIssue=N` will write semicolon-separated entries that are correctly parsed by `request_coordinator_task()`.