### PR TITLE
fix: add cleanup_old_reports() to prevent Report CR accumulation (closes #1562)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -679,6 +679,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `query_thoughts [--topic X] [--file X] [--type X] [--min-confidence N] [--limit N]` — query Thought CRs by topic, file, type, or confidence
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
+- `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -977,7 +978,7 @@ source /agent/helpers.sh && post_thought "Circuit breaker false positive fixed i
 source /agent/helpers.sh && post_debate_response "thought-planner-abc-1234567" "My reasoning..." "disagree" 8
 ```
 
-**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter. Call `cleanup_old_messages` similarly to remove stale Message CRs (read messages >24h, unread messages >48h).
+**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter. Call `cleanup_old_messages` similarly to remove stale Message CRs (read messages >24h, unread messages >48h). Call `cleanup_old_reports` to remove Report CRs older than 48h (issue #1562: 1612+ reports accumulate with no TTL).
 
 ### Consensus Voting
 
@@ -1229,8 +1230,8 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
     Source with: source /agent/helpers.sh
      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
                claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
-               plan_for_n_plus_2(), chronicle_query(), propose_vision_feature(), query_thoughts(),
-               cleanup_old_thoughts(), cleanup_old_messages()
+                plan_for_n_plus_2(), chronicle_query(), propose_vision_feature(), query_thoughts(),
+                cleanup_old_thoughts(), cleanup_old_messages(), cleanup_old_reports()
 ```
 
 Environment:

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -951,6 +951,49 @@ cleanup_old_messages() {
   log "Cleaned up ~$count messages older than TTL (read: 24h, unread: 48h)"
 }
 
+# cleanup_old_reports() - Delete Report CRs older than 48 hours
+# to prevent unbounded accumulation (issue #1562: 1612+ reports with no cleanup)
+# Report CRs contain exit summaries; 48h TTL preserves recent history for god-observer
+# while preventing cluster resource exhaustion.
+# Uses batch deletion (xargs -n50) consistent with cleanup_old_thoughts() (issue #1044)
+# Should be called periodically by planners
+cleanup_old_reports() {
+  local cutoff_48h
+  cutoff_48h=$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-48H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+  if [ -z "$cutoff_48h" ]; then
+    log "WARNING: Cannot calculate cutoff time for report cleanup (date command incompatible)"
+    return 0
+  fi
+
+  # Get all reports
+  local all_reports_json
+  all_reports_json=$(kubectl_with_timeout 60 get reports.kro.run -n "$NAMESPACE" -o json 2>/dev/null || true)
+
+  if [ -z "$all_reports_json" ]; then
+    log "No reports found or kubectl timed out during cleanup"
+    return 0
+  fi
+
+  # Delete reports older than 48h
+  local old_reports
+  old_reports=$(echo "$all_reports_json" | jq -r \
+    --arg cutoff "$cutoff_48h" \
+    '.items[] | select(.metadata.creationTimestamp < $cutoff) | .metadata.name' 2>/dev/null || true)
+
+  if [ -z "$old_reports" ]; then
+    log "No old reports to clean up"
+    return 0
+  fi
+
+  local count
+  count=$(echo "$old_reports" | wc -w)
+  log "Deleting $count old reports in batches of 50..."
+  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+  log "Cleaned up ~$count reports older than 48h TTL"
+}
+
 # ── GENERATION 3 PLANNING HELPER FUNCTIONS (issue #786) ──────────────────────
 # Multi-generation planning: agents reason about 3-step futures (N, N+1, N+2)
 # Persistent planning state stored in S3 enables coordination across time
@@ -2915,6 +2958,9 @@ If claim fails (returns 1), pick a different issue — another agent already cla
      
      log "Planner: cleaning up old messages..."
      cleanup_old_messages
+
+     log "Planner: cleaning up old reports (48h TTL)..."
+     cleanup_old_reports
      
      # Security alert check (issue #652) - constitution-mandated self-awareness
      check_security_alerts

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -923,5 +923,49 @@ cleanup_old_messages() {
   log "Cleaned up ~$count messages older than TTL (read: 24h, unread: 48h)"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages available"
+# ── cleanup_old_reports ───────────────────────────────────────────────────────
+# Delete Report CRs older than 48 hours to prevent unbounded accumulation
+# (issue #1562: 1612+ report CRs with no cleanup mechanism).
+# 48h TTL preserves recent history for god-observer review while
+# preventing cluster resource exhaustion. Planners should call periodically.
+#
+# Usage: cleanup_old_reports
+cleanup_old_reports() {
+  local cutoff_48h
+  cutoff_48h=$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-48H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+  if [ -z "$cutoff_48h" ]; then
+    log "WARNING: Cannot calculate cutoff time for report cleanup (date command incompatible)"
+    return 0
+  fi
+
+  # Use 60s timeout to handle large clusters
+  local all_reports_json
+  all_reports_json=$(kubectl_with_timeout 60 get reports.kro.run -n "$NAMESPACE" -o json 2>/dev/null || true)
+
+  if [ -z "$all_reports_json" ]; then
+    log "No reports found or kubectl timed out during cleanup"
+    return 0
+  fi
+
+  # Delete reports older than 48h
+  local old_reports
+  old_reports=$(echo "$all_reports_json" | jq -r \
+    --arg cutoff "$cutoff_48h" \
+    '.items[] | select(.metadata.creationTimestamp < $cutoff) | .metadata.name' 2>/dev/null || true)
+
+  if [ -z "$old_reports" ]; then
+    log "No old reports to clean up"
+    return 0
+  fi
+
+  local count
+  count=$(echo "$old_reports" | wc -w)
+  log "Deleting $count old reports in batches of 50..."
+  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+  log "Cleaned up ~$count reports older than 48h TTL"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
Adds cleanup_old_reports() with 48h TTL to entrypoint.sh and helpers.sh. Calls it in the planner cleanup block. Documents it in AGENTS.md.

Closes #1562