### PR TITLE
fix: update_specialization and identity stats now write to canonical S3 file (closes #1523)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -380,6 +380,18 @@ update_identity_stats() {
   else
     echo "[identity] WARNING: Could not save updated stats to S3"
   fi
+
+  # Issue #1523: Also update canonical file so accumulated stats persist across agent restarts.
+  # Stats (tasksCompleted, issuesFiled, prsMerged) written here must be reflected in canonical
+  # so that cross-generation inheritance (via save_identity_with_inheritance) picks up the latest data.
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical stat: $stat_name (canonical: $canonical_path)"
+    else
+      echo "[identity] WARNING: Could not update canonical stat (non-fatal)"
+    fi
+  fi
 }
 
 #######################################
@@ -458,6 +470,22 @@ update_specialization() {
   else
     echo "[identity] WARNING: Could not save specialization update to S3"
   fi
+
+  # Issue #1523: Also update canonical file so cross-generation inheritance picks up
+  # the latest specialization data. update_specialization() is called at session END
+  # (after agent completes a labeled issue). Without updating canonical here, the next
+  # session that claims this display name will inherit stale canonical (empty spec)
+  # instead of the accumulated data just written to per-session file.
+  # save_identity() at session START reads per-session and writes canonical, but
+  # update_specialization() runs AFTER save_identity() — so canonical must be updated here.
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical specialization: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not update canonical specialization (non-fatal)"
+    fi
+  fi
 }
 
 #######################################
@@ -518,6 +546,16 @@ update_code_area_specialization() {
   else
     echo "[identity] WARNING: Could not save code area update to S3"
   fi
+
+  # Issue #1523: Also update canonical file so code area data persists across restarts.
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical code areas: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not update canonical code areas (non-fatal)"
+    fi
+  fi
 }
 
 #######################################
@@ -559,6 +597,16 @@ update_debate_specialization() {
     echo "[identity] Updated debate specialization: synthesisCount incremented"
   else
     echo "[identity] WARNING: Could not save debate specialization update to S3"
+  fi
+
+  # Issue #1523: Also update canonical file so debate synthesis data persists across restarts.
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical debate specialization: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not update canonical debate specialization (non-fatal)"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

- Fixes root cause of `specializedAssignments=0` — specialization data was not persisting across agent restarts
- Updates all 4 identity update functions to write to both per-session AND canonical S3 files

Closes #1523

## Root Cause

`update_specialization()`, `update_identity_stats()`, `update_code_area_specialization()`, and `update_debate_specialization()` all wrote ONLY to the per-session identity file (`identities/<agent_name>.json`) but NOT to the canonical file (`identities/canonical/<displayName>.json`).

**Evidence** (from live cluster): Worker `knuth` (worker-1773141236) completed issue #1483 with `bug,self-improvement` labels:
- Per-session file: `specialization="debugger", specializationLabelCounts={"bug":1,"self-improvement":1}`
- Canonical file: `specialization="", specializationLabelCounts={}`

## Why This Matters for v0.2

The coordinator's `score_agent_for_issue()` reads canonical files to score agents for specialization routing. If canonical is always empty (stale from session start), scores are always 0, and `specializedAssignments` never increments — the v0.2 milestone never validates.

## Fix

Each of the 4 update functions now writes the updated JSON to BOTH:
1. `identities/<agent_name>.json` (per-session, as before)
2. `identities/canonical/<displayName>.json` (canonical, NEW — matches pattern in `save_identity()`)

The canonical write is non-fatal (failures are logged but don't abort the update).

## Related

- Issue #1523 (this fix)
- Issue #1515 (coordinator canonical lookup fix)
- Issue #1474 / PR #1479 (routing timing fix)
- Issue #1483 / PR #1486/#1514 (name registry release fix)
- Issue #1098 (emergent specialization milestone)