### PR TITLE
fix: trim whitespace from issue_num in route_tasks_by_specialization() (closes #1521)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2242,6 +2242,11 @@ route_tasks_by_specialization() {
     IFS=',' read -ra queue_issues <<< "$task_queue"
     for issue_num in "${queue_issues[@]}"; do
         [ -z "$issue_num" ] && continue
+        # Issue #1521: trim whitespace — taskQueue can have legacy space-padded entries
+        # (e.g., "1436 " from pre-PR-#1473 update_state() writes). Without trimming,
+        # [[ "1436 " =~ ^[0-9]+$ ]] fails and routing skips ALL such entries, keeping
+        # specializedAssignments=0 even when valid agents and matching issues exist.
+        issue_num=$(echo "$issue_num" | tr -d '[:space:]')
         # Only handle numeric issue numbers
         [[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 


### PR DESCRIPTION
## Summary

Fixes #1521 — \`route_tasks_by_specialization()\` was silently skipping space-padded issue numbers from the task queue, preventing \`specializedAssignments\` from ever incrementing.

## Root Cause

The \`taskQueue\` coordinator state can contain trailing-space-padded entries (e.g., \`1436 \`) from legacy \`update_state()\` writes before the printf fix in PR #1473. The routing loop:

```bash
IFS=',' read -ra queue_issues <<< "$task_queue"
for issue_num in "${queue_issues[@]}"; do
    [[ "$issue_num" =~ ^[0-9]+$ ]] || continue  # fails for "1436 "
```

\`[[ "1436 " =~ ^[0-9]+$ ]]\` → FALSE → routing skips the issue → \`specializedAssignments\` never increments → v0.2 milestone never validates.

## Fix

Add \`tr -d '[:space:]'\` trim before the regex check, consistent with the fix applied to \`cleanup_stale_assignments()\` in PR #1504 (issue #1504):

```bash
# Issue #1521: trim whitespace — taskQueue can have legacy space-padded entries
issue_num=$(echo "$issue_num" | tr -d '[:space:]')
[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
```

## Impact

- Routing can now process all queue entries including legacy space-padded ones
- Unblocks \`specializedAssignments > 0\` validation once specialized agents are active with matching issues

## Changes

- \`images/runner/coordinator.sh\`: 5-line change in \`route_tasks_by_specialization()\`

Closes #1521