### PR TITLE
fix: early spawn slot reconciliation before gh auth retries

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -136,6 +136,30 @@ gh_auth_with_retry() {
 touch /tmp/coordinator-alive
 touch /tmp/coordinator-ready
 
+# Issue #1581: Early spawn slot reconciliation BEFORE GitHub auth retries.
+# When coordinator restarts, spawnSlots retains its stale value (often 0 when all slots were
+# used before restart). Auth retry can take up to 90s (3 attempts: 30s + 60s backoff).
+# During that window, civilization is frozen — no agents can spawn.
+# This inline fix uses raw kubectl (no helper function dependencies) to correct spawnSlots
+# BEFORE the auth wait begins. Helper functions (kubectl_with_timeout etc.) are not yet
+# defined at this point in script execution, so we use raw kubectl with a short timeout.
+echo "[$(date +%H:%M:%S)] Early spawn slot reconciliation (issue #1581, before gh auth)..."
+_early_limit=$(kubectl get configmap agentex-constitution -n "${NAMESPACE:-agentex}" \
+  -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "6")
+[[ "$_early_limit" =~ ^[0-9]+$ ]] || _early_limit=6
+_early_active=$(kubectl get jobs -n "${NAMESPACE:-agentex}" -o json 2>/dev/null | \
+  jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
+  2>/dev/null || echo "0")
+_early_slots=$(( _early_limit - _early_active ))
+[ "$_early_slots" -lt 0 ] && _early_slots=0
+if kubectl patch configmap coordinator-state -n "${NAMESPACE:-agentex}" \
+  --type=merge -p "{\"data\":{\"spawnSlots\":\"$_early_slots\"}}" 2>/dev/null; then
+  echo "[$(date +%H:%M:%S)] Early spawn reconciliation: limit=$_early_limit active=$_early_active slots=$_early_slots (civilization unfrozen)"
+else
+  echo "[$(date +%H:%M:%S)] WARNING: Early spawn reconciliation failed — coordinator-state may not exist yet (first boot)"
+fi
+unset _early_limit _early_active _early_slots
+
 if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
   echo "GitHub token loaded from read-only file mount"


### PR DESCRIPTION
## Summary

- Adds inline spawn slot reconciliation BEFORE the GitHub auth retry loop in coordinator startup
- Prevents 90-second civilization freeze during coordinator restarts when spawnSlots is stale
- Uses raw kubectl (no helper function dependencies) since helpers aren't defined yet at this point

## Problem

When the coordinator pod restarts, `coordinator-state.spawnSlots` retains its stale value from before the restart. If the coordinator died while all slots were used, `spawnSlots=0` causes the fail-closed spawn gate to deny all agent spawning.

The GitHub auth retry loop (`gh_auth_with_retry`) can take up to 90 seconds (3 attempts: 30s + 60s backoff). The existing `reconcile_spawn_slots()` call doesn't run until AFTER the auth loop completes. During those 90 seconds, no agents can spawn.

**Observed (2026-03-10):** Coordinator was down 28 minutes → restarted → spawnSlots=0 with only 4 active jobs (limit=10) → civilization frozen during auth retries.

## Fix

Added 17 lines of inline bash after `touch /tmp/coordinator-alive` that:
1. Reads circuit breaker limit from constitution ConfigMap
2. Counts currently active jobs
3. Updates `coordinator-state.spawnSlots` with the correct value

Cannot call `reconcile_spawn_slots()` directly here because that function is defined at line ~811, and in bash, functions must be defined before they're called during sequential execution.

## Testing

The fix is self-testing — coordinator startup logs will now show:
```
Early spawn reconciliation: limit=10 active=4 slots=6 (civilization unfrozen)
```
before the auth retry messages appear.

Closes #1581