### PR TITLE
fix(identity): write canonical S3 file in update_specialization() and update_identity_stats() (closes #1523)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -374,11 +374,23 @@ update_identity_stats() {
     --argjson inc "$increment" \
     '.stats[$stat] = (.stats[$stat] // 0) + $inc')
   
-  # Save back to S3
+  # Save back to S3 (per-session file)
   if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
     echo "[identity] Updated stat: $stat_name += $increment"
   else
     echo "[identity] WARNING: Could not save updated stats to S3"
+  fi
+
+  # Issue #1523: Also update canonical file so stats persist across agent restarts.
+  # The canonical file (identities/canonical/<displayName>.json) is what new agents
+  # inherit via claim_identity(). Without this, all stats are lost on next session.
+  if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical stats: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not save stats to canonical path (non-fatal)"
+    fi
   fi
 }
 
@@ -452,11 +464,24 @@ update_specialization() {
     updated_json=$(echo "$updated_json" | jq --arg spec "$specialization" '.specialization = $spec')
   fi
   
-  # Save updated identity
+  # Save updated identity (per-session file)
   if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
     echo "[identity] Updated specialization tracking: labels=$issue_labels"
   else
     echo "[identity] WARNING: Could not save specialization update to S3"
+  fi
+
+  # Issue #1523: Also update canonical file so specialization persists across agent restarts.
+  # The canonical file (identities/canonical/<displayName>.json) is loaded by claim_identity()
+  # when the next agent inherits this display name. Without this update, specialization data
+  # (specializationLabelCounts) is lost — the root cause of specializedAssignments=0.
+  if [[ -n "$AGENT_DISPLAY_NAME" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical specialization: $canonical_path (spec=$AGENT_SPECIALIZATION)"
+    else
+      echo "[identity] WARNING: Could not save specialization to canonical path (non-fatal)"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

- `update_specialization()` now writes to both `identities/<agent_name>.json` (per-session) AND `identities/canonical/<displayName>.json` (canonical) after updating label counts
- `update_identity_stats()` now also writes to canonical path after updating stats

## Root Cause

`update_specialization()` and `update_identity_stats()` only wrote to `AGENT_IDENTITY_FILE` (per-session path). The canonical file (`identities/canonical/<displayName>.json`) was only written at session START by `save_identity()` / `save_identity_with_inheritance()`.

Since `claim_identity()` loads canonical at startup, any specialization data accumulated during a session was discarded on the next agent restart — the canonical file stayed empty, causing `score_agent_for_issue()` to always return score=0 and `specializedAssignments` to never increment.

## Impact

- This is the final root cause of `specializedAssignments=0` after all the other v0.2 fixes (#1515, #1474, #1483)
- Without this fix, canonical files always have empty `specializationLabelCounts`, so routing is permanently blocked even after agents complete labeled issues
- With this fix, specialization data accumulates correctly across agent generations

## Changes

`images/runner/identity.sh`:
- `update_identity_stats()`: after per-session write, also write to canonical path (non-fatal if fails)
- `update_specialization()`: after per-session write, also write to canonical path (non-fatal if fails)

Closes #1523