### PR TITLE
fix: sample most recent 5 identity files for v0.2 diagnostic

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2906,8 +2906,8 @@ If claim fails (returns 1), pick a different issue — another agent already cla
        IDENTITY_WITH_SPEC=0
        if [ "${IDENTITY_COUNT:-0}" -gt 0 ]; then
          # Sample up to 5 identity files to check for specialization data
-         for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/" \
-             --region "$BEDROCK_REGION" 2>/dev/null | awk '{print $4}' | head -5); do
+          for identity_key in $(aws s3 ls "s3://${S3_BUCKET}/identities/" \
+              --region "$BEDROCK_REGION" 2>/dev/null | sort -k1,2 -r | awk '{print $4}' | grep -v '^$' | head -5); do
            spec_count=$(aws s3 cp "s3://${S3_BUCKET}/identities/${identity_key}" - \
              --region "$BEDROCK_REGION" 2>/dev/null | \
              jq -r '(.specializationLabelCounts // {} | length)' 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

Fixes #1541 — v0.2 specialization diagnostic was sampling the oldest identity files (god-delegate-*.json from bootstrap), which all have empty `specializationLabelCounts`. This caused false reports of "no specialization found" when recent workers DO have specialization data.

## Root Cause

`aws s3 ls` returns files alphabetically, and `head -5` picked the first (oldest) 5 files. The oldest files are god-delegate-*.json from March 9 bootstrap, which never worked on labeled issues.

Recent worker identity files (planner-gen4-*.json) from March 10 DO have specialization data like `{bug:2, enhancement:1}`.

## Fix

Add `sort -k1,2 -r` before `head -5` to sample the **most recent 5** identity files by timestamp:

```bash
# Before (sampled oldest/alphabetical):
for identity_key in $(aws s3 ls ... | awk '{print $4}' | head -5); do

# After (samples most recent 5):
for identity_key in $(aws s3 ls ... | sort -k1,2 -r | awk '{print $4}' | grep -v '^$' | head -5); do
```

## Impact

- Diagnostic now accurately reports whether recent agents have specialization data
- Prevents false reports in thought stream: "no agents have specialization" when they actually do
- Enables correct diagnosis: issue #1474 (timing) is the real root cause, not lack of specialization

## Changes

- Modified: `images/runner/entrypoint.sh` line 2910 (added sort + grep filters)

Closes #1541