### PR TITLE
perf: eliminate N redundant get_state calls in find_best_agent_for_issue (closes #1478)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2104,10 +2104,12 @@ extract_issue_keywords() {
 # Arguments:
 #   $1 - issue_number
 #   $2 - issue_labels (comma-separated)
+#   $3 - active_assignments (pre-fetched from caller to avoid redundant kubectl calls, issue #1478)
 # Returns: best agent name if score > threshold, empty string otherwise
 find_best_agent_for_issue() {
     local issue_number="$1"
     local issue_labels="$2"
+    local active_assignments="${3:-}"  # Issue #1478: passed from caller to avoid N redundant get_state calls
 
     # Get active agents
     local active_agents
@@ -2115,6 +2117,11 @@ find_best_agent_for_issue() {
     if [ -z "$active_agents" ]; then
         echo ""
         return 0
+    fi
+
+    # If caller didn't pass active_assignments, fetch once here (fallback for direct calls)
+    if [ -z "$active_assignments" ]; then
+        active_assignments=$(get_state "activeAssignments")
     fi
 
     # Extract issue keywords (limit API calls by calling once)
@@ -2134,9 +2141,8 @@ find_best_agent_for_issue() {
         [ "$agent_role" != "worker" ] && continue
 
         # Don't route to agents that already have assignments
-        local assignments
-        assignments=$(get_state "activeAssignments")
-        if echo "$assignments" | grep -q "${agent_name}:"; then
+        # Issue #1478: use pre-fetched active_assignments instead of calling get_state N times
+        if echo "$active_assignments" | grep -q "${agent_name}:"; then
             continue
         fi
 
@@ -2213,8 +2219,9 @@ route_tasks_by_specialization() {
         fi
 
         # Find best specialized agent
+        # Issue #1478: pass active_assignments to avoid N redundant get_state calls inside find_best_agent_for_issue
         local best_agent
-        best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels")
+        best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels" "$active_assignments")
 
         if [ -n "$best_agent" ]; then
             # Record specialized routing decision in coordinator state


### PR DESCRIPTION
## Summary

Fixes redundant `get_state(\"activeAssignments\")` calls inside the per-agent inner loop of `find_best_agent_for_issue()`.

Closes #1478

## Problem

`route_tasks_by_specialization()` already fetches `activeAssignments` once before the routing loop (line ~2181). However, `find_best_agent_for_issue()` called `get_state("activeAssignments")` again inside its own inner per-agent loop — causing **N redundant kubectl API calls** per routing cycle, where N = number of active agents.

```bash
# Before fix: N redundant get_state calls inside loop
for pair in "${agent_pairs[@]}"; do
    ...
    local assignments
    assignments=$(get_state "activeAssignments")  # ← called N times!
    if echo "$assignments" | grep -q "${agent_name}:"; then
        continue
    fi
done
```

## Fix

Pass `active_assignments` as a 3rd parameter from `route_tasks_by_specialization()` to `find_best_agent_for_issue()`. The inner function uses the pre-fetched value instead of re-issuing `get_state()` calls.

```bash
# After fix: active_assignments passed from caller, used in loop
find_best_agent_for_issue() {
    local active_assignments="${3:-}"  # pre-fetched from caller
    ...
    if [ -z "$active_assignments" ]; then
        active_assignments=$(get_state "activeAssignments")  # fallback for direct calls
    fi
    for pair in "${agent_pairs[@]}"; do
        ...
        if echo "$active_assignments" | grep -q "${agent_name}:"; then  # uses pre-fetched value
            continue
        fi
    done
}
```

## Changes

- `find_best_agent_for_issue()`: added `$3 active_assignments` parameter with fallback for backward-compat
- `route_tasks_by_specialization()`: passes pre-fetched `active_assignments` to `find_best_agent_for_issue()`
- Reduced kubectl API calls per routing cycle by N (number of active workers)