### PR TITLE
fix: use GitHub timeline API for duplicate PR detection (closes #1529)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2351,8 +2351,20 @@ spawn_task_and_agent() {
   fi
 
   # DUPLICATE WORK PREVENTION (issue #439): Check if issue already has open PR
+  # Issue #1529: Use GitHub timeline API to find PRs that actually FIX this issue,
+  # not just any PR that mentions the issue number in passing.
+  # The old `gh pr list --search "#N"` matched any PR mentioning N (too broad — false positives).
+  # The timeline API returns PRs that cross-referenced the issue via closes/fixes keywords.
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
-    local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    local existing_pr
+    existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
+      jq -r '[.[] | select(.event == "cross-referenced") |
+              select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
+             first | .source.issue.number // ""' 2>/dev/null || echo "")
+    # Fallback to broad search if API call fails (maintains existing behavior on error)
+    if [ -z "$existing_pr" ]; then
+      existing_pr=$(gh pr list --repo "$REPO" --state open --search "closes:#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    fi
     if [ -n "$existing_pr" ]; then
       log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr}. Skipping spawn."
       post_thought "Skipped spawning worker for issue #${issue}: PR #${existing_pr} already open. Prevents duplicate work." "observation" 8


### PR DESCRIPTION
## Summary

- Fixes false positive duplicate detection in `spawn_task_and_agent()` that could prevent workers from being spawned for legitimate unimplemented issues.
- Replaces `gh pr list --search "#N"` (too broad) with GitHub issue timeline API (precise cross-reference lookup).

## Root Cause

`gh pr list --search "#N"` performs a GitHub full-text search that matches any PR mentioning issue N anywhere — including PRs that merely reference N as a related issue. This caused false positives:

- `gh pr list --search "#1474"` returned PR #1482 (which fixes #1480 but mentions #1474 in its body as a related issue)
- Planner sees "PR #1482 exists for issue #1474" and skips spawning a worker for #1474
- Issue #1474 was eventually worked by other paths, but the protection is fragile

## Fix

Use the GitHub timeline API to find PRs that **properly cross-referenced** the issue (via closes/fixes/resolves keywords). The timeline API distinguishes "this PR fixes #N" from "this PR mentions N in passing":

```bash
existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
  jq -r '[.[] | select(.event == "cross-referenced") |
          select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
         first | .source.issue.number // ""')
```

Added fallback to `closes:#N` search if the API call fails, to maintain coverage when GitHub API is temporarily unavailable.

## Testing

After merge:
- `spawn_task_and_agent` for issue #1474 will correctly detect only PR #1479 (not PR #1482 or any other false positive)
- Issues with no open PR but PRs that mention them will no longer be incorrectly blocked

Closes #1529