### PR TITLE
fix(identity): release registry name on agent exit

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -306,6 +306,13 @@ cleanup_agent_cr_on_exit() {
   fi
   
   log "EXIT trap: cleaning up Agent CR $AGENT_NAME (exit_code=$exit_code)"
+
+  # Step 0: Release identity name back to registry so future agents can reuse it.
+  # Issue #1483: names were permanently claimed — this releases them on every exit path.
+  # Must run BEFORE Agent CR deletion to avoid kubectl failures after AGENT_NAME CR is gone.
+  if type release_identity &>/dev/null; then
+    release_identity || log "WARNING: release_identity failed (non-fatal)"
+  fi
   
   # Step 1: Remove kro finalizer so deletion is not blocked
   # kro adds kro.run/finalizer to Agent CRs. If kro is busy/restarting,

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -654,6 +654,66 @@ get_identity_signature() {
 }
 
 #######################################
+# Release a claimed name back to the registry so future agents can reuse it.
+# MUST be called from the EXIT trap in entrypoint.sh on ALL exit paths
+# (normal completion, error, circuit-breaker early exit, etc.).
+#
+# Before releasing, updates the canonical S3 file with the latest accumulated
+# specialization history so the NEXT agent that claims this name inherits it.
+#
+# Globals:
+#   AGENT_NAME        - the agent's k8s name (e.g., worker-1773006921)
+#   AGENT_ROLE        - the agent's role
+#   AGENT_DISPLAY_NAME - the friendly name to release (e.g., "ada")
+#   AGENT_IDENTITY_FILE - S3 path to this agent's identity JSON
+# Returns:
+#   0 always (non-fatal — errors are logged and skipped)
+#######################################
+release_identity() {
+  # Only release if we claimed a registry name (not a generated fallback)
+  if [[ -z "$AGENT_DISPLAY_NAME" ]] || [[ "$AGENT_DISPLAY_NAME" == "$AGENT_NAME" ]]; then
+    # Generated name or not initialised — nothing to release
+    return 0
+  fi
+
+  echo "[identity] Releasing name '$AGENT_DISPLAY_NAME' back to registry for $AGENT_NAME..."
+
+  # Step 1: Flush the latest identity stats to the canonical S3 file so the
+  # next agent inheriting this name starts with full accumulated history.
+  if [[ -n "$AGENT_IDENTITY_FILE" ]]; then
+    local current_json=""
+    current_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+    if [[ -n "$current_json" ]]; then
+      local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+      if echo "$current_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+        echo "[identity] Updated canonical history for '$AGENT_DISPLAY_NAME' before release"
+      else
+        echo "[identity] WARNING: Could not update canonical history before release (non-fatal)"
+      fi
+    fi
+  fi
+
+  # Step 2: Atomically mark the name as available again in the registry.
+  # Uses test+replace JSON patch: only succeeds if the current value matches
+  # what this agent set at claim time, preventing accidental double-release or
+  # releasing a name that another agent has already re-claimed.
+  local current_value="${AGENT_ROLE}:claimed:${AGENT_NAME}"
+  local available_value="${AGENT_ROLE}:available"
+
+  local patch_result
+  if patch_result=$(timeout 10s kubectl patch configmap agentex-name-registry -n agentex \
+    --type=json \
+    -p "[{\"op\":\"test\",\"path\":\"/data/$AGENT_DISPLAY_NAME\",\"value\":\"$current_value\"},{\"op\":\"replace\",\"path\":\"/data/$AGENT_DISPLAY_NAME\",\"value\":\"$available_value\"}]" \
+    2>&1); then
+    echo "[identity] Successfully released name '$AGENT_DISPLAY_NAME' → ${available_value}"
+  else
+    echo "[identity] WARNING: Could not release name '$AGENT_DISPLAY_NAME' (may have been claimed by another agent or not found): $patch_result"
+  fi
+
+  return 0
+}
+
+#######################################
 # Initialize identity system
 # Call this from entrypoint.sh at startup
 #######################################


### PR DESCRIPTION
## Summary

- Adds `release_identity()` to `identity.sh` — called from the EXIT trap so ALL exit paths (normal, error, circuit-breaker early exit) return the agent's name to the registry.
- Before releasing, flushes the latest specialization stats to `identities/canonical/<display_name>.json` so the next agent that claims the name inherits accumulated history.
- Uses atomic test+replace JSON patch to prevent double-release races.

## Root Cause

`claim_identity()` marks a name as `worker:claimed:<agent>` in `agentex-name-registry`. There was no corresponding release, so completed workers left their names permanently claimed. After the 12 worker slots fill up, every new worker gets a generated fallback name (`worker-bold-tensor`), has no `specializationLabelCounts`, and `specializedAssignments=0` forever — blocking the entire v0.2 emergent specialization milestone.

## Impact

- Fixes v0.2 specialization routing being permanently blocked (root cause of issues #1474, #1475)
- Names recycle correctly across agent generations
- Canonical S3 history ensures cross-generation knowledge transfer

## Testing

1. After merge, watch `kubectl get configmap agentex-name-registry -n agentex -o json` — worker names return to `:available` within seconds of a worker pod completing.
2. Next worker claiming that name will log: `[identity] Inherited specialization history for 'ada' (prior spec: debugger, tasks: 5)`

Closes #1483