### PR TITLE
fix: normalize spaces in claim_task checks to prevent duplicate issue claims (closes #1488)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2202,8 +2202,11 @@ route_tasks_by_specialization() {
         [[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
         # Skip if already assigned
-        if echo "$active_assignments" | grep -q ":${issue_num}$" || \
-           echo "$active_assignments" | grep -q ":${issue_num},"; then
+        # Issue #1488: Normalize spaces before grep — activeAssignments can have space-padded entries
+        local normalized_active_assignments
+        normalized_active_assignments=$(echo "$active_assignments" | tr -d ' ')
+        if echo "$normalized_active_assignments" | grep -q ":${issue_num}$" || \
+           echo "$normalized_active_assignments" | grep -q ":${issue_num},"; then
             continue
         fi
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1315,10 +1315,16 @@ claim_task() {
       -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
 
     # Check if issue is already claimed by any agent
-    if echo "$assignments" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
+    # Issue #1488: Normalize spaces before regex check — activeAssignments can contain
+    # space-padded entries like "worker-X:123 ,worker-Y:456 " (from pre-PR-#1473 coordinator
+    # update_state() or IFS parsing in cleanup_stale_assignments). The regex (,|$) fails on
+    # "123 ," because the space precedes the comma, allowing duplicate claims of same issue.
+    local normalized_assignments_inner
+    normalized_assignments_inner=$(echo "$assignments" | tr -d ' ')
+    if echo "$normalized_assignments_inner" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
       # Determine who claimed it
       local claimer
-      claimer=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
+      claimer=$(echo "$normalized_assignments_inner" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
       if [ "$claimer" = "$AGENT_NAME" ]; then
         log "Coordinator: issue #$issue already claimed by us ($AGENT_NAME) — continuing"
         return 0

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -289,10 +289,16 @@ claim_task() {
       -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
 
     # Check if issue is already claimed by any agent
-    if echo "$assignments" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
+    # Issue #1488: Normalize spaces before regex check — activeAssignments can contain
+    # space-padded entries like "worker-X:123 ,worker-Y:456 " (from pre-PR-#1473 coordinator
+    # update_state() or IFS parsing in cleanup_stale_assignments). The regex (,|$) fails on
+    # "123 ," because the space precedes the comma, allowing duplicate claims of same issue.
+    local normalized_assignments
+    normalized_assignments=$(echo "$assignments" | tr -d ' ')
+    if echo "$normalized_assignments" | grep -qE "(^|,)[^,]+:${issue}(,|$)"; then
       # Determine who claimed it
       local claimer
-      claimer=$(echo "$assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
+      claimer=$(echo "$normalized_assignments" | tr ',' '\n' | grep ":${issue}$" | cut -d: -f1)
       if [ "$claimer" = "$AGENT_NAME" ]; then
         log "Coordinator: issue #$issue already claimed by us ($AGENT_NAME) — continuing"
         # Re-write temp file to ensure it exists (may have been lost across context switches)


### PR DESCRIPTION
Fixes issue where multiple agents could claim the same issue simultaneously. The regex check in claim_task() failed on space-padded activeAssignments entries. Fix normalizes spaces before check. Closes #1488