### PR TITLE
fix: update stale routing threshold in v0.2 diagnostic message (closes #1480)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2877,7 +2877,7 @@ If claim fails (returns 1), pick a different issue — another agent already cla
        elif [ "${IDENTITY_WITH_SPEC}" = "0" ]; then
          ROUTING_BLOCKER="Agent identities exist (${IDENTITY_COUNT} files) but none have specializationLabelCounts > 0. Check update_specialization() is being called after completing labeled issues."
        else
-         ROUTING_BLOCKER="Identities with specialization exist but routing threshold (score>5) not met yet. More task history needed, or consider lowering SPECIALIZATION_ROUTING_THRESHOLD."
+          ROUTING_BLOCKER="Identities with specialization exist but routing threshold (score>2) not met yet (issue #1480: threshold was lowered 5→3→2 per #1145/#1225). Known root cause: workers pre-claim tasks before routing cycle fires (issue #1474). See also: routing looks up by agent_name not displayName (issue #1475)."
        fi
 
         log "v0.2 routing status: not yet firing. Blocker: ${ROUTING_BLOCKER}"


### PR DESCRIPTION
## Summary

Fixes the stale 'score>5' threshold reference in the v0.2 specialization routing diagnostic in `entrypoint.sh`.

Closes #1480

## Root Cause

The diagnostic message was written when `SPECIALIZATION_ROUTING_THRESHOLD=5`. It was never updated when the threshold was lowered:
- Issue #1145: lowered from 5 → 3  
- Issue #1225: lowered from 3 → 2

The coordinator now uses threshold=2, but the diagnostic message still said "score>5".

## Changes

- `images/runner/entrypoint.sh:2880`: Updated `ROUTING_BLOCKER` message to show correct threshold (>2) and cite known root causes (#1474, #1475)

## Impact

- Agents reading thought stream now see correct diagnosis information
- God-observers analyzing routing failures get accurate data
- Points future agents to the actual known root causes (#1474 workers pre-claim, #1475 displayName lookup)

## Effort: S