### PR TITLE
fix: replace GraphQL gh issue view with REST api for issue state checks (coordinator.sh)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -649,8 +649,11 @@ refresh_task_queue() {
                     # Only numeric entries map to GitHub issues; non-numeric feature entries are kept
                     if [[ "$vq_entry" =~ ^[0-9]+$ ]]; then
                         local vq_issue_state
-                        vq_issue_state=$(gh issue view "$vq_entry" --repo "${GITHUB_REPO}" \
-                            --json state --jq '.state' 2>/dev/null || echo "OPEN")
+                        # Issue #1578: Use REST API to avoid GraphQL rate-limit failures.
+                        # Fallback to OPEN (keep the entry) if the API call fails.
+                        # ascii_upcase normalizes REST ("open"/"closed") to match comparison values.
+                        vq_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${vq_entry}" \
+                            --jq '.state | ascii_upcase' 2>/dev/null || echo "OPEN")
                         if [ "$vq_issue_state" = "CLOSED" ]; then
                             echo "[$(date -u +%H:%M:%S)] visionQueue: pruning closed issue #$vq_entry"
                             vq_pruned_count=$((vq_pruned_count + 1))
@@ -735,10 +738,12 @@ cleanup_stale_assignments() {
             echo "$cached"
             return 0
         fi
-        # Not cached — fetch from GitHub API
+        # Not cached — fetch from GitHub API (REST, not GraphQL, to avoid rate limit failures)
+        # Issue #1578: gh issue view --json uses GraphQL; gh api uses REST which is rate-limited
+        # separately and more resilient. UNKNOWN fallback keeps the assignment so agents don't
+        # lose work — better to keep a stale assignment than to silently drop active work.
         local fetched
-        fetched=$(gh issue view "$iss" --repo "${GITHUB_REPO}" --json state \
-            --jq '.state' 2>/dev/null || echo "UNKNOWN")
+        fetched=$(gh api "repos/${GITHUB_REPO}/issues/${iss}" --jq '.state | ascii_upcase' 2>/dev/null || echo "UNKNOWN")
         # Add to cache
         issue_state_cache="${issue_state_cache} ${iss}=${fetched}"
         echo "$fetched"
@@ -1536,8 +1541,11 @@ NUDGE_EOF
 
                  if [ -n "$add_issue" ]; then
                      # Issue #1436: Validate issue is OPEN before adding to visionQueue
-                     local add_issue_state
-                     add_issue_state=$(gh issue view "$add_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                      local add_issue_state
+                      # Issue #1578: Use REST API to avoid GraphQL rate-limit failures.
+                      # ascii_upcase normalizes REST ("open"/"closed") to match comparison values.
+                      add_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${add_issue}" \
+                          --jq '.state | ascii_upcase' 2>/dev/null || echo "unknown")
                      if [ "$add_issue_state" != "OPEN" ]; then
                          echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue is $add_issue_state — skipping visionQueue add"
                      else
@@ -1613,8 +1621,11 @@ NUDGE_EOF
                      vision_issue=$(echo "$kv_pairs" | grep -oE '(issueNumber|addIssue)=[0-9]+' | head -1 | cut -d= -f2 || echo "")
                      if [ -n "$vision_issue" ]; then
                          # Issue #1436: Validate issue is OPEN before adding to visionQueue
-                         local vision_issue_state
-                         vision_issue_state=$(gh issue view "$vision_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                          local vision_issue_state
+                          # Issue #1578: Use REST API to avoid GraphQL rate-limit failures.
+                          # ascii_upcase normalizes REST ("open"/"closed") to match comparison values.
+                          vision_issue_state=$(gh api "repos/${GITHUB_REPO}/issues/${vision_issue}" \
+                              --jq '.state | ascii_upcase' 2>/dev/null || echo "unknown")
                          if [ "$vision_issue_state" != "OPEN" ]; then
                              echo "[$(date -u +%H:%M:%S)] VISION QUEUE: issue #$vision_issue is $vision_issue_state — skipping visionQueue add"
                              patched=true
@@ -1688,8 +1699,11 @@ NUDGE_EOF
                 add_issue=$(echo "$kv_pairs" | tr ' ' '\n' | grep "^addIssue=" | cut -d= -f2 | head -1 || echo "")
                  if [ -n "$add_issue" ] && [[ "$add_issue" =~ ^[0-9]+$ ]]; then
                      # Issue #1436: Validate issue is OPEN before adding to visionQueue
-                     local add_issue_open_state
-                     add_issue_open_state=$(gh issue view "$add_issue" --repo "${GITHUB_REPO}" --json state --jq '.state' 2>/dev/null || echo "unknown")
+                      local add_issue_open_state
+                      # Issue #1578: Use REST API to avoid GraphQL rate-limit failures.
+                      # ascii_upcase normalizes REST ("open"/"closed") to match comparison values.
+                      add_issue_open_state=$(gh api "repos/${GITHUB_REPO}/issues/${add_issue}" \
+                          --jq '.state | ascii_upcase' 2>/dev/null || echo "unknown")
                      if [ "$add_issue_open_state" != "OPEN" ]; then
                          echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: issue #$add_issue is $add_issue_open_state — skipping visionQueue add"
                      else


### PR DESCRIPTION
## Summary

Fixes #1578 — `cleanup_stale_assignments()` and related functions in `coordinator.sh` used `gh issue view --json state` (GraphQL) to check issue state. Under GraphQL rate limits, this returns an error → fallback `UNKNOWN` → stale closed-issue assignments are kept → workers waste cycles on already-closed issues.

## Root Cause

`gh issue view --json` uses the GitHub GraphQL API. REST and GraphQL have separate rate limit budgets; when GraphQL is exhausted, REST still works. All issue-state checks should use `gh api repos/.../issues/N` (REST).

## Changes

Replaced all 5 occurrences of `gh issue view "$x" --repo ... --json state --jq '.state'` with `gh api "repos/${GITHUB_REPO}/issues/${x}" --jq '.state | ascii_upcase'`:

1. `_get_issue_state()` helper in `cleanup_stale_assignments()` — the primary fix described in the issue
2. `visionQueue` pruning in `refresh_task_queue()`
3. VISION-FEATURE governance handler (first occurrence)
4. VISION QUEUE governance handler
5. VISION-FEATURE governance handler (second occurrence)

**Note:** `ascii_upcase` is required because REST returns lowercase (`"open"`, `"closed"`) while GraphQL returned uppercase (`"OPEN"`, `"CLOSED"`). The existing comparison values (`"OPEN"`, `"CLOSED"`) are preserved.

## Related

Part of GraphQL-to-REST migration: #1570 (refresh_task_queue), #1576 (auth check), #1578 (cleanup_stale_assignments + visionQueue handlers).

Closes #1578