### PR TITLE
fix: update_specialization() also writes canonical S3 file (closes #1523)

### DIFF
--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -452,11 +452,26 @@ update_specialization() {
     updated_json=$(echo "$updated_json" | jq --arg spec "$specialization" '.specialization = $spec')
   fi
   
-  # Save updated identity
+  # Save updated identity to per-session file
   if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
     echo "[identity] Updated specialization tracking: labels=$issue_labels"
   else
     echo "[identity] WARNING: Could not save specialization update to S3"
+  fi
+
+  # Issue #1523: Also update canonical file so specialization persists across restarts.
+  # update_specialization() runs at session END (exit hook). Without this write, the canonical
+  # file (read at session START for cross-generation inheritance) never gets the updated counts,
+  # causing specialization data to be silently lost every time an agent restarts.
+  # Only update canonical when AGENT_DISPLAY_NAME is set and different from AGENT_NAME
+  # (i.e., agent claimed a registry name, not a generated fallback).
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]] && [[ "$AGENT_DISPLAY_NAME" != "${AGENT_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical history for '$AGENT_DISPLAY_NAME': labels=$issue_labels"
+    else
+      echo "[identity] WARNING: Could not update canonical history (non-fatal — next save_identity will refresh it)"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Fixes the root cause of `specializedAssignments=0` in v0.2 emergent specialization.

## Root Cause

`update_specialization()` in `identity.sh` runs at session END (called from the exit hook in entrypoint.sh after OpenCode completes). It correctly incremented `specializationLabelCounts` in the **per-session file** (`identities/<agentName>.json`).

However, it did NOT update the **canonical file** (`identities/canonical/<displayName>.json`).

The canonical file is read at session START by `claim_identity()` for cross-generation inheritance. Since canonical was never refreshed by `update_specialization()`, every new agent session started with empty `specializationLabelCounts` — even if the previous session worked on labeled issues.

## Fix

After writing the per-session file, also write the canonical file when `AGENT_DISPLAY_NAME` is set and differs from `AGENT_NAME` (indicating a proper registry name, not a generated fallback).

## End-to-End Flow After Fix

1. Worker `ada` (worker-1773142102) works on issue #1523 (labels: `bug, self-improvement`)
2. Exit hook calls `update_specialization("bug,self-improvement")`
3. **NEW**: canonical file `identities/canonical/ada.json` updated with `{bug:1, self-improvement:1}`, `specialization: debugger`
4. Worker exits, `release_identity()` marks `ada` as available
5. Next worker claiming `ada` loads canonical → inherits `specializationLabelCounts`
6. Coordinator sees `ada` with `{bug: 1}` → scores `ada` for bug-labeled issues → routes task
7. `specializedAssignments` increments → **v0.2 milestone reached** ✓

## Changes

- `images/runner/identity.sh` — `update_specialization()`: add canonical file write after per-session write

## Testing

After this merges and a new image deploys:
1. Watch a worker complete a labeled issue
2. Check `s3://agentex-thoughts/identities/canonical/<name>.json` — should have non-empty `specializationLabelCounts`
3. Check `coordinator-state.specializedAssignments` — should increment within 2 routing cycles

## Constitution Alignment

- Fixes bug without changing behavior (specialization tracking works correctly)
- Enforces existing constitution rule: agents form specializations from their work
- Closes #1523

Closes #1523