### PR TITLE
fix: prune closed issues from visionQueue in refresh_task_queue()

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -568,9 +568,42 @@ refresh_task_queue() {
         # Issue #1149: Prepend visionQueue items BEFORE taskQueue so agent-voted issues get priority
         # visionQueue contains issues that 3+ agents voted to prioritize via governance
         # Issue #1444: visionQueue uses semicolon separator; extract only numeric issue numbers
+        # Issue #1525: Prune visionQueue of closed issues before prepending to taskQueue.
+        #   refresh_task_queue() already removes closed issues from taskQueue — visionQueue
+        #   needs the same treatment. Without pruning, closed issues accumulate permanently
+        #   and planners waste time trying to work on resolved work.
         local vision_queue
         vision_queue=$(get_state "visionQueue")
         if [ -n "$vision_queue" ]; then
+            # Issue #1525: Prune closed issues from visionQueue.
+            # Only check numeric entries (non-numeric feature entries are kept unconditionally).
+            local pruned_vq=""
+            local vq_pruned_count=0
+            while IFS=';' read -ra VQ_ENTRIES; do
+                for vq_entry in "${VQ_ENTRIES[@]}"; do
+                    [ -z "$vq_entry" ] && continue
+                    # Only numeric entries map to GitHub issues; non-numeric feature entries are kept
+                    if [[ "$vq_entry" =~ ^[0-9]+$ ]]; then
+                        local vq_issue_state
+                        vq_issue_state=$(gh issue view "$vq_entry" --repo "${GITHUB_REPO}" \
+                            --json state --jq '.state' 2>/dev/null || echo "OPEN")
+                        if [ "$vq_issue_state" = "CLOSED" ]; then
+                            echo "[$(date -u +%H:%M:%S)] visionQueue: pruning closed issue #$vq_entry"
+                            vq_pruned_count=$((vq_pruned_count + 1))
+                            continue  # Skip closed issue — do not add to pruned_vq
+                        fi
+                    fi
+                    [ -n "$pruned_vq" ] \
+                        && pruned_vq="${pruned_vq};${vq_entry}" \
+                        || pruned_vq="${vq_entry}"
+                done
+            done <<< "$vision_queue"
+            if [ "$vq_pruned_count" -gt 0 ]; then
+                update_state "visionQueue" "$pruned_vq"
+                echo "[$(date -u +%H:%M:%S)] visionQueue: pruned $vq_pruned_count closed issue(s) (was: $vision_queue, now: $pruned_vq)"
+                vision_queue="$pruned_vq"
+            fi
+
             # Extract numeric issue numbers from semicolon-separated entries
             local vision_issues
             vision_issues=$(echo "$vision_queue" | tr ';' '\n' | grep -E '^[0-9]+$' | tr '\n' ',' | sed 's/,$//')


### PR DESCRIPTION
## Summary

Fixes `visionQueue` accumulating closed issues permanently (issue #1525).

## Problem

`coordinator-state.visionQueue` is never pruned. Once an issue is added via governance vote (3+ agents approve), it stays there even after the GitHub issue is CLOSED. `refresh_task_queue()` already removes closed issues from `taskQueue` — `visionQueue` needed the same treatment.

## Changes

**`coordinator.sh`** — inside `refresh_task_queue()`, before prepending visionQueue items to taskQueue:

1. Iterate visionQueue entries (semicolon-separated)
2. For each numeric entry (GitHub issue number), check if the issue is still OPEN
3. If CLOSED: skip and log the pruning
4. Update `coordinator-state.visionQueue` with the pruned list
5. Non-numeric entries (named feature strings) are kept unconditionally

## Why This Is Safe

- Only runs every 5 coordinator iterations (same cadence as `refresh_task_queue()`)
- Backward compatible: if `visionQueue` is empty, this no-ops
- Non-numeric feature entries (e.g., `feature:mentorship-chains:ts:proposer`) are preserved
- Uses the same `gh issue view` pattern already used in `cleanup_stale_assignments()`

## Constitution Alignment

This fix:
- ✅ Fixes a bug without changing existing governance behavior
- ✅ Follows the same pattern as existing cleanup functions
- ✅ Enforces data hygiene: stale entries in coordinator-state degrade signal quality
- ✅ Does not expand agent autonomy or bypass safety mechanisms

Closes #1525

## Constitution Alignment Checklist
- [x] Fixes bug without changing behavior
- [x] Cites relevant constitution sections (coordinator state hygiene)
- [x] Linked to GitHub issue #1525
- [x] Does not expand agent autonomy or bypass safety mechanisms

Ready for god review - constitution alignment verified