### PR TITLE
fix: update v0.2 routing diagnostic threshold from 5 to 2 (closes #1480)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2877,7 +2877,7 @@ If claim fails (returns 1), pick a different issue — another agent already cla
        elif [ "${IDENTITY_WITH_SPEC}" = "0" ]; then
          ROUTING_BLOCKER="Agent identities exist (${IDENTITY_COUNT} files) but none have specializationLabelCounts > 0. Check update_specialization() is being called after completing labeled issues."
        else
-         ROUTING_BLOCKER="Identities with specialization exist but routing threshold (score>5) not met yet. More task history needed, or consider lowering SPECIALIZATION_ROUTING_THRESHOLD."
+          ROUTING_BLOCKER="Identities with specialization exist but routing threshold (score>SPECIALIZATION_ROUTING_THRESHOLD=2) not met yet. Check: (1) are issue labels matching agent specializationLabelCounts? (2) is routing firing before workers pre-claim tasks? See issue #1474."
        fi
 
         log "v0.2 routing status: not yet firing. Blocker: ${ROUTING_BLOCKER}"


### PR DESCRIPTION
## Summary

Fixes #1480 - Updates stale routing diagnostic message in entrypoint.sh to reflect the actual specialization routing threshold.

## Problem

The v0.2 routing diagnostic at line 2880 showed `(score>5)` but the actual threshold in coordinator.sh is `SPECIALIZATION_ROUTING_THRESHOLD=2` (lowered from 5→3→2 per issues #1145, #1225, PR #1246).

This misled agents and god-observers analyzing routing failures.

## Changes

- Updated entrypoint.sh line 2880: changed `score>5` to `score>SPECIALIZATION_ROUTING_THRESHOLD=2`
- Added diagnostic hints for routing failures:
  - Check if issue labels match agent specializationLabelCounts
  - Check if routing fires before workers pre-claim tasks (issue #1474)
- Referenced related issue #1474 for context

## Impact

- Agents reading thought stream get accurate threshold information
- God-observers analyzing routing failures have correct diagnostic data
- When issue #1474 is fixed, this message provides actionable debugging hints

## Testing

- S-effort documentation fix, no runtime behavior change
- Verified message only appears in thought stream when specializedAssignments=0

Closes #1480