### PR TITLE
fix: trim agent_role whitespace in find_best_agent_for_issue() (closes #1548)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2235,8 +2235,11 @@ find_best_agent_for_issue() {
         [ -z "$pair" ] && continue
         local agent_name="${pair%%:*}"
         # Use cut for role: supports both "name:role" and "name:role:displayName" format
+        # Issue #1548: trim whitespace from agent_role — activeAgents entries can have trailing
+        # spaces (e.g., "worker-123:worker ") from pre-PR-#1473 update_state() echo bug.
+        # Without trimming, "worker " != "worker" causes ALL workers to be silently skipped.
         local agent_role
-        agent_role=$(echo "$pair" | cut -d: -f2)
+        agent_role=$(echo "$pair" | cut -d: -f2 | tr -d '[:space:]')
         # Issue #1515: extract displayName from triplet (name:role:displayName)
         # Supports old "name:role" format (displayName will be empty string)
         local agent_display_name


### PR DESCRIPTION
## Summary

Defensive fix for v0.2 specialization routing: trim trailing whitespace from `agent_role` when parsing activeAgents entries in `find_best_agent_for_issue()`.

## Root Cause

`activeAgents` coordinator state entries can have trailing spaces in the role field (e.g., `worker-123:worker `) from the legacy `update_state()` echo-based write bug (pre-PR-#1473). When `find_best_agent_for_issue()` parses the role:

```bash
# Before fix:
agent_role=$(echo "$pair" | cut -d: -f2)
# Result: "worker " (with trailing space)

# Check:
[ "$agent_role" != "worker" ] && continue
# "worker " != "worker" → TRUE → agent SKIPPED
```

This silently skips ALL workers with trailing spaces in their registry entry, keeping `specializedAssignments=0` forever.

## Fix

```bash
# After fix:
agent_role=$(echo "$pair" | cut -d: -f2 | tr -d '[:space:]')
```

## Impact

- Workers with legacy space-padded role entries are no longer skipped
- specializedAssignments can now increment when routing conditions are met
- coordinator.sh only — no protected file changes needed

## Related

- PR #1531 (also fixes entrypoint.sh at source — requires god-approved)
- Issue #1548 (new issue filed for this specific coordinator.sh fix)
- Issue #1491 (closed — this was root cause)

Closes #1548