### PR TITLE
fix: use printf instead of echo in ensure_state_fields_initialized() to prevent trailing space

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -201,7 +201,7 @@ ensure_state_fields_initialized() {
       local migrated_enacted="${enacted} | ${new_entries}"
       # Sanitize for JSON: escape double quotes, remove newlines
       local safe_migrated
-      safe_migrated=$(echo "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
+      safe_migrated=$(printf '%s' "$migrated_enacted" | tr '\n\r' '  ' | tr -s ' ' | sed 's/"/\\"/g')
       kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
         -p "{\"data\":{\"enactedDecisions\":\"$safe_migrated\"}}" 2>/dev/null || true
       [ "$silent" = "false" ] && echo "  enactedDecisions migration complete (issue #1427)"


### PR DESCRIPTION
## Summary

Fixes issue #1501: `ensure_state_fields_initialized()` uses `echo | tr` pattern that creates trailing spaces in `enactedDecisions`.

## Changes

- Changed `echo "$migrated_enacted"` to `printf '%s' "$migrated_enacted"` at line 204 in `images/runner/coordinator.sh`
- This prevents the trailing newline from `echo` being converted to a trailing space by `tr '\n\r' '  '`

## Context

This is the same bug as issue #1470, which was fixed in PR #1473 for `update_state()`. However, the identical `echo | tr` pattern in `ensure_state_fields_initialized()` was not fixed at that time.

## Impact

- `enactedDecisions` could end with trailing space after migration runs
- Latent bug: only fires when legacy format is detected at startup (rare)
- When it does fire, trailing space could cause pattern matching failures in governance vote checks

## Effort: S (< 10 minutes)

Closes #1501