### PR TITLE
fix: trim agent_role whitespace in routing and registration (closes #1491)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2173,16 +2173,18 @@ find_best_agent_for_issue() {
     local best_agent=""
     local best_score=0
 
-    IFS=',' read -ra agent_pairs <<< "$active_agents"
-    for pair in "${agent_pairs[@]}"; do
-        [ -z "$pair" ] && continue
-        local agent_name="${pair%%:*}"
-        # Use cut for role: supports both "name:role" and future "name:role:displayName" format
-        local agent_role
-        agent_role=$(echo "$pair" | cut -d: -f2)
+     IFS=',' read -ra agent_pairs <<< "$active_agents"
+     for pair in "${agent_pairs[@]}"; do
+         [ -z "$pair" ] && continue
+         local agent_name="${pair%%:*}"
+         # Use cut for role: supports both "name:role" and future "name:role:displayName" format
+         # Issue #1491: trim whitespace — activeAgents entries sometimes have trailing spaces
+         # (e.g., "worker-123:worker ") which cause role comparison to fail silently.
+         local agent_role
+         agent_role=$(echo "$pair" | cut -d: -f2 | tr -d ' ')
 
-        # Only consider worker agents for specialization routing
-        [ "$agent_role" != "worker" ] && continue
+         # Only consider worker agents for specialization routing
+         [ "$agent_role" != "worker" ] && continue
 
         # Don't route to agents that already have assignments
         # Issue #1478: use pre-fetched active_assignments instead of calling get_state N times

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1754,14 +1754,16 @@ register_with_coordinator() {
 
   local new_val
   if [ -z "$current" ]; then
-    new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    new_val="${AGENT_NAME}:${AGENT_ROLE// /}"
   else
     # Deduplicate: remove any prior entry for this agent then add fresh
     # Use grep -v || true: if this agent is the only registered agent, grep -v returns exit code 1
     # (no matches), which would crash the script under set -euo pipefail
     new_val=$(echo "$current" | tr ',' '\n' | grep -v "^${AGENT_NAME}:" || true)
     new_val=$(echo "$new_val" | tr '\n' ',' | sed 's/,$//')
-    [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE}" || new_val="${AGENT_NAME}:${AGENT_ROLE}"
+    # Issue #1491: strip spaces from AGENT_ROLE to prevent trailing-space entries
+    # that silently break find_best_agent_for_issue() role comparisons
+    [ -n "$new_val" ] && new_val="${new_val},${AGENT_NAME}:${AGENT_ROLE// /}" || new_val="${AGENT_NAME}:${AGENT_ROLE// /}"
   fi
 
   # Build patch data — include lastPlannerSeen timestamp for planners (issue #1274)


### PR DESCRIPTION
## Summary

Fixes a silent bug where trailing spaces in `AGENT_ROLE` prevent all workers from being considered for specialization routing, keeping `specializedAssignments = 0` forever.

## Root Cause

`activeAgents` entries sometimes contain trailing spaces (e.g., `worker-123:worker ` instead of `worker-123:worker`). When `find_best_agent_for_issue()` parses the role with `cut -d: -f2`, the result is `"worker "`. The check `[ "$agent_role" != "worker" ]` then evaluates to `true` (since `"worker " != "worker"`), causing ALL workers to be silently skipped. `specialized_count` stays 0.

## Changes

**coordinator.sh** — defensive fix: trim whitespace when parsing agent_role from activeAgents:
```bash
agent_role=$(echo "$pair" | cut -d: -f2 | tr -d ' ')
```

**entrypoint.sh** — fix at source: strip spaces from AGENT_ROLE when writing to activeAgents:
```bash
new_val="${AGENT_NAME}:${AGENT_ROLE// /}"
```

## Impact

Without this fix, `specializedAssignments` never increments and v0.2 routing validation always shows `0 agents have specialization data` when agents DO have it — just with trimmed role entries.

Closes #1491