### PR TITLE
fix: canonical S3 lookup fires even when per-session identity file is empty (closes #1515)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2026,28 +2026,44 @@ score_agent_for_issue() {
     local issue_number="$2"
     local issue_labels="$3"
     local issue_keywords="$4"
+    local passed_display_name="${5:-}"  # Issue #1515: optional displayName from activeAgents triplet
 
     # Read agent identity from S3 — first try per-session file (may be empty for new agents)
     local identity_json=""
     identity_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${agent_name}.json" - \
         --region "$BEDROCK_REGION" 2>/dev/null || echo "")
 
-    # Issue #1475: if per-session file exists, try to upgrade to canonical history.
-    # The per-session file contains only THIS session's data (usually empty for new agents).
+    # Issue #1475 / #1515: try to upgrade to canonical history.
+    # The per-session file contains only THIS session's data (usually empty for new agents
+    # since it is written at EXIT, not at startup).
     # The canonical file at identities/canonical/<displayName>.json contains accumulated
     # history across all sessions using this display name (written by identity.sh PR #1489).
+    #
+    # Bug in PR #1505: canonical lookup was only attempted when per-session file existed.
+    # Fix (issue #1515): try canonical lookup with passed_display_name FIRST (when available),
+    # before giving up on an empty per-session file.
+    local display_name=""
+
     if [ -n "$identity_json" ]; then
-        local display_name
+        # Per-session file exists — extract displayName from it
         display_name=$(echo "$identity_json" | jq -r '.displayName // ""' 2>/dev/null || echo "")
-        if [ -n "$display_name" ] && [ "$display_name" != "$agent_name" ]; then
-            local canonical_json
-            canonical_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/canonical/${display_name}.json" - \
-                --region "$BEDROCK_REGION" 2>/dev/null || echo "")
-            if [ -n "$canonical_json" ]; then
-                # Use canonical (accumulated) history instead of per-session (fresh) file
-                identity_json="$canonical_json"
-                echo "[$(date -u +%H:%M:%S)] Routing: using canonical history for $agent_name (displayName=$display_name)" >&2
-            fi
+    fi
+
+    # Prefer the passed displayName from activeAgents registration (more reliable than
+    # per-session file which may be empty or from a prior agent with the same name slot).
+    if [ -n "$passed_display_name" ] && [ "$passed_display_name" != "$agent_name" ]; then
+        display_name="$passed_display_name"
+    fi
+
+    # Try canonical lookup whenever we have a display_name (even if per-session file is empty)
+    if [ -n "$display_name" ] && [ "$display_name" != "$agent_name" ]; then
+        local canonical_json
+        canonical_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/canonical/${display_name}.json" - \
+            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+        if [ -n "$canonical_json" ]; then
+            # Use canonical (accumulated) history instead of per-session (fresh) file
+            identity_json="$canonical_json"
+            echo "[$(date -u +%H:%M:%S)] Routing: using canonical history for $agent_name (displayName=$display_name)" >&2
         fi
     fi
 
@@ -2177,9 +2193,13 @@ find_best_agent_for_issue() {
     for pair in "${agent_pairs[@]}"; do
         [ -z "$pair" ] && continue
         local agent_name="${pair%%:*}"
-        # Use cut for role: supports both "name:role" and future "name:role:displayName" format
+        # Use cut for role: supports both "name:role" and "name:role:displayName" format
         local agent_role
         agent_role=$(echo "$pair" | cut -d: -f2)
+        # Issue #1515: extract displayName from triplet (name:role:displayName)
+        # Supports old "name:role" format (displayName will be empty string)
+        local agent_display_name
+        agent_display_name=$(echo "$pair" | cut -d: -f3)
 
         # Only consider worker agents for specialization routing
         [ "$agent_role" != "worker" ] && continue
@@ -2191,10 +2211,12 @@ find_best_agent_for_issue() {
         fi
 
         local agent_score
+        # Issue #1515: pass displayName so score_agent_for_issue() can try canonical
+        # lookup even when the per-session S3 file is empty (new agent pods)
         agent_score=$(score_agent_for_issue "$agent_name" "$issue_number" \
-            "$issue_labels" "$issue_keywords")
+            "$issue_labels" "$issue_keywords" "$agent_display_name")
 
-        echo "[$(date -u +%H:%M:%S)] Specialization score for $agent_name on issue #$issue_number: $agent_score" >&2
+        echo "[$(date -u +%H:%M:%S)] Specialization score for $agent_name (displayName=${agent_display_name:-?}) on issue #$issue_number: $agent_score" >&2
 
         if [ "$agent_score" -gt "$best_score" ]; then
             best_score="$agent_score"

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1752,16 +1752,22 @@ register_with_coordinator() {
   current=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
     -o jsonpath='{.data.activeAgents}' 2>/dev/null || echo "")
 
+  # Issue #1515: Include displayName in registration triplet (name:role:displayName)
+  # so coordinator's score_agent_for_issue() can look up canonical S3 identity even
+  # when the per-session identity file is empty (new agent pods always start empty).
+  local display_name="${AGENT_DISPLAY_NAME:-$AGENT_NAME}"
+  local agent_entry="${AGENT_NAME}:${AGENT_ROLE}:${display_name}"
+
   local new_val
   if [ -z "$current" ]; then
-    new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    new_val="$agent_entry"
   else
     # Deduplicate: remove any prior entry for this agent then add fresh
     # Use grep -v || true: if this agent is the only registered agent, grep -v returns exit code 1
     # (no matches), which would crash the script under set -euo pipefail
     new_val=$(echo "$current" | tr ',' '\n' | grep -v "^${AGENT_NAME}:" || true)
     new_val=$(echo "$new_val" | tr '\n' ',' | sed 's/,$//')
-    [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}" || new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    [ -n "$new_val" ] && new_val="${new_val},${agent_entry}" || new_val="$agent_entry"
   fi
 
   # Build patch data — include lastPlannerSeen timestamp for planners (issue #1274)
@@ -1779,7 +1785,7 @@ register_with_coordinator() {
     return 1
   fi
   
-  log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE})"
+  log "Coordinator: registered agent ${AGENT_NAME} (${AGENT_ROLE}) displayName=${display_name}"
   [ "${AGENT_ROLE}" = "planner" ] && log "Coordinator: updated lastPlannerSeen=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   return 0
 }


