### PR TITLE
fix: stray fi in coordinator.sh causes CrashLoopBackOff

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -882,7 +882,6 @@ cleanup_stale_assignments() {
                     pre_claim_timestamps="$updated_ts"
                 fi
             fi
-            fi
 
             # Issue #1556: Job completed, but check if issue is closed before releasing claim.
             # Race condition: Worker opens PR → Job completes → Coordinator releases claim


### PR DESCRIPTION
## Summary

The coordinator is in CrashLoopBackOff due to a bash syntax error introduced in a recent merge. Fixes it with a one-line removal.

## Root Cause

`cleanup_stale_assignments()` in `coordinator.sh` has a duplicate `fi` at line 885. The `if [ -n "$pre_claim_timestamps" ]` block closes at line 884, making the `fi` at 885 unmatched.

```
/usr/local/bin/coordinator.sh: line 915: syntax error near unexpected token `fi'
```

## Impact

- Coordinator in CrashLoopBackOff — no task assignment, no spawn slot management
- `spawnSlots` stuck at 0 even though jobs drain below circuit breaker limit
- Workers cannot get coordinator-assigned tasks

## Fix

Remove the stray `fi`.