### PR TITLE
fix: pre-claim specialization routing so route_tasks_by_specialization() actually fires (closes #1474)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2339,12 +2339,33 @@ route_tasks_by_specialization() {
         best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels" "$active_assignments")
 
         if [ -n "$best_agent" ]; then
-            # Record specialized routing decision in coordinator state
-            local routing_entry="${issue_num}:${best_agent}"
-            routing_log="${routing_log}${routing_entry};"
-            specialized_count=$((specialized_count + 1))
-            push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
-            echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num → $best_agent"
+            # Issue #1474: Pre-claim the issue on behalf of the specialized agent.
+            # Write best_agent:issue_num directly to activeAssignments so the agent
+            # finds its pre-assignment when it calls request_coordinator_task().
+            # Without this, workers race to claim tasks BEFORE routing runs and
+            # find nothing left to route, keeping specializedAssignments = 0 forever.
+            local new_pre_assignments
+            local cur_assignments
+            cur_assignments=$(get_state "activeAssignments")
+            if [ -z "$cur_assignments" ]; then
+                new_pre_assignments="${best_agent}:${issue_num}"
+            else
+                new_pre_assignments="${cur_assignments},${best_agent}:${issue_num}"
+            fi
+            if update_state "activeAssignments" "$new_pre_assignments"; then
+                # Also update the local variable so subsequent iterations see the new assignment
+                active_assignments="$new_pre_assignments"
+
+                # Record specialized routing decision in coordinator state
+                local routing_entry="${issue_num}:${best_agent}"
+                routing_log="${routing_log}${routing_entry};"
+                specialized_count=$((specialized_count + 1))
+                push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
+                echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING (pre-claimed): issue #$issue_num → $best_agent"
+            else
+                echo "[$(date -u +%H:%M:%S)] WARNING: pre-claim write failed for $best_agent:$issue_num — falling back to generic"
+                generic_count=$((generic_count + 1))
+            fi
         else
             generic_count=$((generic_count + 1))
         fi

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1512,6 +1512,27 @@ request_coordinator_task() {
   local max_retries=3
   local retry=0
 
+  # ── SPECIALIZATION PRE-ASSIGNMENT CHECK (issue #1474) ────────────────────
+  # The coordinator pre-claims issues on behalf of specialized workers via
+  # route_tasks_by_specialization(). Check if coordinator has already written
+  # this agent's name to activeAssignments. If so, use that pre-assigned issue
+  # without racing against other workers for an item in the task queue.
+  local pre_assignments
+  pre_assignments=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+  if [ -n "$pre_assignments" ]; then
+    local pre_issue
+    pre_issue=$(echo "$pre_assignments" | tr ',' '\n' | grep "^${AGENT_NAME}:" | cut -d: -f2 | head -1 | tr -d ' ')
+    if [ -n "$pre_issue" ] && [ "$pre_issue" != "0" ]; then
+      log "Coordinator: found pre-assignment for $AGENT_NAME — issue #$pre_issue (specialized routing)"
+      push_metric "PreAssignedTaskClaimed" 1
+      COORDINATOR_ISSUE="$pre_issue"
+      # Persist to temp file for end-of-session specialization tracking (issue #1252)
+      echo "$pre_issue" > /tmp/agentex-worked-issue 2>/dev/null || true
+      return 0
+    fi
+  fi
+
   # ── VISION QUEUE PRIORITY CHECK (issue #1149) ────────────────────────────
   # Check vision queue BEFORE the regular task queue. If a vision-queue item
   # is a GitHub issue number, claim it. If it's a feature name, log it for the


### PR DESCRIPTION
## Summary

Fixes the fundamental v0.2 routing bug where `specializedAssignments` stays at 0 forever because workers claim all tasks before routing ever runs.

## Root Cause

`route_tasks_by_specialization()` runs every 7th coordinator iteration (~3.5 min). By that time, workers have already claimed all available tasks via `claim_task()`. Routing iterates the queue but skips every issue already in `activeAssignments` — finding nothing to route.

## Fix (Option A from issue)

**coordinator.sh**: When `find_best_agent_for_issue()` finds a matching agent, write `best_agent:issue_num` directly to `activeAssignments` (coordinator pre-claim). This prevents other workers from racing for the same issue.

**entrypoint.sh**: At the START of `request_coordinator_task()`, check if `activeAssignments` already contains this agent's name (coordinator pre-claim). If found, return that issue immediately without scanning the queue.

## Before / After

**Before**: Worker starts → calls `claim_task()` → grabs first available issue → routing runs → finds nothing → `specializedAssignments = 0`

**After**: Routing runs → finds specialized agent → pre-writes `best_agent:issue` to `activeAssignments` → worker starts → sees pre-assignment → uses it directly → `specializedAssignments++`

## Backward Compatibility

- Workers without a pre-assignment fall through to the existing queue-scanning logic
- Workers that were pre-assigned but whose issue gets closed by another worker will get `COORDINATOR_ISSUE` set to a closed issue — but `release_coordinator_task()` handles cleanup gracefully
- The `update_state()` write in coordinator.sh uses the same pattern as other state updates

Closes #1474