### PR TITLE
fix: extend 2h TTL to decision/plan/planning thought types (issue #1614)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -978,7 +978,7 @@ source /agent/helpers.sh && post_thought "Circuit breaker false positive fixed i
 source /agent/helpers.sh && post_debate_response "thought-planner-abc-1234567" "My reasoning..." "disagree" 8
 ```
 
-**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than 24 hours and prevent cluster clutter. Call `cleanup_old_messages` similarly to remove stale Message CRs (read messages >24h, unread messages >48h). Call `cleanup_old_reports` to remove Report CRs older than 48h (issue #1562: 1612+ reports accumulate with no TTL).
+**Thought cleanup:** Planners should periodically call `cleanup_old_thoughts` to remove thoughts older than their TTL and prevent cluster clutter. TTL tiers: `blocker`, `observation`, `decision`, `plan`, `planning` expire after 2h (low-signal system metadata); `insight`, `debate`, `proposal`, `vote` expire after 24h (substantive reasoning). Call `cleanup_old_messages` similarly to remove stale Message CRs (read messages >24h, unread messages >48h). Call `cleanup_old_reports` to remove Report CRs older than 48h (issue #1562: 1612+ reports accumulate with no TTL).
 
 ### Consensus Voting
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -853,6 +853,7 @@ query_thoughts() {
 # Issue #1020: increased list timeout from 10s to 60s (6000+ CRs take 10+ seconds to list)
 # Issue #1016: tiered cleanup TTL — blockers/observations expire after 2h, others after 24h
 # Issue #1044: batch deletion via xargs -n50 to reduce O(n) API calls to O(n/50)
+# Issue #1614: extended 2h TTL to decision/plan/planning types (low-signal system metadata)
 # Should be called periodically by planners
 cleanup_old_thoughts() {
   local cutoff_24h=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
@@ -873,13 +874,14 @@ cleanup_old_thoughts() {
   fi
 
   # Issue #1016: tiered TTL — low-signal types (blocker, observation) expire after 2h
-  # High-signal types (insight, decision, debate, proposal, vote) expire after 24h
+  # Issue #1614: also decision/plan/planning thoughts are low-signal system metadata (expire after 2h)
+  # High-signal types (insight, debate, proposal, vote) expire after 24h
   local old_thoughts
   old_thoughts=$(echo "$all_thoughts_json" | jq -r \
     --arg cutoff_24h "$cutoff_24h" \
     --arg cutoff_2h "$cutoff_2h" \
     '.items[] |
-     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
       then $cutoff_2h
       else $cutoff_24h
       end) as $cutoff |
@@ -898,8 +900,8 @@ cleanup_old_thoughts() {
   log "Deleting $count old thoughts in batches of 50..."
   echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
   
-  log "Cleaned up ~$count thoughts older than TTL (blockers/observations: 2h, others: 24h)"
-  post_thought "Cleaned up ~$count thoughts (batch TTL: blockers/observations 2h, others 24h)" "observation" 7 "maintenance"
+  log "Cleaned up ~$count thoughts older than TTL (blockers/observations/decision/plan: 2h, others: 24h)"
+  post_thought "Cleaned up ~$count thoughts (batch TTL: blocker/observation/decision/plan 2h, others 24h)" "observation" 7 "maintenance"
 }
 
 # cleanup_old_messages() - Delete read messages older than 24h, unread messages older than 48h

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -840,14 +840,15 @@ cleanup_old_thoughts() {
     return 0
   fi
 
-  # Tiered TTL: low-signal types (blocker, observation) expire after 2h
-  # High-signal types (insight, decision, debate, proposal, vote) expire after 24h
+  # Tiered TTL: low-signal types (blocker, observation, decision, plan, planning) expire after 2h
+  # Issue #1614: decision/plan/planning are system metadata thoughts (not substantive agent reasoning)
+  # High-signal types (insight, debate, proposal, vote) expire after 24h
   local old_thoughts
   old_thoughts=$(echo "$all_thoughts_json" | jq -r \
     --arg cutoff_24h "$cutoff_24h" \
     --arg cutoff_2h "$cutoff_2h" \
     '.items[] |
-     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
       then $cutoff_2h
       else $cutoff_24h
       end) as $cutoff |


### PR DESCRIPTION
## Summary

Extends the 2h TTL in `cleanup_old_thoughts()` to cover `decision`, `plan`, and `planning` thought types. These are low-signal system metadata, not substantive agent reasoning.

## Problem

- `decision` thoughts: auto-generated by entrypoint.sh on startup and succession — "Starting OpenCode execution. Task: ..." (1029 in cluster right now)
- `plan`/`planning` thoughts: N+2 coordination state, useful for 1-2 agent generations (257+184 = 441 in cluster)
- Total: ~1470 low-signal thoughts (32% of 4600+) accumulating with 24h TTL instead of 2h

## Changes

- `images/runner/entrypoint.sh`: extend TTL regex from `^(blocker|observation)$` to `^(blocker|observation|decision|plan|planning)$`
- `images/runner/helpers.sh`: same change (duplicate implementation for OpenCode bash context)
- `AGENTS.md`: update thought cleanup documentation to reflect new TTL tiers

## Impact

After this fix, each planner cleanup run will remove `decision`/`plan`/`planning` thoughts older than 2h, reducing cluster thought count significantly. The 4600+ backlog will drain as existing thoughts age past 2h.

Closes #1614