### PR TITLE
fix: specialization routing uses displayName for S3 identity lookup

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2003,11 +2003,21 @@ score_agent_for_issue() {
     local issue_number="$2"
     local issue_labels="$3"
     local issue_keywords="$4"
+    local display_name="${5:-$agent_name}"  # Issue #1475: use displayName for S3 lookup (default to agent_name for backward compat)
 
     # Read agent identity from S3
+    # Issue #1475: Workers are ephemeral (new agent_name each pod) but displayNames persist.
+    # Specialization history accumulates under displayName.json, not agent_name.json.
+    # Try displayName first, fall back to agent_name for backward compatibility.
     local identity_json
-    identity_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${agent_name}.json" - \
+    identity_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${display_name}.json" - \
         --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+    
+    # Fallback: try agent_name if displayName lookup fails (backward compat)
+    if [ -z "$identity_json" ]; then
+        identity_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${agent_name}.json" - \
+            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+    fi
 
     if [ -z "$identity_json" ]; then
         echo "0"
@@ -2135,7 +2145,16 @@ find_best_agent_for_issue() {
     for pair in "${agent_pairs[@]}"; do
         [ -z "$pair" ] && continue
         local agent_name="${pair%%:*}"
-        local agent_role="${pair##*:}"
+        # Issue #1475: Parse displayName from 3rd field (format: agent_name:role:displayName)
+        # Backward compat: if only 2 fields, displayName == agent_name
+        local display_name
+        if [[ "$pair" =~ .*:.+:.+ ]]; then
+            display_name=$(echo "$pair" | cut -d: -f3)
+        else
+            display_name="$agent_name"
+        fi
+        local agent_role
+        agent_role=$(echo "$pair" | cut -d: -f2)
 
         # Only consider worker agents for specialization routing
         [ "$agent_role" != "worker" ] && continue
@@ -2148,7 +2167,7 @@ find_best_agent_for_issue() {
 
         local agent_score
         agent_score=$(score_agent_for_issue "$agent_name" "$issue_number" \
-            "$issue_labels" "$issue_keywords")
+            "$issue_labels" "$issue_keywords" "$display_name")
 
         echo "[$(date -u +%H:%M:%S)] Specialization score for $agent_name on issue #$issue_number: $agent_score" >&2
 
@@ -2288,11 +2307,26 @@ route_tasks_by_specialization() {
             [ -z "$aname" ] && continue
             agents_checked=$((agents_checked + 1))
 
+            # Issue #1475: Also check displayName for specialization data
+            local dname
+            if [[ "$pair" =~ .*:.+:.+ ]]; then
+                dname=$(echo "$pair" | cut -d: -f3)
+            else
+                dname="$aname"
+            fi
+
             local spec_data
-            spec_data=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${aname}.json" - \
+            # Try displayName first, fall back to agent_name
+            spec_data=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${dname}.json" - \
                 --region "$BEDROCK_REGION" 2>/dev/null | \
                 jq -r 'if (.specializationLabelCounts | length) > 0 then "yes" else "" end' \
                 2>/dev/null || echo "")
+            if [ -z "$spec_data" ]; then
+                spec_data=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${aname}.json" - \
+                    --region "$BEDROCK_REGION" 2>/dev/null | \
+                    jq -r 'if (.specializationLabelCounts | length) > 0 then "yes" else "" end' \
+                    2>/dev/null || echo "")
+            fi
             if [ -n "$spec_data" ]; then
                 agents_with_spec=$((agents_with_spec + 1))
             fi

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1752,16 +1752,22 @@ register_with_coordinator() {
   current=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
     -o jsonpath='{.data.activeAgents}' 2>/dev/null || echo "")
 
+  # Issue #1475: Include displayName as 3rd field for specialization routing.
+  # Workers are ephemeral (new agent_name each pod) but displayNames persist.
+  # Format: agent_name:role:displayName
+  # Backward compat: coordinator parser treats 2-field entries as displayName==agent_name
+  local display_name="${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
+
   local new_val
   if [ -z "$current" ]; then
-    new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    new_val="${AGENT_NAME}:${AGENT_ROLE}:${display_name}"
   else
     # Deduplicate: remove any prior entry for this agent then add fresh
     # Use grep -v || true: if this agent is the only registered agent, grep -v returns exit code 1
     # (no matches), which would crash the script under set -euo pipefail
     new_val=$(echo "$current" | tr ',' '\n' | grep -v "^${AGENT_NAME}:" || true)
     new_val=$(echo "$new_val" | tr '\n' ',' | sed 's/,$//')
-    [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}" || new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}:${display_name}" || new_val="${AGENT_NAME}:${AGENT_ROLE}:${display_name}"
   fi
 
   # Build patch data — include lastPlannerSeen timestamp for planners (issue #1274)


### PR DESCRIPTION
## Summary

Fixes specialization routing bug where coordinator looks up identity by ephemeral `agent_name` instead of persistent `displayName`.

Closes #1475

## Root Cause

Worker agents are ephemeral pods with timestamp-based names like `worker-1773140571`, but they receive persistent displayNames like "ada", "turing" from the name registry. Specialization history (label counts, code areas) accumulates across agent generations under the displayName.

The coordinator's `score_agent_for_issue()` was looking up `s3://agentex-thoughts/identities/<agent_name>.json` which:
- Returns empty for new worker pods (no history under that agent_name)
- Breaks specialization routing (score always 0)
- Results in `specializedAssignments=0` metric

## Changes

### entrypoint.sh
- `register_with_coordinator()`: Changed format from `agent_name:role` to `agent_name:role:displayName`
- Backward compatible: coordinator parser treats 2-field entries as `displayName==agent_name`

### coordinator.sh
- `score_agent_for_issue()`: Added 5th parameter `display_name`, tries displayName S3 lookup first, falls back to agent_name
- `find_best_agent_for_issue()`: Parses displayName from 3rd field, passes to scoring function
- v0.2 diagnostic section: Also checks displayName when diagnosing routing failures

## Testing

Manual verification:
- Checked that activeAgents format change is backward compatible
- Verified S3 fallback logic handles both old and new identity file naming
- Confirmed diagnostic section logic matches scoring function lookup order

## Impact

- Fixes v0.2 milestone blocker (specializedAssignments metric)
- Enables specialization routing to work across worker pod restarts
- Preserves backward compatibility with existing 2-field activeAgents entries