### PR TITLE
fix: use timeline API for duplicate PR check to avoid false positives (closes #1529)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2396,8 +2396,16 @@ spawn_task_and_agent() {
   fi
 
   # DUPLICATE WORK PREVENTION (issue #439): Check if issue already has open PR
+  # Issue #1529: Use timeline API instead of `gh pr list --search "#N"` to avoid false positives.
+  # `--search "#N"` matches ANY PR mentioning issue N (related links, docs, etc.), not just
+  # PRs that CLOSE the issue. The timeline API checks for PRs explicitly cross-referenced by
+  # GitHub's closing keyword mechanism (closes/fixes/resolves #N).
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
-    local existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+    local existing_pr
+    existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate 2>/dev/null | \
+      jq -r '[.[] | select(.event == "cross-referenced") |
+              select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
+             first | .source.issue.number // ""' 2>/dev/null || echo "")
     if [ -n "$existing_pr" ]; then
       log "DUPLICATE DETECTION: Issue #${issue} already has open PR #${existing_pr}. Skipping spawn."
       post_thought "Skipped spawning worker for issue #${issue}: PR #${existing_pr} already open. Prevents duplicate work." "observation" 8


### PR DESCRIPTION
## Summary

Fixes #1529 — `spawn_task_and_agent()` duplicate PR check was producing false positives, causing planners to silently skip spawning workers for issues that had unrelated PRs mentioning them.

## Root Cause

The old check:
```bash
existing_pr=$(gh pr list --repo "$REPO" --state open --search "#${issue}" ...)
```

`--search "#N"` matches ANY PR mentioning issue N anywhere (title, body, related-issues sections, docs, etc.). This meant PRs like docs PRs listing all v0.2 PRs, or PRs mentioning an issue as "related work", would block worker spawning for that issue.

## Fix

Replace full-text search with GitHub's timeline API which specifically tracks cross-referenced PRs via closing keywords (`closes/fixes/resolves #N`):

```bash
existing_pr=$(gh api "repos/${REPO}/issues/${issue}/timeline" --paginate | \
  jq -r '[.[] | select(.event == "cross-referenced") |
          select((.source.issue.pull_request != null) and (.source.issue.state == "open"))] |
         first | .source.issue.number // ""')
```

This only returns PRs that explicitly use a closing keyword linking them to the issue — the correct semantic for "PR is fixing this issue".

## Impact

- Prevents false positives in duplicate detection
- Workers will no longer be silently blocked from issues that merely had related mentions in other PRs
- More reliable planner behavior when checking if an issue is already being worked on

## Related

- Issue #1529
- Issue #439 (original duplicate prevention feature)
- Issue #1474 (PR #1479 was blocked by false positive from this bug)

Closes #1529