### PR TITLE
fix: touch liveness probe files before auth retry to prevent coordinator crash-loop (closes #1526)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -113,6 +113,17 @@ gh_auth_with_retry() {
   return 1
 }
 
+# Issue #1526: Touch liveness probe files BEFORE auth retry to prevent crash-loop.
+# The Kubernetes liveness probe (initialDelaySeconds=30, periodSeconds=30, failureThreshold=3)
+# kills the coordinator at t=90s if /tmp/coordinator-alive doesn't exist yet.
+# gh_auth_with_retry() can take up to 90s (30s + 60s delays across 3 attempts) if GitHub
+# rate-limits the pod at startup. This caused continuous crash-loops when auth was slow.
+# Creating the file here signals "process is alive" — NOT that auth succeeded.
+# Auth failure is handled gracefully (gh commands log warnings, coordinator continues).
+touch /tmp/coordinator-alive
+touch /tmp/coordinator-ready
+echo "Liveness probe files created early (before auth, issue #1526)"
+
 if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
   echo "GitHub token loaded from read-only file mount"


### PR DESCRIPTION
## Summary

- Coordinator crash-loops when GitHub auth takes longer than the Kubernetes liveness probe window (90s total = 30+60s backoff)
- Fix: create `/tmp/coordinator-alive` and `/tmp/coordinator-ready` BEFORE `gh_auth_with_retry()` is called

## Root Cause

The coordinator startup sequence:
1. `gh_auth_with_retry()` — retries with 30s + 60s delays (up to 90s total on failure)
2. ... hundreds of lines later ...
3. `touch /tmp/coordinator-alive` ← **Kubernetes kills the pod before this line**

The liveness probe: `initialDelaySeconds=30, periodSeconds=30, failureThreshold=3` = pod killed at t=90s if file doesn't exist.

## Fix

Move the `touch /tmp/coordinator-alive` + `touch /tmp/coordinator-ready` to BEFORE the auth calls (Option A from the issue). Auth failure is already handled gracefully — the coordinator continues with logged warnings.

## Changes

- `images/runner/coordinator.sh`: add 3 lines before the GitHub token load block (lines 116-132)

Closes #1526

## Testing

After this fix, coordinator pods will survive auth retry cycles. The liveness probe will see the file at t=0, and auth can proceed at its own pace.