### PR TITLE
fix: use GitHub timeline API for accurate duplicate PR detection

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2395,9 +2395,14 @@ spawn_task_and_agent() {
     log "Issue #${issue} validated: state=$issue_state"
   fi
 
-  # DUPLICATE WORK PREVENTION (issue #439): Check if issue already has open PR
+  # DUPLICATE WORK PREVENTION (issue #439, fixed #1529): Check if issue already has open PR
+  # Issue #1529: Use GitHub issue timeline API to find PRs that actually close this issue,
+  # not just PRs that mention it. The --search approach gives false positives.
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
-    local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    local existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
+      jq -r '[.[] | select(.event == "cross-referenced") | 
+              select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] | 
+             first | .source.issue.number // ""')
     if [ -n "$existing_pr" ]; then
       log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr}. Skipping spawn."
       post_thought "Skipped spawning worker for issue #${issue}: PR #${existing_pr} already open. Prevents duplicate work." "observation" 8


### PR DESCRIPTION
## Summary

Fixes #1529 — spawn_task_and_agent() now uses GitHub issue timeline API to accurately detect open PRs that close an issue, eliminating false positives from the previous full-text search approach.

## Problem

The previous implementation used `gh pr list --search "#N"` which matches **any PR mentioning issue N anywhere** (title, body, comments), not just PRs that fix it. This caused false positives that silently prevented worker spawning.

Example: When checking for PRs fixing #1474, the search returned:
- PR #1479 (correct — closes #1474)
- PR #1482 (false positive — mentions #1474 as related)
- PR #1514 (false positive — lists #1474 in related-issues)
- PR #1516 (false positive — docs PR listing all issues)

## Changes

**File**: `images/runner/entrypoint.sh` line 2398-2405

**Before**:
```bash
local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
```

**After**:
```bash
local existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
  jq -r '[.[] | select(.event == "cross-referenced") | 
          select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] | 
         first | .source.issue.number // ""')
```

## Why This Works

The GitHub timeline API tracks cross-references natively. When a PR body contains "Closes #N", GitHub creates a `cross-referenced` event in issue N's timeline. By filtering for events where:
1. The event is a cross-reference
2. The source is a pull request (not another issue)
3. The PR state is open

We get **only PRs that actually link to this issue**, not passing mentions.

## Testing

- ✅ Bash syntax check passed
- ✅ Timeline API returns empty string when no open PRs exist
- ✅ Timeline API correctly identifies cross-referenced PRs

## Impact

- Eliminates false positives that blocked worker spawning
- More accurate duplicate work prevention
- Planners won't mis-report "PR already open" for issues without PRs

Closes #1529