### PR TITLE
fix: coordinator pre-claims tasks for specialized agents (closes #1474)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2339,12 +2339,50 @@ route_tasks_by_specialization() {
         best_agent=$(find_best_agent_for_issue "$issue_num" "$issue_labels" "$active_assignments")
 
         if [ -n "$best_agent" ]; then
-            # Record specialized routing decision in coordinator state
-            local routing_entry="${issue_num}:${best_agent}"
-            routing_log="${routing_log}${routing_entry};"
-            specialized_count=$((specialized_count + 1))
-            push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
-            echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num → $best_agent"
+            # Pre-claim the issue on behalf of the best agent using CAS on activeAssignments.
+            # (issue #1474: route_tasks_by_specialization() never fired because workers claimed
+            # tasks before routing ran — fix: coordinator pre-claims on the agent's behalf.
+            # When the worker later calls claim_task(), it sees its own name in activeAssignments
+            # and returns success immediately instead of racing the generic queue.)
+            local current_assignments
+            current_assignments=$(get_state "activeAssignments")
+            local pre_claim_entry="${best_agent}:${issue_num}"
+
+            # Refresh active_assignments so subsequent iterations in this loop see the pre-claim
+            active_assignments="$current_assignments"
+
+            # Only pre-claim if not already in activeAssignments (idempotent)
+            if ! echo ",${current_assignments}," | grep -q ",${pre_claim_entry},"; then
+                local new_assignments
+                if [ -z "$current_assignments" ]; then
+                    new_assignments="$pre_claim_entry"
+                else
+                    new_assignments="${current_assignments},${pre_claim_entry}"
+                fi
+                # Atomic CAS to prevent races with concurrent claim_task() calls
+                local cas_patch
+                if [ -z "$current_assignments" ]; then
+                    cas_patch="[{\"op\":\"add\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]"
+                else
+                    cas_patch="[{\"op\":\"test\",\"path\":\"/data/activeAssignments\",\"value\":\"${current_assignments}\"},{\"op\":\"replace\",\"path\":\"/data/activeAssignments\",\"value\":\"${new_assignments}\"}]"
+                fi
+                if kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+                    --type=json -p "${cas_patch}" 2>/dev/null; then
+                    echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: pre-claimed issue #$issue_num for $best_agent (assignments: $new_assignments)"
+                    # Update local active_assignments so the skip check works for subsequent loop iterations
+                    active_assignments="$new_assignments"
+                    # Record specialized routing decision in coordinator state
+                    local routing_entry="${issue_num}:${best_agent}"
+                    routing_log="${routing_log}${routing_entry};"
+                    specialized_count=$((specialized_count + 1))
+                    push_metric "SpecializedTaskRouting" 1 "Count" "IssueNumber=${issue_num}"
+                else
+                    echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: CAS failed for issue #$issue_num → $best_agent (concurrent modification) — falling back to generic"
+                    generic_count=$((generic_count + 1))
+                fi
+            else
+                echo "[$(date -u +%H:%M:%S)] SPECIALIZED ROUTING: issue #$issue_num already pre-claimed for $best_agent — skipping"
+            fi
         else
             generic_count=$((generic_count + 1))
         fi


### PR DESCRIPTION
## Summary

Fixes #1474 — `route_tasks_by_specialization()` never fired in production because workers claimed all available tasks before the routing cycle ran.

## Root Cause

The coordinator's routing function ran every 7 iterations (~3.5 min). By that time, workers had already called `claim_task()` and written their assignments into `activeAssignments`. The routing function only **recorded recommendations** in `lastRoutingDecisions` but workers never checked this field — so `specializedAssignments` stayed 0 forever.

## Fix

When `find_best_agent_for_issue()` returns a match, the coordinator now **atomically pre-claims** the issue in `activeAssignments` on the agent's behalf using CAS (test+replace kubectl patch):

1. Coordinator routing fires → finds active specialized agent for an issue
2. Coordinator pre-claims: writes `agent:issue` into `activeAssignments` via CAS
3. Worker calls `claim_task(issue)` → sees its own name already in `activeAssignments` → returns 0 (success, no race needed)
4. `specializedAssignments` increments → v0.2 milestone validated

## Flow After Fix

```
route_tasks_by_specialization():
  for each issue in taskQueue:
    if already in activeAssignments → skip
    find_best_agent_for_issue() → best_agent
    if best_agent found:
      CAS: activeAssignments += "best_agent:issue"   ← NEW
      specialized_count++
    else:
      generic_count++
```

Worker side (no change needed — existing claim_task() already handles this):
```
claim_task(issue):
  if "AGENT_NAME:issue" already in activeAssignments:
    log "already claimed by us — continuing"
    return 0  ← worker picks up pre-assigned issue correctly
```

## Changes

- Only `images/runner/coordinator.sh` modified (NOT a protected file)
- Replaces the old "record-only" routing with atomic pre-claiming
- CAS is idempotent (skips if pre-claim already present)
- On CAS failure: falls back to generic assignment, logs it
- Updates `local active_assignments` after pre-claim so subsequent loop iterations skip double-routing

## Testing Note

This should cause `coordinator-state.specializedAssignments` to increment from 0 once a specialized worker is active and a matching issue is in the queue. Validate by monitoring:
```bash
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.specializedAssignments}'
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastRoutingDecisions}'
```

## Related

- Issue #1474 (root cause: timing mismatch)
- Issue #1475 (related: identity lookup by displayName — complementary concern)
- PR #1479 (prior fix attempt — same Option A approach but included entrypoint.sh changes that require god-approved; this PR only touches coordinator.sh)
- Issue #1098 (emergent specialization — this unblocks v0.2)
- Issue #1145 (v0.2 milestone — `specializedAssignments > 0` will now happen)