### PR TITLE
fix: pre-claim specialization routing so route_tasks_by_specialization() actually fires (closes #1474)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2276,6 +2276,32 @@ route_tasks_by_specialization() {
         best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels" "$active_assignments")
 
         if [ -n "$best_agent" ]; then
+            # Issue #1474: Pre-claim the issue on the agent's behalf by writing to activeAssignments.
+            # Previously routing only wrote to lastRoutingDecisions, which workers ignored.
+            # Now the coordinator acts as a "pre-assigning authority" — the agent entry is
+            # already in activeAssignments when the worker starts, so claim_task() detects
+            # it as already claimed (by itself) and returns 0 immediately.
+            local current_assignments
+            current_assignments=$(get_state "activeAssignments")
+            # Only pre-assign if agent doesn't already have another issue assigned
+            local normalized_current
+            normalized_current=$(echo "$current_assignments" | tr -d ' ')
+            if ! echo "$normalized_current" | grep -qE "(^|,)${best_agent}:"; then
+                # Append pre-assignment to activeAssignments
+                local pre_assignment="${best_agent}:${issue_num}"
+                if [ -z "$current_assignments" ]; then
+                    update_state "activeAssignments" "$pre_assignment"
+                else
+                    update_state "activeAssignments" "${current_assignments},${pre_assignment}"
+                fi
+                echo "[$(date -u +%H:%M:%S)] PRE-ASSIGNED issue #$issue_num → $best_agent (written to activeAssignments)"
+                # Also write to /tmp for the working issue tracking
+                # Update active_assignments for subsequent loop iterations
+                active_assignments=$(get_state "activeAssignments")
+            else
+                echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING (not pre-assigned: $best_agent already has active issue): #$issue_num"
+            fi
+
             # Record specialized routing decision in coordinator state
             local routing_entry="${issue_num}:${best_agent}"
             routing_log="${routing_log}${routing_entry};"

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1505,6 +1505,31 @@ request_coordinator_task() {
   local max_retries=3
   local retry=0
 
+  # ── COORDINATOR PRE-ASSIGNMENT CHECK (issue #1474) ───────────────────────
+  # The coordinator's route_tasks_by_specialization() runs every 7 iterations (~3.5 min).
+  # Previously it only wrote to lastRoutingDecisions, which workers never checked.
+  # Fix: coordinator now pre-writes "agent:issue" to activeAssignments before workers start.
+  # Here, we check if the coordinator already pre-assigned an issue to us.
+  # If yes, use it directly — skip the queue scan. claim_task() will return 0 immediately
+  # (detecting it was already claimed by us) and we proceed to work the issue.
+  local pre_assignments
+  pre_assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+  if [ -n "$pre_assignments" ]; then
+    # Look for a pre-assignment for this agent
+    local pre_assigned_issue
+    pre_assigned_issue=$(echo "$pre_assignments" | tr -d ' ' | tr ',' '\n' | \
+      grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1)
+    if [ -n "$pre_assigned_issue" ] && [[ "$pre_assigned_issue" =~ ^[0-9]+$ ]]; then
+      log "Coordinator: found coordinator pre-assignment: issue #$pre_assigned_issue (specialized routing)"
+      # Write to temp file for end-of-session specialization tracking (issue #1252)
+      echo "$pre_assigned_issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+      COORDINATOR_ISSUE="$pre_assigned_issue"
+      push_metric "SpecializedTaskClaimed" 1
+      return 0
+    fi
+  fi
+
   # ── VISION QUEUE PRIORITY CHECK (issue #1149) ────────────────────────────
   # Check vision queue BEFORE the regular task queue. If a vision-queue item
   # is a GitHub issue number, claim it. If it's a feature name, log it for the


### PR DESCRIPTION
## Summary

Fixes the root cause of `specializedAssignments` permanently staying at 0 since the specialization routing feature was added.

**Root cause**: `route_tasks_by_specialization()` ran every 7 coordinator iterations (~3.5 min), but workers called `request_coordinator_task()` at startup and already raced to claim all available tasks. By the time routing ran, `activeAssignments` was full → routing found nothing to assign → `specializedAssignments` stayed 0.

## Changes

### coordinator.sh
- When `route_tasks_by_specialization()` finds a best-matched agent, it now **pre-writes the assignment to `activeAssignments`** directly on the agent's behalf (Option A from issue #1474).
- If the agent already has an active issue, the pre-assignment is skipped (agents work one issue at a time).
- After pre-assigning, `active_assignments` is refreshed so subsequent loop iterations don't double-assign.

### entrypoint.sh
- `request_coordinator_task()` now checks `activeAssignments` for a **pre-assignment for this agent** BEFORE scanning the queue.
- If a coordinator pre-assignment is found, it's used directly — the queue race is bypassed entirely.
- Emits `SpecializedTaskClaimed` CloudWatch metric when pre-assignment is used.
- Writes the pre-assigned issue to `/tmp/agentex-worked-issue` for end-of-session specialization tracking.

## How It Works (end-to-end)

1. Coordinator routing cycle runs at iteration 7 (first time ~3.5 min after start).
2. It finds agent `ada` (specialization=`debugger`) is best match for issue `#1523` (labels: `bug`).
3. Coordinator writes `ada:1523` to `activeAssignments`.
4. Next time `ada` (or a worker claiming the `ada` display name) calls `request_coordinator_task()`, it finds `ada:1523` pre-assigned and uses it directly.
5. `specializedAssignments` increments → **v0.2 milestone achieved**.

## Notes

- The pre-assignment uses `update_state()` (simple merge patch), not CAS. There's a small race window where two routing cycles could both try to pre-assign the same agent, but the second write will be idempotent (same agent:issue pair).
- The `cleanup_stale_assignments()` coordinator function will release stale pre-assignments if the targeted agent never picks them up (same 30s cleanup logic as regular assignments).

Closes #1474