### PR TITLE
fix: align agent-graph.yaml with cluster live config — use GITHUB_TOKEN secretKeyRef

### DIFF
--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -107,8 +107,11 @@ spec:
                       value: ${schema.spec.clusterName}
                     - name: NAMESPACE
                       value: "agentex"
-                    - name: GITHUB_TOKEN_FILE
-                      value: "/var/secrets/github/token"
+                    - name: GITHUB_TOKEN  # env var via secretKeyRef (matches cluster live config, PR #691)
+                      valueFrom:
+                        secretKeyRef:
+                          name: agentex-github-token
+                          key: token
                   resources:
                     requests:
                       memory: "512Mi"
@@ -119,14 +122,7 @@ spec:
                   volumeMounts:
                     - name: workspace
                       mountPath: /workspace
-                    - name: github-token
-                      mountPath: /var/secrets/github
-                      readOnly: true
               volumes:
                 - name: workspace
                   emptyDir:
                     sizeLimit: 2Gi
-                - name: github-token
-                  secret:
-                    secretName: agentex-github-token
-                    defaultMode: 0400  # read-only for owner only


### PR DESCRIPTION
## Summary

Aligns `manifests/rgds/agent-graph.yaml` with the cluster's live RGD (generation 7, applied via PR #691). The git version had drifted to use file-based `GITHUB_TOKEN_FILE` while the cluster uses `GITHUB_TOKEN` env var via `secretKeyRef`.

Closes #1615

## Problem

The cluster's live agent-graph RGD uses:
- `GITHUB_TOKEN` env var from `secretKeyRef: {name: agentex-github-token, key: token}`
- No github-token volume

The git version was using:
- `GITHUB_TOKEN_FILE=/var/secrets/github/token` (pointing to file)  
- `volumeMounts`: github-token → /var/secrets/github
- `volumes`: github-token from secret agentex-github-token

If the git version were re-applied to the cluster via the sync-rgds workflow, it would revert to file-based auth which could break agents depending on image version.

## Changes

- Replace `GITHUB_TOKEN_FILE` env var with `GITHUB_TOKEN` secretKeyRef
- Remove github-token volumeMount (unused)
- Remove github-token volume definition (unused)

## Constitution Alignment

This is a protected file fix. The change:
- Fixes a git/cluster drift without changing cluster behavior
- Does not expand agent autonomy
- Prevents potential future breakage if RGD is re-applied from git

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior (cluster already uses this config, just syncing git)
- [x] Cites relevant constitution/vision sections: protected file in manifests/rgds/*.yaml, PR #691 history
- [x] Linked to GitHub issue #1615
- [x] Does not expand agent autonomy or bypass safety mechanisms