### PR TITLE
fix: replace gh issue view GraphQL with REST API to survive rate limits (closes #1586)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -649,8 +649,9 @@ refresh_task_queue() {
                     # Only numeric entries map to GitHub issues; non-numeric feature entries are kept
                     if [[ "$vq_entry" =~ ^[0-9]+$ ]]; then
                         local vq_issue_state
-                        vq_issue_state=$(gh issue view "$vq_entry" --repo "${GITHUB_REPO}" \
-                            --json state --jq '.state' 2>/dev/null || echo "OPEN")
+                        # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures
+                        vq_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${vq_entry}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+                        [ -z "$vq_issue_state" ] && vq_issue_state="OPEN"  # fail-open
                         if [ "$vq_issue_state" = "CLOSED" ]; then
                             echo "[$(date -u +%H:%M:%S)] visionQueue: pruning closed issue #$vq_entry"
                             vq_pruned_count=$((vq_pruned_count + 1))
@@ -736,9 +737,11 @@ cleanup_stale_assignments() {
             return 0
         fi
         # Not cached — fetch from GitHub API
+        # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures.
+        # Fail-open: empty/error response → OPEN (don't prematurely release valid assignments).
         local fetched
-        fetched=$(gh issue view "$iss" --repo "${GITHUB_REPO}" --json state \
-            --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        fetched=$(gh api "repos/${GITHUB_REPO}/issues/${iss}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+        [ -z "$fetched" ] && fetched="OPEN"  # fail-open: assume open if REST API unavailable
         # Add to cache
         issue_state_cache="${issue_state_cache} ${iss}=${fetched}"
         echo "$fetched"
@@ -1536,8 +1539,10 @@ NUDGE_EOF
 
                  if [ -n "$add_issue" ]; then
                      # Issue #1436: Validate issue is OPEN before adding to visionQueue
+                     # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures (fail-open)
                      local add_issue_state
-                     add_issue_state=$(gh issue view "$add_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                     add_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${add_issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+                     [ -z "$add_issue_state" ] && add_issue_state="OPEN"  # fail-open: assume open if API unavailable
                      if [ "$add_issue_state" != "OPEN" ]; then
                          echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue is $add_issue_state — skipping visionQueue add"
                      else
@@ -1613,8 +1618,10 @@ NUDGE_EOF
                      vision_issue=$(echo "$kv_pairs" | grep -oE '(issueNumber|addIssue)=[0-9]+' | head -1 | cut -d= -f2 || echo "")
                      if [ -n "$vision_issue" ]; then
                          # Issue #1436: Validate issue is OPEN before adding to visionQueue
+                         # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures (fail-open)
                          local vision_issue_state
-                         vision_issue_state=$(gh issue view "$vision_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                         vision_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${vision_issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+                         [ -z "$vision_issue_state" ] && vision_issue_state="OPEN"  # fail-open: assume open if API unavailable
                          if [ "$vision_issue_state" != "OPEN" ]; then
                              echo "[$(date -u +%H:%M:%S)] VISION QUEUE: issue #$vision_issue is $vision_issue_state — skipping visionQueue add"
                              patched=true
@@ -1688,8 +1695,10 @@ NUDGE_EOF
                 add_issue=$(echo "$kv_pairs" | tr ' ' '\n' | grep "^addIssue=" | cut -d= -f2 | head -1 || echo "")
                  if [ -n "$add_issue" ] && [[ "$add_issue" =~ ^[0-9]+$ ]]; then
                      # Issue #1436: Validate issue is OPEN before adding to visionQueue
+                     # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures (fail-open)
                      local add_issue_open_state
-                     add_issue_open_state=$(gh issue view "$add_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                     add_issue_open_state=$(gh api "repos/${GITHUB_REPO}/issues/${add_issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+                     [ -z "$add_issue_open_state" ] && add_issue_open_state="OPEN"  # fail-open: assume open if API unavailable
                      if [ "$add_issue_open_state" != "OPEN" ]; then
                          echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue is $add_issue_open_state — skipping visionQueue add"
                      else

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1609,8 +1609,11 @@ request_coordinator_task() {
 
        # Issue #1362: Validate the issue is still OPEN before claiming
        # (mirrors the closed-issue check in the regular queue path at issue #1015)
+       # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures
+       # Fail-open: if API unavailable, assume OPEN to preserve queue integrity
        local vq_issue_state
-       vq_issue_state=$(gh issue view "$vq_feature" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+       vq_issue_state=$(gh api "repos/${REPO}/issues/${vq_feature}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+       [ -z "$vq_issue_state" ] && vq_issue_state="OPEN"  # fail-open: assume open if API unavailable
        if [ "$vq_issue_state" != "OPEN" ]; then
          log "Coordinator: vision-queue issue #$vq_feature is $vq_issue_state — removing from visionQueue"
          # Remove this closed item from visionQueue to prevent future agents from hitting it
@@ -1758,8 +1761,11 @@ request_coordinator_task() {
     # The coordinator queue may be stale and contain closed issues.
     # If the issue is closed, release the claim and remove from queue to avoid
     # wasting agent sessions on already-resolved work.
+    # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures.
+    # Fail-open: if API unavailable, assume OPEN to preserve task queue integrity.
     local issue_state
-    issue_state=$(gh issue view "$claimed_issue" --repo "${REPO}" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")  # issue #1066: was GITHUB_REPO (undefined), correct var is REPO
+    issue_state=$(gh api "repos/${REPO}/issues/${claimed_issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")  # issue #1066 fix, #1586: REST API, fail-open
+    [ -z "$issue_state" ] && issue_state="OPEN"  # fail-open: assume open if REST API unavailable
     if [ "$issue_state" != "OPEN" ]; then
       log "Coordinator: issue #$claimed_issue is $issue_state — releasing claim and removing from queue"
       # Release the claim atomically
@@ -2476,8 +2482,16 @@ spawn_task_and_agent() {
   log "Creating Task $task_name and Agent $agent_name (role=$role)"
 
   # ISSUE VALIDATION (issue #561): Verify GitHub issue exists and is open
+  # Issue #1586: Use REST API instead of GraphQL to avoid rate-limit failures.
+  # Fail-open for API errors: assume OPEN to avoid blocking spawns during rate-limit storms.
   if [ "$issue" != "0" ] && [ "$issue" -gt 0 ] 2>/dev/null; then
-    local issue_state=$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+    local issue_state
+    issue_state=$(gh api "repos/${REPO}/issues/${issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]' || echo "")
+    
+    if [ -z "$issue_state" ]; then
+      log "WARNING: Could not verify issue #${issue} state via REST API — assuming OPEN (fail-open)"
+      issue_state="OPEN"
+    fi
     
     if [ "$issue_state" = "NOT_FOUND" ]; then
       log "ERROR: GitHub issue #${issue} does not exist. Skipping spawn."


### PR DESCRIPTION
## Summary

Fixes cascading failures during GitHub GraphQL rate-limit storms by replacing `gh issue view --json` (GraphQL) with `gh api` (REST API) in all issue-state validation calls.

## Problem

When GitHub GraphQL rate limits are exceeded, `gh issue view --json state` fails silently, returning nothing or erroring. This caused two cascading failures:

1. **`spawn_task_and_agent()`**: Issue state returned empty → treated as `NOT_FOUND` → spawn skipped → workers never dispatched
2. **`request_coordinator_task()`**: Issue state returned empty → treated as non-`OPEN` → claim released + issue REMOVED from coordinator queue → task queue wiped clean
3. **`cleanup_stale_assignments()`**: All assignments returned `UNKNOWN` → all treated as stale → everything pruned

## Fix

Replace all `gh issue view "$issue" --repo "$REPO" --json state --jq '.state'` with:
```bash
gh api "repos/${REPO}/issues/${issue}" --jq '.state' 2>/dev/null | tr '[:lower:]' '[:upper:]'
```

All calls use **fail-open** behavior: empty/error response → assume `OPEN` to preserve queue/assignment integrity during rate-limit storms.

## Changes

- `images/runner/entrypoint.sh`: 3 locations fixed
  - `spawn_task_and_agent()` issue validation
  - `request_coordinator_task()` closed-issue check
  - Vision-queue priority path closed-issue check
- `images/runner/coordinator.sh`: 4 locations fixed
  - `_get_issue_state()` in `cleanup_stale_assignments()` (also fixes #1578)
  - visionQueue prune loop
  - Two visionQueue add-validation paths

## Impact

- Workers now spawn reliably during rate-limit storms
- Task queue no longer wiped by false `NOT_FOUND` detections
- Stale assignments no longer mass-pruned during rate-limit events
- REST API has much higher rate limits than GraphQL

Closes #1586