### PR DESCRIPTION
## Summary

Fixes the incomplete fix from PR #1505 (issue #1515). Canonical S3 identity lookup now fires correctly for new agent pods, enabling specialization routing to score agents with accumulated history.

## Root Cause

PR #1505 (merged 2026-03-10) gated the canonical identity lookup behind a check for a non-empty per-session file:

```bash
if [ -n "$identity_json" ]; then  # ← PROBLEM: new agents have empty per-session file!
    display_name=$(...)
    # canonical lookup here — never reached for new agents
fi
```

New agent pods ALWAYS start with an empty per-session S3 file (it is written at EXIT, not startup). The canonical lookup path was effectively unreachable in production.

## Fix

### `coordinator.sh` — `score_agent_for_issue()`
- Added optional 5th argument `passed_display_name` 
- Canonical lookup now fires when `display_name` is available from EITHER the passed arg OR the per-session file
- Priority: `passed_display_name` (from activeAgents triplet) > per-session file extractedDisplayName

### `coordinator.sh` — `find_best_agent_for_issue()`
- Extracts 3rd field (displayName) from `name:role:displayName` triplet in `activeAgents`
- Passes it to `score_agent_for_issue()` as the new 5th argument
- Backward compatible with old `name:role` format (`cut -d: -f3` returns empty string)

### `entrypoint.sh` — `register_with_coordinator()`
- Changed registration format from `name:role` to `name:role:displayName`
- Uses `AGENT_DISPLAY_NAME` (set at startup by identity.sh) which holds the persistent registry name

## Flow After Fix

1. Agent starts → identity.sh sets `AGENT_DISPLAY_NAME=ada` (claimed from registry)
2. Agent calls `register_with_coordinator()` → writes `worker-XYZ:worker:ada` to `activeAgents`
3. Coordinator routing fires → `find_best_agent_for_issue()` extracts `ada` as displayName
4. `score_agent_for_issue("worker-XYZ", ..., "ada")` → tries `s3://identities/canonical/ada.json`
5. Canonical file found → returns accumulated specializationLabelCounts → score > 0
6. `specializedAssignments` increments → v0.2 validated

## Closes

Closes #1515