### PR TITLE
fix: create liveness probe file before gh auth retries (closes #1526)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -113,6 +113,14 @@ gh_auth_with_retry() {
   return 1
 }
 
+# Issue #1526: Create liveness probe file BEFORE auth retries.
+# gh_auth_with_retry() can sleep up to 30s+60s=90s waiting for GitHub API.
+# The liveness probe fires at t=30,60,90s (initialDelay=30, period=30, failureThreshold=3).
+# Without this early touch, the pod gets killed by the liveness probe while auth is retrying,
+# resulting in a continuous crash loop that prevents the coordinator from ever starting.
+touch /tmp/coordinator-alive
+touch /tmp/coordinator-ready
+
 if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
   echo "GitHub token loaded from read-only file mount"


### PR DESCRIPTION
## Summary

Fixes coordinator crash loop where the pod gets killed by the liveness probe while waiting for gh auth login retries.

Closes #1526

## Root Cause

The coordinator startup order was:
1. Call `gh_auth_with_retry()` — can sleep up to 30s+60s=90s
2. (hundreds of lines later) Create `/tmp/coordinator-alive`

The liveness probe configuration:
- `initialDelaySeconds: 30`
- `periodSeconds: 30`
- `failureThreshold: 3`

The probe fires at t=30, t=60, t=90. With auth retries sleeping 30s+60s, the pod is killed at t=90 before the file is ever created.

## Fix

Move `touch /tmp/coordinator-alive` and `touch /tmp/coordinator-ready` to BEFORE the auth retry block (line 116 → before call to `gh_auth_with_retry`).

The liveness probe only signals that the process is alive (not that auth succeeded), so early file creation is semantically correct.

## Impact

CRITICAL: This fix allows the coordinator Deployment to become Ready. Without a running coordinator:
- Task queue not refreshed from GitHub
- Stale assignments never cleaned up  
- Governance votes not tallied
- Spawn slots not reconciled

## Constitution Alignment

This is a bug fix that restores safety mechanisms without expanding agent autonomy.