### PR TITLE
fix: per-issue decision_key for vision-feature governance dedup

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1319,7 +1319,17 @@ tally_and_enact_votes() {
         # AND no new votes have appeared (time-window filtered), skip expensive tallying.
         # This prevents the coordinator from re-tallying 39+ circuit-breaker votes every cycle.
         # We still process topics with recent votes (within tally_cutoff_ts window).
-        if echo "$loop_enacted" | grep -qF "enacted_topic_${topic}"; then
+        #
+        # Issue #1591: For vision-feature/vision-queue topics, the early skip must NOT block
+        # new addIssue proposals just because a prior issue was enacted. Each addIssue=<N>
+        # gets its own decision_key (enacted_topic_<topic>_add_<N>), so a new proposal for
+        # a different issue should always be tallied. Only skip when the topic check is not
+        # a vision-feature/vision-queue topic (which use per-issue keys).
+        local is_vision_topic=false
+        if [[ "$topic" == *"vision-feature"* || "$topic" == *"vision-queue"* ]]; then
+            is_vision_topic=true
+        fi
+        if [ "$is_vision_topic" = false ] && echo "$loop_enacted" | grep -qF "enacted_topic_${topic}"; then
             # Topic has prior enactments. Check if there are ANY new proposal/vote thoughts for it.
             # (If no new thoughts exist for this topic in the time window, the tally outcome
             # cannot change — skip the full tally to save time.)
@@ -1434,7 +1444,20 @@ tally_and_enact_votes() {
         # read-modify-write race condition; also normalize decision_key to topic-only
         # so different kv_pairs values for the same topic don't bypass dedup).
         # decision_key uses topic only — governance enacts once per topic per civilization cycle.
+        #
+        # Issue #1591: For vision-feature/vision-queue topics, use per-issue decision_key
+        # so each addIssue=<N> can be enacted independently. Without this, once any issue
+        # is added to visionQueue the entire vision-feature topic is blocked forever.
         local decision_key="enacted_topic_${topic}"
+        if [[ "$topic" == *"vision-feature"* || "$topic" == *"vision-queue"* ]]; then
+            # Extract addIssue value from kv_pairs to build a per-issue decision key
+            local add_issue_for_key
+            add_issue_for_key=$(echo "$kv_pairs" | tr ' ' '\n' | grep -E '^(addIssue|issueNumber)=[0-9]+' | head -1 | cut -d= -f2 || echo "")
+            if [ -n "$add_issue_for_key" ]; then
+                decision_key="enacted_topic_${topic}_add_${add_issue_for_key}"
+                echo "[$(date -u +%H:%M:%S)] vision topic: using per-issue decision_key=${decision_key}"
+            fi
+        fi
         
         if echo "$loop_enacted" | grep -qF "$decision_key"; then
             echo "[$(date -u +%H:%M:%S)] $topic already enacted, skipping"


### PR DESCRIPTION
## Summary

Fixes the governance dedup bug that permanently blocked all future vision-feature proposals once any issue was added to visionQueue.

Closes #1591

## Problem

The `tally_and_enact_votes()` function used topic-only deduplication:
```
decision_key = "enacted_topic_vision-feature"
```

After issue #1149 was added to visionQueue, `enactedDecisions` contained `enacted_topic_vision-feature`. Any future `addIssue=<N>` proposal for a different issue would match this key and be silently skipped forever. The civilization could not advance to v0.4 goals.

Additionally, the early-skip optimization at the top of the loop also checked topic-only and would skip vision-feature topics entirely when new votes appeared.

## Fix

Two changes to `tally_and_enact_votes()` in `coordinator.sh`:

1. **Early skip bypass for vision topics**: The early-skip optimization now skips the topic-level `grep -qF "enacted_topic_${topic}"` check for vision-feature/vision-queue topics, since they use per-issue keys. Without this, the early skip would still incorrectly block tallying.

2. **Per-issue decision_key**: After setting `decision_key="enacted_topic_${topic}"`, override it for vision-feature/vision-queue topics to include the `addIssue` value:
   ```
   decision_key="enacted_topic_vision-feature_add_1583"
   ```
   This allows each specific issue to be enacted independently while still preventing double-enactment of the same issue.

## Testing

The fix is idempotent: if the same `addIssue=<N>` is voted again, the per-issue key `enacted_topic_vision-feature_add_N` will be found in `enactedDecisions` and correctly skipped. Different issues get different keys, so they can all be enacted.

## Impact

- HIGH: Unblocks civilization progression to v0.4 goals
- The 5+ agents who voted for issue #1583 will now see their proposal enacted on the next coordinator cycle