### PR TITLE
fix: add S3 idempotency check to coordinator record_synthesis_debates_to_s3 (closes #1606)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2007,10 +2007,14 @@ record_synthesis_debates_to_s3() {
 
         local s3_path="s3://${s3_bucket}/debates/${thread_id}.json"
 
-        # Issue #1585: Replaced individual aws s3 ls check (1 API call per debate = 200+ calls)
-        # with try-write approach: attempt S3 write; skip silently if file already exists.
-        # S3 PUT is idempotent and overwrites with same data are harmless.
-        # This eliminates the per-debate ls check, cutting API calls roughly in half.
+        # Issue #1606: Skip debates already written to S3 — debate files are immutable once written.
+        # This prevents rewriting all 250+ debates every coordinator cycle (~145k S3 PUTs/day).
+        # The per-cycle limit still bounds total new writes per cycle.
+        if aws s3 ls "$s3_path" >/dev/null 2>&1; then
+            idx=$((idx + 1))
+            continue
+        fi
+
         # Still enforce per-cycle limit to bound coordinator blocking time.
         if [ "$writes_this_cycle" -ge "$max_writes_per_cycle" ]; then
             echo "[$(date -u +%H:%M:%S)] Reached per-cycle write limit ($max_writes_per_cycle) — remaining debates will be written next cycle"


### PR DESCRIPTION
## Summary

Fixes coordinator rewriting all 250+ synthesis debate outcomes to S3 on every coordinator cycle.

Closes #1606

## Problem

`record_synthesis_debates_to_s3()` in coordinator.sh was writing ALL synthesis debate outcomes to S3 every ~2.5 minutes, even for files already persisted. This was causing:
- ~145,000 unnecessary S3 PUTs per day
- Coordinator spending ~12 minutes per cycle writing S3 (3s/write × 252 debates)
- `coordinator-state.lastHeartbeat` appearing stale (coordinator busy writing)

Root cause: The function used a "try-write" approach with comment "S3 PUT is idempotent and overwrites with same data are harmless." — but idempotent ≠ should always be called.

A second implementation in `track_debate_activity()` already correctly checks `aws s3 ls` before writing. This PR applies the same pattern to `record_synthesis_debates_to_s3()`.

## Changes

- `images/runner/coordinator.sh`: Add `aws s3 ls` check before writing debate to S3; skip if file already exists

## Testing

After this fix:
- `record_synthesis_debates_to_s3()` will write 0 files per cycle (all 250+ already exist)
- Coordinator cycle time drops from ~12 min blocking to near-zero for debate writes
- `lastHeartbeat` updates on schedule again
- S3 API calls drop dramatically

## Cost Impact

~145k S3 PUTs/day → near-zero ongoing writes (only new synthesis debates trigger writes, which is rare once all existing ones are captured)