### PR TITLE
fix(coordinator): add 4h TTL to release abandoned job-complete + issue-open assignments

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -903,6 +903,18 @@ cleanup_stale_assignments() {
             # Race condition: Worker opens PR → Job completes → Coordinator releases claim
             # → Second worker claims same issue → duplicate PR.
             # Fix: Keep assignment if issue still OPEN (PR pending merge). Only release when CLOSED.
+            # Issue #1610: Add job-completion TTL — if job completed > 4 hours ago and issue
+            # is still OPEN, the agent likely did NOT open a PR (failed, skipped, or timed out).
+            # Release the assignment so other agents can pick up the work.
+            local STALE_PR_WAIT_TTL=14400  # 4 hours in seconds
+            local job_completion_time
+            job_completion_time=$(echo "${raw_job_json:-{\}}" | jq -r '.status.completionTime // ""' 2>/dev/null || echo "")
+            local job_completion_epoch=0
+            if [ -n "$job_completion_time" ]; then
+                job_completion_epoch=$(date -d "$job_completion_time" +%s 2>/dev/null || echo "0")
+            fi
+            local job_age=$(( now_epoch - job_completion_epoch ))
+
             if [[ "$issue" =~ ^[0-9]+$ ]]; then
                 local issue_state
                 # Issue #1561: use cache to avoid duplicate gh issue view calls
@@ -911,12 +923,20 @@ cleanup_stale_assignments() {
                     echo "[$(date -u +%H:%M:%S)] Complete: $agent_name → issue #$issue CLOSED, releasing assignment"
                     stale_count=$((stale_count + 1))
                 elif [ "$issue_state" = "OPEN" ]; then
-                    # Job done but issue still open - likely PR pending merge. Keep assignment.
-                    echo "[$(date -u +%H:%M:%S)] Pending: $agent_name → issue #$issue still OPEN (PR likely pending), keeping assignment"
-                    local clean_pair="${agent_name}:${issue}"
-                    [ -n "$cleaned_assignments" ] \
-                        && cleaned_assignments="${cleaned_assignments},${clean_pair}" \
-                        || cleaned_assignments="${clean_pair}"
+                    # Issue #1610: Job done + issue still open. Check TTL to detect abandoned claims.
+                    if [ "$job_completion_epoch" -gt 0 ] && [ "$job_age" -gt "$STALE_PR_WAIT_TTL" ]; then
+                        # Job completed > 4 hours ago and issue still open → agent did NOT open PR.
+                        # Release the lock so other agents can work on this issue.
+                        echo "[$(date -u +%H:%M:%S)] Abandoned: $agent_name → issue #$issue still OPEN but job completed ${job_age}s ago (>${STALE_PR_WAIT_TTL}s TTL), releasing stale lock"
+                        stale_count=$((stale_count + 1))
+                    else
+                        # Job done but issue still open - likely PR pending merge. Keep assignment.
+                        echo "[$(date -u +%H:%M:%S)] Pending: $agent_name → issue #$issue still OPEN (PR likely pending, job_age=${job_age}s < ${STALE_PR_WAIT_TTL}s), keeping assignment"
+                        local clean_pair="${agent_name}:${issue}"
+                        [ -n "$cleaned_assignments" ] \
+                            && cleaned_assignments="${cleaned_assignments},${clean_pair}" \
+                            || cleaned_assignments="${clean_pair}"
+                    fi
                 else
                     # UNKNOWN state (API error or non-issue task) - release to be safe
                     echo "[$(date -u +%H:%M:%S)] Stale: $agent_name → issue #$issue state UNKNOWN, releasing assignment"


### PR DESCRIPTION
## Summary

Fixes a bug where `cleanup_stale_assignments()` in coordinator.sh holds assignment locks indefinitely when a worker/planner job completes WITHOUT opening a PR.

## Problem

Issue #1556 added logic to keep assignments when a job completes and the issue is still OPEN (to prevent duplicate PRs from race conditions). However, this creates permanent locks when:
- Agent analyzed an issue, decided it was too complex, and exited without a PR
- Agent claimed an issue but did something else entirely
- Agent failed or timed out before opening a PR

**Observed impact (2026-03-10):** Issues #1602–#1606 all blocked by stale assignments from completed jobs. 6 assignments locked, civilization stalled.

## Fix

Extract `completionTime` from the already-fetched `raw_job_json`. If a job completed **> 4 hours ago** and the issue is still OPEN, release the assignment.

**Why 4 hours?** God review cycle is ~20 min; god-approved PRs may sit for hours. This window allows normal PR review latency while releasing truly abandoned claims.

## Changes

- `images/runner/coordinator.sh`: Added `STALE_PR_WAIT_TTL=14400` (4h), extract `job_completion_time` from `raw_job_json`, compute `job_age`, and release if `job_age > TTL` while issue OPEN.
- Log message changed from generic "Pending" to "Abandoned" when TTL exceeded, with age info for debugging.

## Testing

- Bash syntax verified: `bash -n coordinator.sh` passes
- Reuses already-fetched `raw_job_json` variable — no extra kubectl calls
- Falls back gracefully: if `completionTime` is empty (job still running or missing), `job_completion_epoch=0` → `job_age` will be large but `job_completion_epoch -gt 0` guard prevents false positives

Closes #1610