### PR TITLE
fix: extend 2h TTL to decision/plan/planning thought types (closes #1614)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -852,6 +852,7 @@ query_thoughts() {
 # to prevent cluster clutter and kubectl performance degradation.
 # Issue #1020: increased list timeout from 10s to 60s (6000+ CRs take 10+ seconds to list)
 # Issue #1016: tiered cleanup TTL — blockers/observations expire after 2h, others after 24h
+# Issue #1614: extend 2h TTL to decision/plan/planning (auto-generated metadata, ~10/agent/run)
 # Issue #1044: batch deletion via xargs -n50 to reduce O(n) API calls to O(n/50)
 # Should be called periodically by planners
 cleanup_old_thoughts() {
@@ -873,13 +874,15 @@ cleanup_old_thoughts() {
   fi
 
   # Issue #1016: tiered TTL — low-signal types (blocker, observation) expire after 2h
-  # High-signal types (insight, decision, debate, proposal, vote) expire after 24h
+  # Issue #1614: extend 2h TTL to decision, plan, planning types — these are auto-generated
+  # system metadata messages (not agent reasoning) that accumulate rapidly (~10/agent/run).
+  # High-signal types (insight, debate, proposal, vote) expire after 24h
   local old_thoughts
   old_thoughts=$(echo "$all_thoughts_json" | jq -r \
     --arg cutoff_24h "$cutoff_24h" \
     --arg cutoff_2h "$cutoff_2h" \
     '.items[] |
-     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
       then $cutoff_2h
       else $cutoff_24h
       end) as $cutoff |
@@ -898,8 +901,8 @@ cleanup_old_thoughts() {
   log "Deleting $count old thoughts in batches of 50..."
   echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
   
-  log "Cleaned up ~$count thoughts older than TTL (blockers/observations: 2h, others: 24h)"
-  post_thought "Cleaned up ~$count thoughts (batch TTL: blockers/observations 2h, others 24h)" "observation" 7 "maintenance"
+  log "Cleaned up ~$count thoughts older than TTL (blockers/observations/decisions/plan: 2h, others: 24h)"
+  post_thought "Cleaned up ~$count thoughts (batch TTL: low-signal 2h, high-signal 24h)" "observation" 7 "maintenance"
 }
 
 # cleanup_old_messages() - Delete read messages older than 24h, unread messages older than 48h

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -813,11 +813,11 @@ query_thoughts() {
 
 # ── cleanup_old_thoughts ─────────────────────────────────────────────────────
 # Delete thoughts older than 24 hours (or 2h for low-signal types like
-# blockers and observations) to prevent cluster clutter and kubectl performance
-# degradation. Planners should call this periodically.
+# blockers, observations, decisions, and planning thoughts) to prevent cluster
+# clutter and kubectl performance degradation. Planners should call this periodically.
 #
-# Low-signal types (blocker, observation): 2h TTL
-# High-signal types (insight, decision, debate, proposal, vote): 24h TTL
+# Low-signal types (blocker, observation, decision, plan, planning): 2h TTL
+# High-signal types (insight, debate, proposal, vote): 24h TTL
 #
 # Usage: cleanup_old_thoughts
 cleanup_old_thoughts() {
@@ -840,14 +840,15 @@ cleanup_old_thoughts() {
     return 0
   fi
 
-  # Tiered TTL: low-signal types (blocker, observation) expire after 2h
-  # High-signal types (insight, decision, debate, proposal, vote) expire after 24h
+  # Tiered TTL: low-signal types (blocker, observation, decision, plan, planning) expire after 2h
+  # Issue #1614: decision/plan/planning are auto-generated system metadata thoughts (~10/agent/run)
+  # High-signal types (insight, debate, proposal, vote) expire after 24h
   local old_thoughts
   old_thoughts=$(echo "$all_thoughts_json" | jq -r \
     --arg cutoff_24h "$cutoff_24h" \
     --arg cutoff_2h "$cutoff_2h" \
     '.items[] |
-     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+     (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
       then $cutoff_2h
       else $cutoff_24h
       end) as $cutoff |
@@ -865,8 +866,8 @@ cleanup_old_thoughts() {
   log "Deleting $count old thoughts in batches of 50..."
   echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
 
-  log "Cleaned up ~$count thoughts older than TTL (blockers/observations: 2h, others: 24h)"
-  post_thought "Cleaned up ~$count thoughts (batch TTL: blockers/observations 2h, others 24h)" "observation" 7 "maintenance" 2>/dev/null || true
+  log "Cleaned up ~$count thoughts older than TTL (blockers/observations/decisions/plan: 2h, others: 24h)"
+  post_thought "Cleaned up ~$count thoughts (batch TTL: low-signal 2h, high-signal 24h)" "observation" 7 "maintenance" 2>/dev/null || true
 }
 
 # ── cleanup_old_messages ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the 2h TTL in `cleanup_old_thoughts()` to cover `decision`, `plan`, and `planning` thought types.

## Problem

`decision` and `plan`/`planning` thoughts were classified as high-signal (24h TTL) but are auto-generated system metadata:
- `decision`: auto-generated by entrypoint.sh — "Starting OpenCode execution. Task: ..." 
- `plan`/`planning`: generated by `post_planning_thought()` for N+2 coordination

These grow at ~10/agent/run and were accumulating to 1029+ `decision` thoughts in the cluster.

## Fix

Add `decision|plan|planning` to the 2h TTL regex in both `entrypoint.sh` and `helpers.sh`:

```bash
# Before:
test("^(blocker|observation)$")
# After:
test("^(blocker|observation|decision|plan|planning)$")
```

## Changes

- `images/runner/entrypoint.sh` `cleanup_old_thoughts()`: extend 2h TTL pattern + update comments/logs
- `images/runner/helpers.sh` `cleanup_old_thoughts()`: same fix for OpenCode bash tool context

## Impact

- Reduces cluster thought accumulation rate (~10x reduction for decision types)
- Improves kubectl list performance (fewer thoughts = faster scans)
- High-signal types (insight, debate, proposal, vote) remain at 24h TTL

Closes #1614