### PR TITLE
fix: release identity names back to registry on agent completion (closes #1483)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4053,10 +4053,27 @@ if type update_specialization &>/dev/null && [ -n "${WORKED_ISSUE:-}" ] && [ "$W
       log "WARNING: GitHub API unavailable for label fetch on issue #$WORKED_ISSUE — specialization not updated (issue #1268)"
     fi
   fi
-  if [ -n "$WORKED_LABELS" ]; then
-    update_specialization "$WORKED_LABELS" 2>/dev/null || true
-    log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"
-  fi
+   if [ -n "$WORKED_LABELS" ]; then
+     update_specialization "$WORKED_LABELS" 2>/dev/null || true
+     log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"
+   fi
+fi
+
+# ── 11.4. RELEASE IDENTITY NAME (issue #1483) ────────────────────────────────
+# Release the claimed display name back to the registry AFTER all identity stats
+# are saved to S3. This allows the NEXT agent to claim the same display name and
+# inherit the accumulated specializationLabelCounts, codeAreas, and stats.
+#
+# Without this step, all 12 worker name slots become permanently claimed after
+# the first 12 agents, and every subsequent agent gets a generated name with an
+# empty identity file — blocking specialization accumulation across generations.
+#
+# IMPORTANT: release_identity() is defined in identity.sh and sourced at startup.
+# It only releases names claimed from the registry (not generated names).
+if type release_identity &>/dev/null; then
+  release_identity 2>/dev/null || true
+else
+  log "WARNING: release_identity function not available — name will remain claimed"
 fi
 
 # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────
@@ -4348,6 +4365,43 @@ fi
 # Only planners do this cleanup (to avoid redundant work from every agent).
 if [ "$AGENT_ROLE" = "planner" ]; then
   log "Cleaning up old completed Agent CRs (issue #443)..."
+
+  # ── 13.5a. Name registry stale claim cleanup (issue #1483) ───────────────
+  # Release name registry slots claimed by agents whose Jobs no longer exist.
+  # This recovers slots that were permanently claimed when agents exited before
+  # release_identity() was added (backfill for pre-fix agents).
+  log "Checking name registry for stale claims (issue #1483)..."
+  REGISTRY_JSON=$(kubectl_with_timeout 10 get configmap agentex-name-registry -n agentex -o json 2>/dev/null || echo "")
+  if [ -n "$REGISTRY_JSON" ]; then
+    STALE_RELEASED=0
+    # Find all "role:claimed:agent-name" entries
+    CLAIMED_ENTRIES=$(echo "$REGISTRY_JSON" | jq -r '.data | to_entries | .[] | select(.value | test(":claimed:")) | "\(.key)=\(.value)"' 2>/dev/null || echo "")
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      reg_name="${entry%%=*}"
+      reg_value="${entry#*=}"
+      claimed_agent="${reg_value##*:claimed:}"
+      claimed_role="${reg_value%%:claimed:*}"
+      # Check if the claimed agent's Job still exists and is active
+      job_exists=$(kubectl_with_timeout 10 get job "$claimed_agent" -n "$NAMESPACE" 2>/dev/null && echo "yes" || echo "no")
+      if [ "$job_exists" = "no" ]; then
+        # Job gone — release the name back to the pool
+        if kubectl_with_timeout 10 patch configmap agentex-name-registry -n agentex \
+          --type=json \
+          -p "[{\"op\":\"replace\",\"path\":\"/data/${reg_name}\",\"value\":\"${claimed_role}:available\"}]" \
+          2>/dev/null; then
+          log "Released stale name claim: $reg_name (was claimed by dead agent $claimed_agent)"
+          STALE_RELEASED=$((STALE_RELEASED + 1))
+        fi
+      fi
+    done <<< "$CLAIMED_ENTRIES"
+    if [ "$STALE_RELEASED" -gt 0 ]; then
+      log "Released $STALE_RELEASED stale name registry claims — pool partially restored"
+      post_thought "Name registry maintenance: released $STALE_RELEASED stale claims from dead agents. Registry pool now has available slots for new agents. (issue #1483)" "observation" 8 "maintenance"
+    else
+      log "Name registry: no stale claims found (all claimed names have active Jobs)"
+    fi
+  fi
   
   # Find Agent CRs older than 1 hour that have completed Jobs
   # Use a simple timestamp-based approach for robustness

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -537,6 +537,58 @@ get_identity_signature() {
 # Initialize identity system
 # Call this from entrypoint.sh at startup
 #######################################
+#######################################
+# Release the claimed display name back to the registry pool.
+# Called from entrypoint.sh exit cleanup AFTER save_identity() has persisted
+# the final stats to S3. This allows the next agent to claim the same name
+# and inherit the accumulated specializationLabelCounts and codeAreas.
+#
+# Without this function, all 12 worker name slots become permanently claimed
+# after the first 12 workers, and every subsequent worker gets a generated
+# name (worker-<adj>-<noun>) with an empty S3 identity file. This permanently
+# blocks specialization accumulation across generations (issue #1483).
+#
+# Safety: only releases names that are in the registry (i.e., were claimed via
+# claim_identity(), not generated via generate_identity()). Generated names
+# like "worker-bold-tensor" are not in the registry and are silently skipped.
+#
+# Globals:
+#   AGENT_DISPLAY_NAME - the name to release
+#   AGENT_ROLE - used to set the "available" value correctly
+#######################################
+release_identity() {
+  local name="${AGENT_DISPLAY_NAME:-}"
+  if [[ -z "$name" ]]; then
+    echo "[identity] release_identity: no display name set, skipping"
+    return 0
+  fi
+
+  # Check if this name exists in the registry and is claimed by us
+  local registry_value
+  registry_value=$(timeout 10s kubectl get configmap agentex-name-registry -n agentex \
+    -o jsonpath="{.data.${name}}" 2>/dev/null || echo "")
+
+  if [[ -z "$registry_value" ]]; then
+    echo "[identity] release_identity: name $name not in registry (generated name), skipping"
+    return 0
+  fi
+
+  if ! echo "$registry_value" | grep -q ":claimed:"; then
+    echo "[identity] release_identity: name $name is not claimed (value: $registry_value), skipping"
+    return 0
+  fi
+
+  # Atomically release: replace "role:claimed:agent" with "role:available"
+  if timeout 10s kubectl patch configmap agentex-name-registry -n agentex \
+    --type=json \
+    -p "[{\"op\":\"replace\",\"path\":\"/data/${name}\",\"value\":\"${AGENT_ROLE}:available\"}]" \
+    2>/dev/null; then
+    echo "[identity] Released name $name back to registry (role: $AGENT_ROLE)"
+  else
+    echo "[identity] WARNING: Failed to release name $name — will remain claimed"
+  fi
+}
+
 init_identity() {
   echo "[identity] Initializing agent identity system..."
   


### PR DESCRIPTION
Fixes root cause of v0.2 emergent specialization never working: all 12 worker name slots permanently claimed. Added release_identity() to identity.sh and step 11.4 + 13.5a to entrypoint.sh. Closes #1483