### PR TITLE
fix: strip trailing whitespace from issue numbers in cleanup_stale_assignments (closes #1504)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -608,7 +608,14 @@ cleanup_stale_assignments() {
     for pair in "${PAIRS[@]}"; do
         [ -z "$pair" ] && continue
         local agent_name="${pair%%:*}"
-        local issue="${pair##*:}"
+        # Issue #1504: Strip trailing whitespace from issue number.
+        # Legacy coordinator writes (before PR #1473 fixed update_state()) stored issue
+        # numbers with trailing spaces (e.g., "1483 "). This caused two failures:
+        # 1. [[ "$issue" =~ ^[0-9]+$ ]] → FALSE, skipping the closed-issue check.
+        # 2. claim_task()'s grep regex didn't match "1483 " when checking for "1483",
+        #    allowing duplicate claims of the same issue by different agents.
+        local issue
+        issue=$(echo "${pair##*:}" | tr -d '[:space:]')
 
         local job_active
         # Issue #1170: Suppress jq parse errors from kubectl non-JSON output.
@@ -634,9 +641,12 @@ cleanup_stale_assignments() {
                     continue
                 fi
             fi
+            # Issue #1504: Reconstruct the pair from sanitized agent_name + issue (no trailing spaces).
+            # Using ${pair} would preserve the original trailing space and corrupt future reads.
+            local clean_pair="${agent_name}:${issue}"
             [ -n "$cleaned_assignments" ] \
-                && cleaned_assignments="${cleaned_assignments},${pair}" \
-                || cleaned_assignments="$pair"
+                && cleaned_assignments="${cleaned_assignments},${clean_pair}" \
+                || cleaned_assignments="${clean_pair}"
         else
             echo "[$(date -u +%H:%M:%S)] Stale: $agent_name → issue #$issue, releasing assignment (NOT re-queuing; refresh_task_queue handles re-population)"
             stale_count=$((stale_count + 1))


### PR DESCRIPTION
## Summary

Fixes trailing whitespace corruption in `coordinator.sh`'s `cleanup_stale_assignments()` that caused duplicate issue claims and silent failures.

Closes #1504

## Root Cause

Before PR #1473 fixed `update_state()` to use `printf` instead of `echo`, coordinator writes stored issue numbers with trailing spaces (e.g., `worker-xxx:1483 `). While new writes are now correct, the corrupt data persisted in `coordinator-state.activeAssignments`.

When `cleanup_stale_assignments()` reads these pairs and extracts the issue with `${pair##*:}`, it gets `"1483 "` (with trailing space), causing:

1. `[[ "1483 " =~ ^[0-9]+$ ]]` → FALSE — closed-issue GitHub state check is silently skipped
2. The corrupt pair `"worker-xxx:1483 "` is written back to `activeAssignments` unchanged
3. `claim_task()`'s regex `(^|,)[^,]+:${issue}(,|$)` doesn't match `"1483 "` when looking for `"1483"` — duplicate claims allowed

**Observed evidence in production:**
```
worker-1773139219:1483 ,worker-1773139586:1483 ,worker-1773140292:1436,worker-1773140292:1474,worker-1773139219:1487
```
- `worker-1773139219` had BOTH `1483 ` (trailing space) AND `1487` — double assignment
- `worker-1773140292` had BOTH `1436` AND `1474` — double assignment

## Fix

1. Strip trailing whitespace from issue number: `issue=$(echo "${pair##*:}" | tr -d '[:space:]')`
2. Reconstruct the pair cleanly: use `"${agent_name}:${issue}"` instead of `"${pair}"`

This is a one-time cleanup that will run on the next coordinator cycle and normalize all existing corrupt entries.

## Files Changed

- `images/runner/coordinator.sh` (non-protected file, no `god-approved` required)