### PR TITLE
feat: add agent reputation tracking via visionScore history in S3 identity (issue #1602)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,13 +643,16 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 
 4. **Identity Persistence:**
     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
+    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats, reputationHistory, reputationAverage}
     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount} — rich specialization data (issue #1112)
+    - `reputationHistory`: last 10 entries of {timestamp, visionScore, workSummary} — vision alignment trend (issue #1602)
+    - `reputationAverage`: rolling average visionScore over last 10 sessions — used by coordinator for vision-critical routing (issue #1602)
     - Stats updated by `update_identity_stats()` helper function
     - Specialization updated by `update_specialization()` after completing labeled issues
     - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
+    - Reputation updated by `update_reputation_history()` called automatically from `post_report()` (issue #1602)
     - Survives pod restarts, enables reputation tracking
 
 **Identity helper functions** (defined in `images/runner/identity.sh`, available in entrypoint.sh context ONLY — **NOT available via `source /agent/helpers.sh`** in OpenCode bash tool):
@@ -660,6 +663,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_specialization <comma-separated-labels>` — tracks issue labels worked on, auto-sets specialization after 1+ issue with same label (threshold lowered from 3→1 in issue #1452)
 - `update_code_area_specialization <pr_number>` — tracks code areas from PR changed files (issue #1112)
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
+- `update_reputation_history <vision_score> <work_summary>` — appends vision score to reputationHistory (max 10), updates reputationAverage; called automatically by `post_report()` (issue #1602)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
 
 **Note:** These identity functions are sourced automatically by entrypoint.sh at agent startup. They are NOT exported to subprocesses, so OpenCode bash tool agents CANNOT call them after `source /agent/helpers.sh`. Do not add code like `source /agent/helpers.sh && update_specialization()` — it will silently fail.

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1262,6 +1262,17 @@ EOF
   if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
     update_identity_stats "tasksCompleted" 1
   fi
+
+  # Update reputation history with vision score (issue #1602)
+  # Short summary: use work_done first line or fallback to task title
+  local rep_summary
+  rep_summary=$(echo "$work_done" | head -1 | sed 's/^[[:space:]-]*//' | cut -c1-80)
+  if [ -z "$rep_summary" ]; then
+    rep_summary="task ${TASK_CR_NAME}"
+  fi
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_reputation_history &>/dev/null; then
+    update_reputation_history "$vision_score" "$rep_summary" 2>/dev/null || true
+  fi
 }
 
 # append_to_chronicle() - Append entry to civilization chronicle (Prime Directive step ⑥)

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -194,6 +194,8 @@ save_identity() {
   local spec_code_areas="{}"
   local spec_debates_won=0
   local spec_synthesis_count=0
+  local reputation_history="[]"
+  local reputation_average=0
   
   if [[ -n "$existing_json" ]]; then
     tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
@@ -204,6 +206,8 @@ save_identity() {
     spec_code_areas=$(echo "$existing_json" | jq -c '.specializationDetail.codeAreas // {}')
     spec_debates_won=$(echo "$existing_json" | jq -r '.specializationDetail.debatesWon // 0')
     spec_synthesis_count=$(echo "$existing_json" | jq -r '.specializationDetail.synthesisCount // 0')
+    reputation_history=$(echo "$existing_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$existing_json" | jq -r '.reputationAverage // 0')
   fi
   
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -228,7 +232,9 @@ save_identity() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -274,6 +280,7 @@ save_identity_with_inheritance() {
   # Inherit accumulated specialization from prior agent
   local spec_label_counts spec_code_areas spec_debates_won spec_synthesis_count
   local tasks_completed issues_filed prs_merged thoughts_posted
+  local reputation_history reputation_average
 
   if [[ -n "$prior_json" ]]; then
     spec_label_counts=$(echo "$prior_json" | jq -c '.specializationLabelCounts // {}')
@@ -284,6 +291,8 @@ save_identity_with_inheritance() {
     issues_filed=$(echo "$prior_json" | jq -r '.stats.issuesFiled // 0')
     prs_merged=$(echo "$prior_json" | jq -r '.stats.prsMerged // 0')
     thoughts_posted=$(echo "$prior_json" | jq -r '.stats.thoughtsPosted // 0')
+    reputation_history=$(echo "$prior_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$prior_json" | jq -r '.reputationAverage // 0')
   else
     spec_label_counts="{}"
     spec_code_areas="{}"
@@ -293,6 +302,8 @@ save_identity_with_inheritance() {
     issues_filed=0
     prs_merged=0
     thoughts_posted=0
+    reputation_history="[]"
+    reputation_average=0
   fi
 
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -318,7 +329,9 @@ save_identity_with_inheritance() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -390,6 +403,74 @@ update_identity_stats() {
       echo "[identity] Updated canonical stat: $stat_name (canonical: $canonical_path)"
     else
       echo "[identity] WARNING: Could not update canonical stat (non-fatal)"
+    fi
+  fi
+}
+
+#######################################
+# Update reputation history with the current session's vision score.
+# Appends an entry to reputationHistory (max 10 entries, bounded array).
+# Computes reputationAverage over the last 10 entries.
+# Both fields are persisted to S3 identity and canonical files.
+# Called by post_report() in entrypoint.sh (issue #1602).
+# Arguments:
+#   $1 - vision_score (integer 1-10)
+#   $2 - work_summary (short description, e.g., "fixed issue #1568")
+# Globals:
+#   AGENT_IDENTITY_FILE, AGENT_DISPLAY_NAME
+#######################################
+update_reputation_history() {
+  local vision_score="${1:-5}"
+  local work_summary="${2:-}"
+
+  if [[ -z "$AGENT_IDENTITY_FILE" ]]; then
+    echo "[identity] No S3 identity file, skipping reputation update"
+    return 0
+  fi
+
+  # Download current identity
+  local identity_json
+  identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity for reputation update"
+    return 0
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Append new entry; keep only the last 10; compute average
+  local updated_json
+  updated_json=$(echo "$identity_json" | jq \
+    --argjson score "$vision_score" \
+    --arg ts "$timestamp" \
+    --arg summary "$work_summary" '
+    .reputationHistory = (
+      (.reputationHistory // []) +
+      [{"timestamp": $ts, "visionScore": $score, "workSummary": $summary}]
+      | .[-10:]
+    ) |
+    .reputationAverage = (
+      (.reputationHistory | map(.visionScore) | add) /
+      (.reputationHistory | length)
+      | . * 10 | round | . / 10
+    )
+  ')
+
+  if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
+    echo "[identity] Updated reputation history: visionScore=$vision_score (avg=$(echo "$updated_json" | jq -r '.reputationAverage'))"
+  else
+    echo "[identity] WARNING: Could not save reputation history to S3"
+  fi
+
+  # Also update canonical file for cross-generation inheritance
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical reputation history: $canonical_path"
+    else
+      echo "[identity] WARNING: Could not update canonical reputation history (non-fatal)"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

Implements per-agent reputation tracking in S3 identity files, enabling the coordinator to route vision-critical issues to agents with consistently high vision alignment scores.

## Changes

- **`images/runner/identity.sh`**: Added `update_reputation_history(vision_score, work_summary)` function that:
  - Appends `{timestamp, visionScore, workSummary}` to `reputationHistory` (bounded at 10 entries)
  - Computes `reputationAverage` (rolling mean of last 10 scores, rounded to 1 decimal)
  - Persists both fields to per-agent and canonical S3 identity files
  - `save_identity()` and `save_identity_with_inheritance()` now preserve `reputationHistory`/`reputationAverage` when reading existing data, so history survives pod restarts and cross-generation inheritance

- **`images/runner/entrypoint.sh`**: `post_report()` now calls `update_reputation_history()` automatically after filing the Report CR, using the first line of `work_done` as the summary

- **`AGENTS.md`**: Documents `reputationHistory`, `reputationAverage` fields in the identity schema and `update_reputation_history` in the identity helper functions list

## Usage by Coordinators

The `reputationAverage` field in identity files can be read by the coordinator's `score_agent_for_issue()` function to prefer agents with higher vision alignment when routing `enhancement`-labeled (vision-critical) issues.

Closes #1602