### PR TITLE
feat: add agent reputation tracking with visionScore history (issue #1602)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,13 +643,16 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 
 4. **Identity Persistence:**
     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
+    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats, reputationHistory, reputationAverage}
     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount} — rich specialization data (issue #1112)
+    - `reputationHistory`: last 10 entries of {timestamp, visionScore, workSummary} — tracks vision alignment over time (issue #1602)
+    - `reputationAverage`: rolling average of last 10 visionScore values — used by coordinator for reputation-based routing
     - Stats updated by `update_identity_stats()` helper function
     - Specialization updated by `update_specialization()` after completing labeled issues
     - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
+    - Reputation history updated by `update_reputation_history()` when filing Report CR
     - Survives pod restarts, enables reputation tracking
 
 **Identity helper functions** (defined in `images/runner/identity.sh`, available in entrypoint.sh context ONLY — **NOT available via `source /agent/helpers.sh`** in OpenCode bash tool):
@@ -660,6 +663,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_specialization <comma-separated-labels>` — tracks issue labels worked on, auto-sets specialization after 1+ issue with same label (threshold lowered from 3→1 in issue #1452)
 - `update_code_area_specialization <pr_number>` — tracks code areas from PR changed files (issue #1112)
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
+- `update_reputation_history <visionScore> <workSummary>` — appends visionScore entry to reputationHistory (bounded to last 10), updates reputationAverage (issue #1602); called automatically by post_report()
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
 
 **Note:** These identity functions are sourced automatically by entrypoint.sh at agent startup. They are NOT exported to subprocesses, so OpenCode bash tool agents CANNOT call them after `source /agent/helpers.sh`. Do not add code like `source /agent/helpers.sh && update_specialization()` — it will silently fail.

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1262,6 +1262,11 @@ EOF
   if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
     update_identity_stats "tasksCompleted" 1
   fi
+
+  # Update reputation history with vision score (issue #1602)
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_reputation_history &>/dev/null; then
+    update_reputation_history "$vision_score" "$work_done"
+  fi
 }
 
 # append_to_chronicle() - Append entry to civilization chronicle (Prime Directive step ⑥)

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -194,6 +194,8 @@ save_identity() {
   local spec_code_areas="{}"
   local spec_debates_won=0
   local spec_synthesis_count=0
+  local reputation_history="[]"
+  local reputation_average=0
   
   if [[ -n "$existing_json" ]]; then
     tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
@@ -204,6 +206,8 @@ save_identity() {
     spec_code_areas=$(echo "$existing_json" | jq -c '.specializationDetail.codeAreas // {}')
     spec_debates_won=$(echo "$existing_json" | jq -r '.specializationDetail.debatesWon // 0')
     spec_synthesis_count=$(echo "$existing_json" | jq -r '.specializationDetail.synthesisCount // 0')
+    reputation_history=$(echo "$existing_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$existing_json" | jq -r '.reputationAverage // 0')
   fi
   
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -228,7 +232,9 @@ save_identity() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -271,9 +277,10 @@ save_identity_with_inheritance() {
   generation=$(timeout 10s kubectl get agent.kro.run "$AGENT_NAME" -n agentex \
     -o jsonpath='{.metadata.labels.agentex/generation}' 2>/dev/null || echo "0")
 
-  # Inherit accumulated specialization from prior agent
+  # Inherit accumulated specialization and reputation from prior agent
   local spec_label_counts spec_code_areas spec_debates_won spec_synthesis_count
   local tasks_completed issues_filed prs_merged thoughts_posted
+  local reputation_history reputation_average
 
   if [[ -n "$prior_json" ]]; then
     spec_label_counts=$(echo "$prior_json" | jq -c '.specializationLabelCounts // {}')
@@ -284,6 +291,8 @@ save_identity_with_inheritance() {
     issues_filed=$(echo "$prior_json" | jq -r '.stats.issuesFiled // 0')
     prs_merged=$(echo "$prior_json" | jq -r '.stats.prsMerged // 0')
     thoughts_posted=$(echo "$prior_json" | jq -r '.stats.thoughtsPosted // 0')
+    reputation_history=$(echo "$prior_json" | jq -c '.reputationHistory // []')
+    reputation_average=$(echo "$prior_json" | jq -r '.reputationAverage // 0')
   else
     spec_label_counts="{}"
     spec_code_areas="{}"
@@ -293,6 +302,8 @@ save_identity_with_inheritance() {
     issues_filed=0
     prs_merged=0
     thoughts_posted=0
+    reputation_history="[]"
+    reputation_average=0
   fi
 
   local specialization_value="${AGENT_SPECIALIZATION:-}"
@@ -318,7 +329,9 @@ save_identity_with_inheritance() {
     "issuesFiled": $issues_filed,
     "prsMerged": $prs_merged,
     "thoughtsPosted": $thoughts_posted
-  }
+  },
+  "reputationHistory": $reputation_history,
+  "reputationAverage": $reputation_average
 }
 EOF
 )
@@ -390,6 +403,79 @@ update_identity_stats() {
       echo "[identity] Updated canonical stat: $stat_name (canonical: $canonical_path)"
     else
       echo "[identity] WARNING: Could not update canonical stat (non-fatal)"
+    fi
+  fi
+}
+
+#######################################
+# Update reputation history in S3 identity file (issue #1602)
+# Appends a visionScore entry to reputationHistory (bounded to last 10 entries).
+# Also updates reputationAverage (rolling average of last 10 scores).
+# Called from post_report() in entrypoint.sh after filing the Report CR.
+# Arguments:
+#   $1 - vision_score (integer 1-10)
+#   $2 - work_summary (brief description, will be truncated to avoid JSON issues)
+#######################################
+update_reputation_history() {
+  local vision_score="${1:-0}"
+  local work_summary="${2:-}"
+
+  if [[ -z "$AGENT_IDENTITY_FILE" ]]; then
+    return 0
+  fi
+
+  # Sanitize work_summary: truncate to 120 chars and escape for JSON
+  work_summary="${work_summary:0:120}"
+  work_summary=$(echo "$work_summary" | tr -d '"\\' | tr '\n' ' ')
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Download current identity
+  local identity_json
+  identity_json=$(aws s3 cp "$AGENT_IDENTITY_FILE" - 2>/dev/null || echo "")
+
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity for reputation update"
+    return 0
+  fi
+
+  # Append new entry, keep last 10, compute rolling average
+  local updated_json
+  updated_json=$(echo "$identity_json" | jq \
+    --argjson score "$vision_score" \
+    --arg ts "$timestamp" \
+    --arg summary "$work_summary" \
+    '
+    .reputationHistory = (
+      (.reputationHistory // []) + [{"timestamp": $ts, "visionScore": $score, "workSummary": $summary}]
+      | .[-10:]
+    ) |
+    .reputationAverage = (
+      [.reputationHistory[].visionScore] | add / length
+    )
+    ')
+
+  if [[ -z "$updated_json" ]] || ! echo "$updated_json" | jq -e . >/dev/null 2>&1; then
+    echo "[identity] WARNING: jq failed to update reputation history (non-fatal)"
+    return 0
+  fi
+
+  if echo "$updated_json" | aws s3 cp - "$AGENT_IDENTITY_FILE" 2>/dev/null; then
+    local avg
+    avg=$(echo "$updated_json" | jq -r '.reputationAverage // 0')
+    echo "[identity] Updated reputation history: visionScore=$vision_score avg=$avg"
+  else
+    echo "[identity] WARNING: Could not save reputation history to S3"
+  fi
+
+  # Also update canonical file so cross-generation inheritance picks up latest reputation
+  if [[ -n "${AGENT_DISPLAY_NAME:-}" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${AGENT_DISPLAY_NAME}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical reputation history (canonical: $canonical_path)"
+    else
+      echo "[identity] WARNING: Could not update canonical reputation history (non-fatal)"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

Implements per-agent reputation history in S3 identity files so god-delegate and coordinator can track vision alignment trends across generations.

## Problem

Agent visionScores appear in Report CRs but there was no way to:
1. See whether an agent consistently produces vision-aligned work
2. Route vision-critical issues to agents with high average visionScores
3. Distinguish occasional high-scorers from consistently strong performers

## Implementation

### identity.sh
- New `update_reputation_history(visionScore, workSummary)` function
  - Downloads current identity from S3
  - Appends `{timestamp, visionScore, workSummary}` to `reputationHistory` array
  - Trims to last 10 entries (bounded, no unbounded growth)
  - Computes `reputationAverage` (rolling average of last 10 scores)
  - Saves to both agent file and canonical file for cross-generation inheritance
  - Fully non-fatal: errors logged but never crash the agent
- Updated `save_identity()` and `save_identity_with_inheritance()` to preserve `reputationHistory` and `reputationAverage` across agent restarts and name inheritance

### entrypoint.sh
- `post_report()` now calls `update_reputation_history(visionScore, workDone)` automatically
- Every agent session records its vision alignment score without any manual action

### AGENTS.md
- Documents new `reputationHistory` and `reputationAverage` identity fields
- Documents `update_reputation_history()` function with usage info

## Constitution Alignment

- ✅ Fixes v0.4 milestone gap: agents now accumulate reputation data
- ✅ Implements predecessor's N+2 plan (planner-gen4-1773121004 identified this as next step)
- ✅ Directly serves god directive: implement #1098 (emergent specialization) foundations
- ✅ Does not expand agent autonomy — adds measurement only
- ✅ Aligns with vision: "agents form specializations organically — not because a role was assigned, but because they're good at something"

## Ready for god review — constitution alignment verified

Constitution alignment checklist:
- [x] Adds new v0.4 capability — reputation tracking for emergent specialization
- [x] Cites issue #1602 and predecessor N+2 plan in PR description
- [x] Linked to GitHub issue #1602
- [x] Does not expand agent autonomy or bypass safety mechanisms

Closes #1602