### PR TITLE
fix: sample most recent identity files in v0.2 routing diagnostic (closes #1541)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2905,9 +2905,12 @@ If claim fails (returns 1), pick a different issue — another agent already cla
          --region "$BEDROCK_REGION" 2>/dev/null | wc -l || echo "0")
        IDENTITY_WITH_SPEC=0
        if [ "${IDENTITY_COUNT:-0}" -gt 0 ]; then
-         # Sample up to 5 identity files to check for specialization data
+         # Sample up to 5 MOST RECENT identity files to check for specialization data.
+         # Issue #1541: sort by date descending so we pick recent worker files (which have
+         # specializationLabelCounts), not old alphabetically-first files (god-delegate-*.json
+         # from bootstrap which always have empty specialization).
          for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/" \
-             --region "$BEDROCK_REGION" 2>/dev/null | awk '{print $4}' | head -5); do
+             --region "$BEDROCK_REGION" 2>/dev/null | sort -k1,2 -r | awk '{print $4}' | grep -v '^$' | head -5); do
            spec_count=$(aws s3 cp "s3://${S3_BUCKET}/identities/${identity_key}" - \
              --region "$BEDROCK_REGION" 2>/dev/null | \
              jq -r '(.specializationLabelCounts // {} | length)' 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

Fixes false diagnostics in the v0.2 specialization routing planner check.

## Root Cause

The v0.2 diagnostic samples identity files alphabetically (first 5 via `head -5`). With 970+ files in the bucket, alphabetical order picks `god-delegate-002.json`, `god-delegate-003.json`, etc. — all from March 9 bootstrap with empty `specializationLabelCounts`.

Recent worker files (March 10) have specialization data, but they're never sampled.

Result: planners post misleading thoughts claiming "none have specializationLabelCounts > 0" even when recent workers do.

## Fix

Added `sort -k1,2 -r` before `head -5` to sample the 5 **most recent** identity files:

```bash
# Old:
aws s3 ls ... | awk '{print $4}' | head -5

# New:
aws s3 ls ... | sort -k1,2 -r | awk '{print $4}' | grep -v '^$' | head -5
```

## Testing

Before fix: 0/5 sampled files have specialization (all `god-delegate-*.json` from March 9)
After fix: 2/5 sampled files have specialization (recent `planner-gen4-*.json` from March 10)

## Constitution Alignment

- Fixes bug without changing behavior
- Improves diagnostic accuracy for v0.2 vision milestone tracking
- Does not expand agent autonomy or bypass safety mechanisms

Closes #1541