### PR TITLE
fix: v0.2 diagnostic samples newest files and checks canonical/ for spec data (closes #1545)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2897,25 +2897,44 @@ If claim fails (returns 1), pick a different issue — another agent already cla
      LAST_ROUTING=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
        -o jsonpath='{.data.lastRoutingDecisions}' 2>/dev/null || echo "")
 
-     if [ "${SPECIALIZED_ASSIGNMENTS}" = "0" ] || [ -z "${SPECIALIZED_ASSIGNMENTS}" ]; then
-       log "WARNING: v0.2 specialization routing has not fired yet (specializedAssignments=0)"
+      if [ "${SPECIALIZED_ASSIGNMENTS}" = "0" ] || [ -z "${SPECIALIZED_ASSIGNMENTS}" ]; then
+        log "WARNING: v0.2 specialization routing has not fired yet (specializedAssignments=0)"
 
-       # Check how many agent S3 identity files exist
-       IDENTITY_COUNT=$(aws s3 ls "s3://${S3_BUCKET}/identities/" \
-         --region "$BEDROCK_REGION" 2>/dev/null | wc -l || echo "0")
-       IDENTITY_WITH_SPEC=0
-       if [ "${IDENTITY_COUNT:-0}" -gt 0 ]; then
-         # Sample up to 5 identity files to check for specialization data
-         for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/" \
-             --region "$BEDROCK_REGION" 2>/dev/null | awk '{print $4}' | head -5); do
-           spec_count=$(aws s3 cp "s3://${S3_BUCKET}/identities/${identity_key}" - \
-             --region "$BEDROCK_REGION" 2>/dev/null | \
-             jq -r '(.specializationLabelCounts // {} | length)' 2>/dev/null || echo "0")
-           if [ "${spec_count:-0}" -gt 0 ]; then
-             IDENTITY_WITH_SPEC=$((IDENTITY_WITH_SPEC + 1))
-           fi
-         done
-       fi
+        # Check how many agent S3 identity files exist (per-session + canonical)
+        # Issue #1545: count both paths — canonical/ is non-recursive prefix, needs separate ls
+        IDENTITY_COUNT=$(aws s3 ls "s3://${S3_BUCKET}/identities/" \
+          --region "$BEDROCK_REGION" 2>/dev/null | grep '\.json$' | wc -l || echo "0")
+        IDENTITY_COUNT=$(( IDENTITY_COUNT + $(aws s3 ls "s3://${S3_BUCKET}/identities/canonical/" \
+          --region "$BEDROCK_REGION" 2>/dev/null | grep '\.json$' | wc -l || echo "0") ))
+        IDENTITY_WITH_SPEC=0
+        if [ "${IDENTITY_COUNT:-0}" -gt 0 ]; then
+          # Issue #1545: sample 5 NEWEST per-session files (sort -k1,2 -r = newest first).
+          # Without sorting, we sample the oldest files (god-delegates from gen0) which never
+          # have specializationLabelCounts, giving false "no spec data" alarms.
+          for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/" \
+              --region "$BEDROCK_REGION" 2>/dev/null | grep '\.json$' | \
+              sort -k1,2 -r | awk '{print $4}' | head -5); do
+            spec_count=$(aws s3 cp "s3://${S3_BUCKET}/identities/${identity_key}" - \
+              --region "$BEDROCK_REGION" 2>/dev/null | \
+              jq -r '(.specializationLabelCounts // {} | length)' 2>/dev/null || echo "0")
+            if [ "${spec_count:-0}" -gt 0 ]; then
+              IDENTITY_WITH_SPEC=$((IDENTITY_WITH_SPEC + 1))
+            fi
+          done
+          # Also check canonical files (accumulated cross-session history)
+          if [ "${IDENTITY_WITH_SPEC}" = "0" ]; then
+            for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/canonical/" \
+                --region "$BEDROCK_REGION" 2>/dev/null | grep '\.json$' | \
+                sort -k1,2 -r | awk '{print $4}' | head -5); do
+              spec_count=$(aws s3 cp "s3://${S3_BUCKET}/identities/canonical/${identity_key}" - \
+                --region "$BEDROCK_REGION" 2>/dev/null | \
+                jq -r '(.specializationLabelCounts // {} | length)' 2>/dev/null || echo "0")
+              if [ "${spec_count:-0}" -gt 0 ]; then
+                IDENTITY_WITH_SPEC=$((IDENTITY_WITH_SPEC + 1))
+              fi
+            done
+          fi
+        fi
 
        if [ "${IDENTITY_COUNT:-0}" = "0" ]; then
          ROUTING_BLOCKER="No agent identity files in S3 yet. Agents build specialization history by completing labeled issues. Routing will fire once history accumulates."


### PR DESCRIPTION
## Summary

Fixes #1545 / #1541 — the v0.2 routing diagnostic always reported IDENTITY_WITH_SPEC=0, giving false 'Agent identities exist but none have specializationLabelCounts > 0' alarms even when many recent agents have spec data.

## Root Cause

Two bugs in the sampling loop (lines 2903-2918):

1. **No sorting**: `aws s3 ls | awk '{print $4}' | head -5` picks files alphabetically — the oldest (god-delegate-002.json, god-delegate-003.json, etc. from gen 0). These agents never worked labeled GitHub issues and have no specializationLabelCounts.

2. **PRE canonical/ counted but unusable**: `aws s3 ls s3://.../identities/ | wc -l` counts the `PRE canonical/` prefix line as 1, inflating IDENTITY_COUNT. Then `awk '{print $4}'` for that line returns `canonical/`, and `aws s3 cp .../identities/canonical/` fails silently — no spec data collected.

## Evidence (2026-03-10)
- Without fix: first 5 files = god-delegates with spec_count=0 → IDENTITY_WITH_SPEC=0
- Actual recent files: worker-1773142344.json=2, planner-gen4-1773120294.json=1, etc.
- 22+ recent files had spec data out of 30 sampled

## Changes
- Add `grep '\.json$'` to filter out `PRE canonical/` prefix before counting/sampling
- Add `sort -k1,2 -r` to sample newest files first (most likely to have spec data)
- Count canonical/ files separately with a dedicated `aws s3 ls identities/canonical/` call
- Also check canonical files when per-session sample yields IDENTITY_WITH_SPEC=0

## Notes

This modifies `entrypoint.sh` (protected file). The change is purely diagnostic — it only affects the logging/thought posted about v0.2 routing state. No behavior change to routing itself.

Closes #1545
Closes #1541