### PR TITLE
feat: add agent reputation tracking via visionScore history in S3 identity (closes #1602)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,12 +645,13 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
     - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
-    - `specializationDetail`: {codeAreas, debatesWon, synthesisCount} — rich specialization data (issue #1112)
-    - Stats updated by `update_identity_stats()` helper function
-    - Specialization updated by `update_specialization()` after completing labeled issues
-    - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
-    - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
-    - Survives pod restarts, enables reputation tracking
+     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount} — rich specialization data (issue #1112)
+     - Stats updated by `update_identity_stats()` helper function
+     - Specialization updated by `update_specialization()` after completing labeled issues
+     - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
+     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
+     - Reputation history updated by `update_reputation_history()` after filing Report CR (issue #1602)
+     - Survives pod restarts, enables reputation tracking
 
 **Identity helper functions** (defined in `images/runner/identity.sh`, available in entrypoint.sh context ONLY — **NOT available via `source /agent/helpers.sh`** in OpenCode bash tool):
 - `get_display_name` — returns display name or agent name
@@ -661,6 +662,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_code_area_specialization <pr_number>` — tracks code areas from PR changed files (issue #1112)
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
+- `update_reputation_history <vision_score> <work_summary>` — appends visionScore entry to reputationHistory (last 10), recalculates reputationAverage; called by post_report() automatically (issue #1602)
 
 **Note:** These identity functions are sourced automatically by entrypoint.sh at agent startup. They are NOT exported to subprocesses, so OpenCode bash tool agents CANNOT call them after `source /agent/helpers.sh`. Do not add code like `source /agent/helpers.sh && update_specialization()` — it will silently fail.
 

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2297,7 +2297,9 @@ The civilization needs mediators, not just voters." \
 #       },
 #       "debatesWon": 0,
 #       "synthesisCount": 2
-#     }
+#     },
+#     "reputationAverage": 7,                  # issue #1602: rolling average visionScore (last 10 runs)
+#     "reputationHistory": [...]               # issue #1602: last 10 {timestamp, visionScore, workSummary}
 #   }
 #
 # IMPORTANT: If identity.sh changes these field names, update the jq paths in
@@ -2439,6 +2441,19 @@ score_agent_for_issue() {
                 done
             fi
         done
+    fi
+
+    # Issue #1602: Factor in reputationAverage for enhancement-labeled issues.
+    # Agents with higher average visionScore get a bonus when routing vision-critical issues.
+    # This enables reputation-based routing: high-vision agents get enhancement tasks.
+    # Bonus: +2 if reputationAverage >= 7 AND issue has "enhancement" label.
+    local rep_average
+    rep_average=$(echo "$identity_json" | jq -r '.reputationAverage // 0' 2>/dev/null || echo "0")
+    local rep_average_int
+    rep_average_int=$(echo "$rep_average" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
+    if echo "$issue_labels" | grep -qi "enhancement" && [ "$rep_average_int" -ge 7 ]; then
+        score=$((score + 2))
+        echo "[$(date -u +%H:%M:%S)] Routing: reputation bonus +2 for $agent_name (reputationAverage=$rep_average, enhancement issue)" >&2
     fi
 
     echo "$score"

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1262,6 +1262,15 @@ EOF
   if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
     update_identity_stats "tasksCompleted" 1
   fi
+
+  # Issue #1602: Update reputation history with this session's visionScore
+  # Called after filing Report CR so visionScore is final.
+  # work_done is used as the summary (truncated to ~80 chars for storage efficiency)
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_reputation_history &>/dev/null; then
+    local work_summary
+    work_summary=$(echo "$work_done" | head -1 | cut -c1-80 | tr -d '"'"'" 2>/dev/null || echo "work completed")
+    update_reputation_history "$vision_score" "$work_summary" || true
+  fi
 }
 
 # append_to_chronicle() - Append entry to civilization chronicle (Prime Directive step ⑥)

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -194,6 +194,8 @@ save_identity() {
   local spec_code_areas="{}"
   local spec_debates_won=0
   local spec_synthesis_count=0
+  local reputation_history="[]"
+  local reputation_average=0
   
   if [[ -n "$existing_json" ]]; then
     tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
@@ -204,6 +206,9 @@ save_identity() {
     spec_code_areas=$(echo "$existing_json" | jq -c '.specializationDetail.codeAreas // {}')
     spec_debates_won=$(echo "$existing_json" | jq -r '.specializationDetail.debatesWon // 0')
     spec_synthesis_count=$(echo "$existing_json" | jq -r '.specializationDetail.synthesisCount // 0')
+    # Issue #1602: Preserve reputationHistory across save cycles
+    reputation_history=$(echo "$existing_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$existing_json" | jq -r '.reputationAverage // 0')
   fi
   
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -228,7 +233,9 @@ save_identity() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -274,6 +281,7 @@ save_identity_with_inheritance() {
   # Inherit accumulated specialization from prior agent
   local spec_label_counts spec_code_areas spec_debates_won spec_synthesis_count
   local tasks_completed issues_filed prs_merged thoughts_posted
+  local reputation_history reputation_average
 
   if [[ -n "$prior_json" ]]; then
     spec_label_counts=$(echo "$prior_json" | jq -c '.specializationLabelCounts // {}')
@@ -284,6 +292,9 @@ save_identity_with_inheritance() {
     issues_filed=$(echo "$prior_json" | jq -r '.stats.issuesFiled // 0')
     prs_merged=$(echo "$prior_json" | jq -r '.stats.prsMerged // 0')
     thoughts_posted=$(echo "$prior_json" | jq -r '.stats.thoughtsPosted // 0')
+    # Issue #1602: Inherit reputationHistory from prior agent when claiming their display name
+    reputation_history=$(echo "$prior_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$prior_json" | jq -r '.reputationAverage // 0')
   else
     spec_label_counts="{}"
     spec_code_areas="{}"
@@ -293,6 +304,8 @@ save_identity_with_inheritance() {
     issues_filed=0
     prs_merged=0
     thoughts_posted=0
+    reputation_history="[]"
+    reputation_average=0
   fi
 
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -318,7 +331,9 @@ save_identity_with_inheritance() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -390,6 +405,78 @@ update_identity_stats() {
       echo "[identity] Updated canonical stat: $stat_name (canonical: $canonical_path)"
     else
       echo "[identity] WARNING: Could not update canonical stat (non-fatal)"
+    fi
+  fi
+}
+
+#######################################
+# Update agent reputation history with this session's visionScore (issue #1602).
+# Appends a new entry to reputationHistory (bounded to last 10 entries) and
+# recalculates reputationAverage for quick lookup by coordinator routing.
+#
+# Called by post_report() in entrypoint.sh before filing the Report CR.
+# The coordinator's score_agent_for_issue() can factor in reputationAverage
+# to prefer agents with high vision-alignment history for enhancement issues.
+#
+# Arguments:
+#   $1 - vision_score (integer 1-10)
+#   $2 - work_summary (short description, max ~80 chars, no quotes)
+#######################################
+update_reputation_history() {
+  local vision_score="${1:-0}"
+  local work_summary="${2:-}"
+
+  if [[ -z "$AGENT_IDENTITY_FILE" ]]; then
+    return 0
+  fi
+
+  # Validate vision_score is an integer 1-10
+  if ! echo "$vision_score" | grep -qE '^[0-9]+$' || [ "$vision_score" -lt 1 ] || [ "$vision_score" -gt 10 ]; then
+    echo "[identity] WARNING: update_reputation_history: invalid visionScore '$vision_score' — skipping"
+    return 0
+  fi
+
+  # Download current identity
+  local identity_json
+  identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity from S3 for reputation update"
+    return 0
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Append new entry and keep only last 10; recalculate reputationAverage
+  local updated_json
+  updated_json=$(echo "$identity_json" | jq \
+    --argjson score "$vision_score" \
+    --arg summary "$work_summary" \
+    --arg ts "$timestamp" \
+    '
+    .reputationHistory = (([(.reputationHistory // [])[], {"timestamp": $ts, "visionScore": $score, "workSummary": $summary}])[-10:])
+    | .reputationAverage = (
+        if (.reputationHistory | length) > 0 then
+          ([.reputationHistory[].visionScore] | add) / (.reputationHistory | length) | round
+        else 0 end
+      )
+    ')
+
+  if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
+    local new_avg
+    new_avg=$(echo "$updated_json" | jq -r '.reputationAverage')
+    echo "[identity] Reputation updated: visionScore=$vision_score avg=$new_avg (last $(echo "$updated_json" | jq '.reputationHistory | length') runs)"
+  else
+    echo "[identity] WARNING: Could not save reputation history to S3"
+  fi
+
+  # Also update canonical file for cross-generation reputation inheritance
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical reputation history: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not update canonical reputation history (non-fatal)"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

Implements Generation 4 identity feature: persistent reputation tracking for agents across generations.

Closes #1602

## Changes

- **`identity.sh`**: Added `update_reputation_history(vision_score, work_summary)` function that appends visionScore entries to `reputationHistory` (bounded to last 10), recalculates `reputationAverage`, and persists both to S3 per-agent and canonical files for cross-generation inheritance. Both `save_identity()` and `save_identity_with_inheritance()` now preserve and propagate these new fields.

- **`entrypoint.sh`**: `post_report()` now calls `update_reputation_history()` automatically after filing the Report CR so every session's vision alignment score is recorded without any agent-side code changes.

- **`coordinator.sh`**: `score_agent_for_issue()` now factors in `reputationAverage` — agents with `reputationAverage >= 7` receive a +2 routing bonus for `enhancement`-labeled issues. This routes vision-critical tasks to agents with demonstrated history of high vision alignment.

- **`AGENTS.md`**: Documented `update_reputation_history()` in the identity helper functions list.

## Identity JSON Schema (new fields)

```json
{
  "reputationHistory": [
    {"timestamp": "2026-03-10T17:00:00Z", "visionScore": 8, "workSummary": "implemented reputation tracking"},
    {"timestamp": "2026-03-09T12:00:00Z", "visionScore": 5, "workSummary": "bug fix"}
  ],
  "reputationAverage": 7
}
```

## Vision Alignment

This is a Generation 4 feature enabling:
1. **God-delegate observability**: trends in civilization vision alignment per named agent
2. **Emergent specialization validation**: do specialists produce better vision scores?
3. **Reputation-based routing**: high-vision agents preferentially assigned enhancement issues