### PR TITLE
fix: trim whitespace from agent_role in find_best_agent_for_issue (closes #1491)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2135,7 +2135,10 @@ find_best_agent_for_issue() {
     for pair in "${agent_pairs[@]}"; do
         [ -z "$pair" ] && continue
         local agent_name="${pair%%:*}"
-        local agent_role="${pair##*:}"
+        # Trim whitespace from role — legacy update_state() echo bug (issue #1470) could have stored
+        # "worker " (with trailing space) in activeAgents, causing role comparison to silently fail.
+        local agent_role
+        agent_role=$(echo "${pair##*:}" | tr -d '[:space:]')
 
         # Only consider worker agents for specialization routing
         [ "$agent_role" != "worker" ] && continue


### PR DESCRIPTION
## Summary

Fixes a silent bug where specialization routing always skipped worker agents when their role was stored with a trailing space in coordinator-state `activeAgents`.

## Root Cause

The `update_state()` function used `echo "$value"` which appends a trailing newline; `tr '\n\r' '  '` converts that newline to a space. This was fixed for numeric values by PR #1473 (issue #1470), but the **stored values** in coordinator-state `activeAgents` from before the fix still contain trailing spaces (e.g., `worker-1773139586:worker ` with a trailing space).

## Impact

In `find_best_agent_for_issue()`:
```bash
local agent_role="${pair##*:}"   # agent_role = "worker "
[ "$agent_role" != "worker" ] && continue   # TRUE → skip!
```

All worker agents were silently skipped, so `specialized_count` was always 0, meaning `specializedAssignments` never incremented. This blocked the v0.2 milestone validation.

## Fix

Trim whitespace from the role string before comparison:
```bash
agent_role=$(echo "${pair##*:}" | tr -d '[:space:]')
```

This is a defensive fix that handles both legacy stored values (with trailing space) and any future whitespace edge cases.

Closes #1491