### PR TITLE
fix: load GitHub token before coordinator task validation (stops planner crash-loop)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2939,6 +2939,24 @@ else
   export RECOVERY_MODE=false
 fi
 
+# ── 3.6.5. Load GitHub token (early — required before coordinator task validation) ──
+# request_coordinator_task() calls `gh api` to validate issue state.
+# GITHUB_TOKEN must be available before that call or gh fails unauthenticated,
+# causing a spurious release_coordinator_task → script exit under set -euo pipefail.
+# The token file is mounted at pod startup; we just need to read it early.
+# (issue #1601 — token was previously only loaded in step 7, ~270 lines too late)
+if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
+  export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
+  export GH_TOKEN="$GITHUB_TOKEN"
+  log "GitHub token loaded early (required for coordinator task validation)"
+elif [ -n "${GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="$GITHUB_TOKEN"
+  log "GitHub token already set in environment"
+else
+  log "ERROR: No GitHub token available (neither GITHUB_TOKEN_FILE nor GITHUB_TOKEN set)"
+  exit 1
+fi
+
 # ── 3.7. Register with coordinator ───────────────────────────────────────────
 # Announce this agent's presence so the coordinator knows who is active.
 register_with_coordinator
@@ -3225,20 +3243,13 @@ post_thought "Task received: $TASK_TITLE. Beginning work." "observation" 8
 
 # ── 7. Clone repo ─────────────────────────────────────────────────────────────
 # Issue #6: Read GitHub token from read-only file mount instead of environment variable
+# Issue #1601: Token is already loaded in step 3.6.5 — this is a no-op guard for safety.
 log "Configuring GitHub authentication..."
-if [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
-  export GITHUB_TOKEN=$(cat "$GITHUB_TOKEN_FILE")
-  log "GitHub token loaded from read-only file mount"
-elif [ -n "${GITHUB_TOKEN:-}" ]; then
-  log "GitHub token loaded from environment variable (legacy)"
-else
+if [ -z "${GITHUB_TOKEN:-}" ]; then
   log "ERROR: No GitHub token available (neither GITHUB_TOKEN_FILE nor GITHUB_TOKEN set)"
   exit 1
 fi
-# Issue #1576: Export GH_TOKEN so gh CLI uses REST API without needing gh auth login.
-# gh CLI reads GH_TOKEN env var for REST API calls, bypassing GraphQL token validation.
-# This ensures gh commands work even when GraphQL rate limit is exceeded.
-export GH_TOKEN="$GITHUB_TOKEN"
+# GH_TOKEN already exported in step 3.6.5
 
 log "Cloning repo..."
 gh auth setup-git


### PR DESCRIPTION
## Summary

Fixes the planner crash-loop that has been blocking the civilization since 2026-03-10.

## Root cause

`request_coordinator_task()` calls `gh api` to validate GitHub issue state at two points:
- Line 1614: vision-queue closed-issue check
- Line 1766: regular queue closed-issue check

But `GITHUB_TOKEN` was only loaded from the file mount in **step 7** (~line 3229), which runs after the coordinator section (~line 2961). Every planner was calling `gh api` unauthenticated.

Result: `gh api` returned empty → treated as `NOT_FOUND` → `release_coordinator_task` called on a non-existent claim → kubectl patch may fail → script exits 1 under `set -euo pipefail`.

Observed symptom in every planner pod log:
```
planner: requesting task from coordinator...
EXIT trap: cleaning up Agent CR ... (exit_code=1)
```

## Fix

Add a new **step 3.6.5** that loads `GITHUB_TOKEN` from the file mount immediately before `register_with_coordinator`. The token file is already mounted at pod startup — it just wasn't being read until 270 lines too late.

Simplify the duplicate token-loading block in step 7 to a no-op safety guard (`[ -z "${GITHUB_TOKEN:-}" ]`).

## Why existing PRs (#1590, #1596, #1600) didn't fix this

Those PRs switched GraphQL → REST API and exported `GH_TOKEN`, but they all exported it at the *same* late location (step 7). The token was still unset when `request_coordinator_task` ran.

## Testing

After image rebuild, planner pods should:
1. Log `"GitHub token loaded early (required for coordinator task validation)"`
2. Successfully request a task from the coordinator
3. NOT exit immediately with `exit_code=1`

## Protected file

This touches `images/runner/entrypoint.sh` — requires `god-approved` label.

Closes #1601