### PR TITLE
fix: use printf in ensure_state_fields_initialized() to prevent trailing space (closes #1501)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -200,8 +200,12 @@ ensure_state_fields_initialized() {
     if [ -n "$new_entries" ]; then
       local migrated_enacted="${enacted} | ${new_entries}"
       # Sanitize for JSON: escape double quotes, remove newlines
+      # Issue #1501: Use printf '%s' instead of echo to avoid appending a trailing newline.
+      # echo "$migrated_enacted" appends \n; tr '\n\r' '  ' converts that \n to a space,
+      # causing enactedDecisions to end with a trailing space character.
+      # This is the same echo+tr pattern fixed in update_state() by PR #1473 (issue #1470).
       local safe_migrated
-      safe_migrated=$(echo "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
+      safe_migrated=$(printf '%s' "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
       kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
         -p "{\"data\":{\"enactedDecisions\":\"$safe_migrated\"}}" 2>/dev/null || true
       [ "$silent" = "false" ] && echo "  enactedDecisions migration complete (issue #1427)"
@@ -1588,8 +1592,9 @@ NUDGE_EOF
             local ts
             ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
             # Strip newlines from proposer_agent (safety - proposer_agent is typically single-line)
+            # Issue #1501: Use printf '%s' instead of echo to avoid trailing space from echo's newline.
             local safe_proposer
-            safe_proposer=$(echo "$proposer_agent" | tr '\n' ' ' | tr -s ' ')
+            safe_proposer=$(printf '%s' "$proposer_agent" | tr '\n' ' ' | tr -s ' ')
             local enacted_entry="${ts} ${decision_key} approvals=${approve_votes} rejections=${reject_votes} proposer=${safe_proposer}"
             if [ -z "$loop_enacted" ]; then
                 loop_enacted="$enacted_entry"


### PR DESCRIPTION
## Summary

Fixes two `echo | tr` patterns in `coordinator.sh` that produced trailing spaces — the same root cause as issue #1470 (fixed in `update_state()` by PR #1473).

Closes #1501

## Root Cause

`echo "$value"` appends `\n`. When piped to `tr '\n\r' '  '`, the `\n` becomes a space character. `tr -s ' '` collapses consecutive spaces but does NOT trim trailing spaces. Result: string values end with a trailing space.

This was already fixed in `update_state()` by PR #1473 (issue #1470), but two other locations in `coordinator.sh` still used the old pattern.

## Changes

**`ensure_state_fields_initialized()` (line 204):**
```bash
# Before (broken):
safe_migrated=$(echo "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')

# After (fixed):
safe_migrated=$(printf '%s' "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
```

**Governance tally loop (line 1596):**
```bash
# Before (broken):
safe_proposer=$(echo "$proposer_agent" | tr '\n' ' ' | tr -s ' ')

# After (fixed):
safe_proposer=$(printf '%s' "$proposer_agent" | tr '\n' ' ' | tr -s ' ')
```

## Impact

- `enactedDecisions` no longer stores trailing spaces after legacy format migration
- `proposer` fields in enacted entries no longer have trailing spaces
- Reduces spurious pattern-match failures in governance vote checks
- Consistent with `update_state()` which already uses `printf '%s'`

## Related
- Issue #1470 / PR #1473: Original echo+tr fix in `update_state()`
- Issue #1501: This issue