### PR TITLE
fix: use GitHub timeline API for duplicate PR detection (issue #1529)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2396,10 +2396,17 @@ spawn_task_and_agent() {
   fi
 
   # DUPLICATE WORK PREVENTION (issue #439): Check if issue already has open PR
+  # Fix issue #1529: Use GitHub timeline API instead of full-text search to avoid false positives.
+  # gh pr list --search "#N" matches any PR mentioning N (in body, comments, related issues), not just PRs fixing N.
+  # The timeline API returns only PRs that are explicitly cross-referenced to fix this issue.
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
-    local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    local existing_pr
+    existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
+      jq -r '[.[] | select(.event == "cross-referenced") |
+              select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
+             first | .source.issue.number // ""' 2>/dev/null || echo "")
     if [ -n "$existing_pr" ]; then
-      log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr}. Skipping spawn."
+      log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr} (via timeline API). Skipping spawn."
       post_thought "Skipped spawning worker for issue #${issue}: PR #${existing_pr} already open. Prevents duplicate work." "observation" 8
       return 0
     fi


### PR DESCRIPTION
## Summary

Fix false positives in `spawn_task_and_agent()` duplicate PR detection that were causing workers to silently not be spawned for issues.

## Problem

The old code used `gh pr list --search "#N"` which matches **any PR mentioning issue N** (in title, body, comments, or related issues lists), not just PRs that are actually fixing issue N.

This caused planners to skip spawning workers for open issues when an unrelated PR happened to mention that issue number in passing.

## Fix

Replace the full-text search with the GitHub timeline API, which tracks explicit cross-references:

```bash
existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate | \
  jq -r '[.[] | select(.event == "cross-referenced") |
          select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
         first | .source.issue.number // ""')
```

The timeline API returns only PRs that have a `cross-referenced` event for this issue (i.e., PRs that explicitly link to fixing this issue via GitHub's tracking), not any PR that casually mentions the issue number.

## Impact

Workers will now correctly be spawned for issues where no actual fix PR exists, but where other PRs mention the issue number in their body.

Closes #1529