### PR TITLE
fix: pre-claim specialization routing so route_tasks_by_specialization() actually fires

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2212,12 +2212,47 @@ route_tasks_by_specialization() {
         best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels")
 
         if [ -n "$best_agent" ]; then
-            # Record specialized routing decision in coordinator state
-            local routing_entry="${issue_num}:${best_agent}"
-            routing_log="${routing_log}${routing_entry};"
-            specialized_count=$((specialized_count + 1))
-            push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
-            echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num → $best_agent"
+            # Pre-claim the issue on behalf of the best agent using CAS on activeAssignments.
+            # This ensures the routing decision is actionable — the agent will find its
+            # assignment when it calls request_coordinator_task() and claim_task() will
+            # succeed (issue already in activeAssignments as agent:issue). Without this,
+            # workers race to claim tasks before routing runs and routing never fires.
+            # (issue #1474: route_tasks_by_specialization() never fired because workers
+            #  claimed tasks before routing ran — fix: coordinator pre-claims on agent behalf)
+            local current_assignments
+            current_assignments=$(get_state "activeAssignments")
+            local pre_claim_entry="${best_agent}:${issue_num}"
+
+            # Only pre-claim if not already in activeAssignments (idempotent)
+            if ! echo ",${current_assignments}," | grep -q ",${pre_claim_entry},"; then
+                local new_assignments
+                if [ -z "$current_assignments" ]; then
+                    new_assignments="$pre_claim_entry"
+                else
+                    new_assignments="${current_assignments},${pre_claim_entry}"
+                fi
+                # Atomic CAS to prevent races with concurrent claim_task() calls
+                local cas_patch
+                if [ -z "$current_assignments" ]; then
+                    cas_patch="[{\"op\":\"add\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]"
+                else
+                    cas_patch="[{\"op\":\"test\",\"path\":\"/data/activeAssignments\",\"value\":\"${current_assignments}\"},{\"op\":\"replace\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]"
+                fi
+                if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+                    --type=json -p "${cas_patch}" 2>/dev/null; then
+                    echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: pre-claimed issue #$issue_num for $best_agent (assignments: $new_assignments)"
+                    # Record specialized routing decision in coordinator state
+                    local routing_entry="${issue_num}:${best_agent}"
+                    routing_log="${routing_log}${routing_entry};"
+                    specialized_count=$((specialized_count + 1))
+                    push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
+                else
+                    echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: CAS failed for issue #$issue_num → $best_agent (concurrent modification) — falling back to generic"
+                    generic_count=$((generic_count + 1))
+                fi
+            else
+                echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num already pre-claimed for $best_agent — skipping"
+            fi
         else
             generic_count=$((generic_count + 1))
         fi

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1499,6 +1499,57 @@ request_coordinator_task() {
   local max_retries=3
   local retry=0
 
+  # ── COORDINATOR PRE-ASSIGNMENT CHECK (issue #1474) ───────────────────────
+  # Check if the coordinator's routing cycle has pre-assigned an issue to THIS
+  # agent before the generic queue scan. This is how specialization routing
+  # actually fires: route_tasks_by_specialization() writes agent:issue into
+  # activeAssignments on the agent's behalf; we detect it here and return it
+  # directly, bypassing the first-come-first-served generic queue race.
+  #
+  # Without this check, workers would see the pre-claim as "already taken" and
+  # skip to the next issue — the opposite of the intended routing behavior.
+  local pre_assignments
+  pre_assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+  if [ -n "$pre_assignments" ]; then
+    # Look for an entry of form "AGENT_NAME:ISSUE_NUMBER" in the assignments
+    local pre_assigned_issue
+    pre_assigned_issue=$(echo "$pre_assignments" | tr ',' '\n' | grep "^${AGENT_NAME}:" | head -1 | cut -d: -f2 || true)
+    if [ -n "$pre_assigned_issue" ] && [ "$pre_assigned_issue" != "0" ]; then
+      # Coordinator pre-assigned this issue via specialization routing — return it directly
+      log "Coordinator: found pre-assigned issue #$pre_assigned_issue for $AGENT_NAME (specialization routing)"
+      # Write to temp file for end-of-session specialization tracking (issue #1252)
+      echo "$pre_assigned_issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+      # Cache issue labels at claim time (issue #1268)
+      local pre_labels
+      pre_labels=$(gh issue view "$pre_assigned_issue" --repo "${REPO}" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+      if [ -n "$pre_labels" ]; then
+        local existing_labels_cache
+        existing_labels_cache=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+          -o jsonpath='{.data.issueLabels}' 2>/dev/null || echo "")
+        local updated_cache
+        updated_cache=$(echo "$existing_labels_cache" | tr '|' '\n' | grep -v "^${pre_assigned_issue}:" || true)
+        updated_cache=$(echo "${updated_cache}" | tr '\n' '|' | sed 's/|$//')
+        [ -n "$updated_cache" ] && updated_cache="${updated_cache}|${pre_assigned_issue}:${pre_labels}" || updated_cache="${pre_assigned_issue}:${pre_labels}"
+        kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+          --type=merge -p "{\"data\":{\"issueLabels\":\"${updated_cache}\"}}" 2>/dev/null || true
+      fi
+      # Validate issue is still open
+      local pre_issue_state
+      pre_issue_state=$(gh issue view "$pre_assigned_issue" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+      if [ "$pre_issue_state" = "OPEN" ]; then
+        push_metric "SpecializedPreAssignmentClaimed" 1
+        COORDINATOR_ISSUE="$pre_assigned_issue"
+        return 0
+      else
+        log "Coordinator: pre-assigned issue #$pre_assigned_issue is $pre_issue_state — releasing pre-claim"
+        release_coordinator_task "$pre_assigned_issue"
+        # Fall through to normal queue
+      fi
+    fi
+  fi
+
   # ── VISION QUEUE PRIORITY CHECK (issue #1149) ────────────────────────────
   # Check vision queue BEFORE the regular task queue. If a vision-queue item
   # is a GitHub issue number, claim it. If it's a feature name, log it for the


### PR DESCRIPTION
## Summary

Fixes #1474 — `route_tasks_by_specialization()` never fired in production because workers claimed all available tasks before the routing cycle ran.

## Root Cause

The coordinator's routing function (`route_tasks_by_specialization()`) runs every 7 iterations (~3.5 min). By that time, workers had already called `claim_task()` and written their assignments into `activeAssignments`. The routing function skips already-assigned issues, finds nothing to route, and `specializedAssignments` stays 0 forever.

This is a **timing/design flaw**: the routing is purely analytical (records recommendations in `lastRoutingDecisions`) but workers never check `lastRoutingDecisions` before claiming tasks.

## Fix

**Option A from issue**: Coordinator pre-claims issues on behalf of best agents (atomic, CAS-based).

### Changes

**`coordinator.sh`**: In `route_tasks_by_specialization()`, when `find_best_agent_for_issue()` returns a match, immediately write `agent:issue` into `activeAssignments` via CAS patch. This reserves the issue for the specialized worker *before* generic claiming can race.

**`entrypoint.sh`**: Add pre-assignment check at the start of `request_coordinator_task()`. If the coordinator has pre-assigned an issue to this agent (found as `AGENT_NAME:ISSUE` in `activeAssignments`), return it directly without scanning the generic queue.

## Flow After Fix

1. Worker registers with coordinator (activeAgents)
2. Worker calls `request_coordinator_task()` 
3. **NEW**: Check if coordinator pre-assigned an issue → return it immediately if found
4. Every 7 iterations, coordinator routing fires → finds active worker with specialization data
5. Coordinator pre-claims issue via CAS on `activeAssignments`
6. Worker (starting a new session) hits step 3 → gets its pre-assigned specialized issue
7. `specializedAssignments` increments → v0.2 milestone validated

## Impact

This unblocks the v0.2 milestone: `specializedAssignments > 0` will now happen when specialized workers are active and matching issues are in the queue. Closes the path to emergent specialization (issue #1098).

## Related

- Issue #1475 (identity lookup by displayName) is a separate concern — this fix addresses the timing/design flaw, not the identity mapping problem
- Issue #1098 (emergent specialization) — this is the unblocking fix
- Issue #1145 (v0.2 milestone validation) — `specializedAssignments` will now increment