### PR TITLE
fix: use printf in update_state() to prevent trailing space on numeric values (closes #1470)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -317,7 +317,12 @@ update_state() {
     # in JSON. Embedded newlines cause 'invalid character \n in string literal' errors that are
     # swallowed by 2>/dev/null, causing silent failures (e.g., enactedDecisions never updated).
     local safe_value
-    safe_value=$(echo "$value" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
+    # Issue #1470: Use printf instead of echo to avoid appending a trailing newline.
+    # echo "$value" always appends \n; tr '\n\r' '  ' converts that \n to a space,
+    # causing numeric values like "6" to become "6 " (with trailing space).
+    # This broke spawnSlots: "6 " fails the ^[0-9]+$ regex, triggering the
+    # ALERT: spawnSlots invalid warning on every coordinator iteration.
+    safe_value=$(printf '%s' "$value" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
     kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" \
         --type=merge -p "{\"data\":{\"$field\":\"$safe_value\"}}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Replaces `echo "$value"` with `printf '%s' "$value"` in `update_state()` (coordinator.sh line 320)
- `echo` always appends a trailing newline; `tr '\n\r' '  '` converts that `\n` to a space
- Result: numeric values like `6` were stored as `6 ` (with trailing space) in coordinator-state

Closes #1470

## Root Cause

`update_state()` sanitizes values using:
```bash
safe_value=$(echo "$value" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
```

`echo "$value"` appends `\n`. `tr '\n\r' '  '` converts `\n` → space. `tr -s ' '` squeezes but keeps the trailing space. Result: `"6"` → `"6 "`.

## Impact

`spawnSlots` was stored as `"6 "` instead of `"6"` after every `reconcile_spawn_slots()` call. The coordinator's fast-path check on line 2412:
```bash
if [ -z "$spawn_slots_now" ] || ! [[ "$spawn_slots_now" =~ ^[0-9]+$ ]]; then
```
fails for `"6 "` (trailing space not matched by `[0-9]+`), causing:
- `ALERT: spawnSlots='6 ' is invalid` logged every 30s
- `reconcile_spawn_slots()` runs unnecessarily every cycle
- CAS operations in `request_spawn_slot()` / `release_spawn_slot()` potentially fail

## Fix

Use `printf '%s'` which does NOT append a trailing newline. Multi-line values (e.g., planning thoughts) still work correctly: any embedded newlines in `$value` are still converted to spaces by `tr`.

## Test

```bash
printf '%s' "6" | tr '\n\r' '  ' | tr -s ' ' | cat -A
# Output: 6$   ← no trailing space
echo "6" | tr '\n\r' '  ' | tr -s ' ' | cat -A
# Output: 6 $  ← trailing space (old behavior)
```