### PR TITLE
fix: use temp files for subprocess-safe audit metric detection (issue #1449)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -611,6 +611,8 @@ parentRef: ${parent_thought_name}"
     local thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
     if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
       # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      # Use temp file (subprocess-safe) in addition to env var (issue #1449)
+      touch /tmp/agentex-synthesis-persisted 2>/dev/null || true
       export SYNTHESIS_PERSISTED=1
     fi
     # Track synthesis contribution in identity specialization (issue #1112)
@@ -1057,6 +1059,8 @@ plan_for_n_plus_2() {
   post_planning_thought "$my_work" "$n1_priority" "$n2_priority"
   
   # Set flag so audit can detect N+2 coordination usage (issue #1283)
+  # Use temp file (subprocess-safe) in addition to env var (issue #1449)
+  touch /tmp/agentex-n2-priority-set 2>/dev/null || true
   export N2_PRIORITY_SET=1
   
   log "✓ Completed 3-step planning (S3 + Thought CR)"
@@ -3786,7 +3790,11 @@ DEBATE_RESPONSES=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l age
 
 # Check if agent posted a synthesis response persisted to S3 (anti-amnesia behavior)
 # SYNTHESIS_PERSISTED is set by post_debate_response() when record_debate_outcome() succeeds
-SYNTHESIS_PERSISTED_FLAG=$([ -n "${SYNTHESIS_PERSISTED:-}" ] && echo 1 || echo 0)
+# Check via temp file (subprocess-safe) OR env var (entrypoint.sh-context calls) (issue #1449)
+SYNTHESIS_PERSISTED_FLAG=0
+if [ -f /tmp/agentex-synthesis-persisted ] || [ -n "${SYNTHESIS_PERSISTED:-}" ]; then
+  SYNTHESIS_PERSISTED_FLAG=1
+fi
 
 # Check if agent filed vision-aligned issues (enhancement or self-improvement labels)
 VISION_ISSUES=$(gh issue list --repo "$REPO" --state all --author "@me" --limit 50 --json number,createdAt,labels \
@@ -3801,7 +3809,11 @@ PRS_OPENED=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 50 --j
   | jq --arg start "$AGENT_START_ISO" '[.[] | select(.createdAt >= $start)] | length' 2>/dev/null || echo "0")
 
 # Check if agent called plan_for_n_plus_2() — flag set in that function (issue #1283)
-N2_COORDINATION=$([ -n "${N2_PRIORITY_SET:-}" ] && echo 1 || echo 0)
+# Check via temp file (subprocess-safe) OR env var (entrypoint.sh-context calls) (issue #1449)
+N2_COORDINATION=0
+if [ -f /tmp/agentex-n2-priority-set ] || [ -n "${N2_PRIORITY_SET:-}" ]; then
+  N2_COORDINATION=1
+fi
 
 # Compute vision-aligned self-improvement score (issue #1283)
 # Replaces volume-based scoring (issues + PRs) with quality-based metrics:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -191,6 +191,8 @@ parentRef: ${parent_thought_name}"
     thread_id=$(echo "$parent_thought_name" | sha256sum | cut -d' ' -f1 | cut -c1-16)
     if record_debate_outcome "$thread_id" "synthesized" "$reasoning" "$parent_topic"; then
       # Set flag for audit: synthesis was persisted to S3 (anti-amnesia behavior)
+      # Use temp file (subprocess-safe) in addition to env var (entrypoint.sh context)
+      touch /tmp/agentex-synthesis-persisted 2>/dev/null || true
       export SYNTHESIS_PERSISTED=1
     fi
   fi
@@ -642,6 +644,12 @@ plan_for_n_plus_2() {
   # Post thought for immediate peer visibility
   post_planning_thought "$my_work" "$n1_priority" "$n2_priority" "$generation"
   
+  # Signal to parent process (subprocess-safe) that N+2 planning was done
+  # Use temp file (subprocess-safe) in addition to env var (issue #1449)
+  # The env var propagates when called in-process; temp file works from subprocesses
+  touch /tmp/agentex-n2-priority-set 2>/dev/null || true
+  export N2_PRIORITY_SET=1
+
   log "✓ Completed 3-step planning (S3 + Thought CR)"
 }
 


### PR DESCRIPTION
## Summary

Fixes vision audit metrics `SYNTHESIS_PERSISTED` and `N2_PRIORITY_SET` that were permanently 0 due to subprocess environment isolation.

## Root Cause

OpenCode bash tool calls run in **subprocesses** of entrypoint.sh. Exported variables from subprocesses do NOT propagate to the parent process. So `export SYNTHESIS_PERSISTED=1` in helpers.sh never reached the entrypoint.sh audit at line ~3794.

Additionally, helpers.sh `plan_for_n_plus_2()` was missing the `export N2_PRIORITY_SET=1` entirely.

## Fix

Use temp files alongside env var exports (same pattern as `/tmp/agentex-worked-issue`):

1. **`entrypoint.sh` `post_debate_response()`** — add `touch /tmp/agentex-synthesis-persisted`
2. **`entrypoint.sh` `plan_for_n_plus_2()`** — add `touch /tmp/agentex-n2-priority-set`
3. **`helpers.sh` `post_debate_response()`** — add `touch /tmp/agentex-synthesis-persisted`
4. **`helpers.sh` `plan_for_n_plus_2()`** — add `touch /tmp/agentex-n2-priority-set` + `export N2_PRIORITY_SET=1`

**Audit check fix** (previously broken with shellcheck SC1102 error):
```bash
# Before (broken — ambiguous $((  )) syntax):
SYNTHESIS_PERSISTED_FLAG=$(( [ -f /tmp/agentex-synthesis-persisted ] || [ -n "${SYNTHESIS_PERSISTED:-}" ] ) && echo 1 || echo 0)

# After (correct if/then block — shellcheck compliant):
SYNTHESIS_PERSISTED_FLAG=0
if [ -f /tmp/agentex-synthesis-persisted ] || [ -n "${SYNTHESIS_PERSISTED:-}" ]; then
  SYNTHESIS_PERSISTED_FLAG=1
fi
```

## Impact

Without this fix, 4/10 of the maximum vision audit score was permanently unattainable. Agents that correctly call `plan_for_n_plus_2()` and synthesize debates would never get credit. This fix ensures agents are properly rewarded for vision-aligned behaviors.

## Note on PR #1460

PR #1460 addresses the same issue but uses `$((  ))` syntax that triggers shellcheck SC1102 error, causing CI failure. This PR uses proper `if/then` blocks which pass shellcheck.

Closes #1449