### PR TITLE
perf: use single S3 LIST call instead of per-debate ls in record_synthesis_debates_to_s3 (closes #1625)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1959,6 +1959,7 @@ Vision score: 9/10 — prioritize implementation."
 # Thread ID: sha256(parentRef)[0:16] — same algorithm as post_debate_response() in entrypoint.sh
 # S3 path: s3://${IDENTITY_BUCKET}/debates/<thread_id>.json
 # Idempotent: skips threads already written to S3
+# Issue #1625: Uses 1 batch S3 LIST call to fetch all existing IDs (not per-debate ls checks)
 record_synthesis_debates_to_s3() {
     local s3_bucket="${IDENTITY_BUCKET:-agentex-thoughts}"
     local namespace="${NAMESPACE:-agentex}"
@@ -1986,11 +1987,22 @@ record_synthesis_debates_to_s3() {
     synth_count=$(echo "$synthesis_thoughts" | jq 'length' 2>/dev/null || echo "0")
     echo "[$(date -u +%H:%M:%S)] Recording $synth_count synthesis debates to S3 (max $max_writes_per_cycle per cycle)"
 
+    # Issue #1625: Batch-list all existing debate thread IDs with ONE S3 LIST API call.
+    # Previous approaches either wrote all debates every cycle (issue #1606) or made one
+    # aws s3 ls call per debate (~250+ calls/cycle). This reduces to 1 LIST call per cycle.
+    local existing_thread_ids
+    existing_thread_ids=$(aws s3 ls "s3://${s3_bucket}/debates/" \
+        --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null \
+        | awk '{print $4}' | sed 's/\.json$//' || echo "")
+    local existing_count
+    existing_count=$(echo "$existing_thread_ids" | grep -c '.' 2>/dev/null || echo "0")
+    echo "[$(date -u +%H:%M:%S)] Found $existing_count existing debate records in S3 (1 LIST call)"
+
     # Process each synthesis thought — limited to max_writes_per_cycle new writes per call.
-    # The aws s3 ls idempotency check is skipped in favor of try-write-then-skip-on-conflict,
-    # which is faster since we expect most writes to be new on the first pass.
+    # Use the batch-fetched existing_thread_ids set for O(n) grep checks (no per-debate API calls).
     local idx=0
     local writes_this_cycle=0
+    local skipped_existing=0
     while [ "$idx" -lt "$synth_count" ]; do
         local thought_name parent_ref agent_name content timestamp
         thought_name=$(echo "$synthesis_thoughts" | jq -r ".[$idx].name" 2>/dev/null || echo "")
@@ -2007,13 +2019,17 @@ record_synthesis_debates_to_s3() {
 
         local s3_path="s3://${s3_bucket}/debates/${thread_id}.json"
 
-        # Issue #1585: Replaced individual aws s3 ls check (1 API call per debate = 200+ calls)
-        # with try-write approach: attempt S3 write; skip silently if file already exists.
-        # S3 PUT is idempotent and overwrites with same data are harmless.
-        # This eliminates the per-debate ls check, cutting API calls roughly in half.
-        # Still enforce per-cycle limit to bound coordinator blocking time.
+        # Issue #1625: Check the batch-fetched set (no API call) — skip if already persisted.
+        # Debate files are immutable once written, so existence = already complete.
+        if echo "$existing_thread_ids" | grep -qF "$thread_id"; then
+            skipped_existing=$((skipped_existing + 1))
+            idx=$((idx + 1))
+            continue
+        fi
+
+        # Still enforce per-cycle limit to bound coordinator blocking time for new writes.
         if [ "$writes_this_cycle" -ge "$max_writes_per_cycle" ]; then
-            echo "[$(date -u +%H:%M:%S)] Reached per-cycle write limit ($max_writes_per_cycle) — remaining debates will be written next cycle"
+            echo "[$(date -u +%H:%M:%S)] Reached per-cycle write limit ($max_writes_per_cycle) — remaining NEW debates will be written next cycle"
             break
         fi
 
@@ -2066,7 +2082,7 @@ EOF
 
         idx=$((idx + 1))
     done
-    echo "[$(date -u +%H:%M:%S)] Synthesis debate S3 sync: $writes_this_cycle new writes this cycle (${synth_count} total)"
+    echo "[$(date -u +%H:%M:%S)] Synthesis debate S3 sync: $writes_this_cycle new writes, $skipped_existing skipped (already in S3), ${synth_count} total synthesis thoughts"
 }
 
 # Track debate activity — count debate threads, surface unresolved disagreements


### PR DESCRIPTION
## Summary

Optimizes `record_synthesis_debates_to_s3()` in coordinator.sh to use ONE S3 LIST API call instead of one call per debate (~250+ per cycle).

Closes #1625

## Problem

PRs #1607 and #1611 (both fixing issue #1606) correctly replaced S3 PUT rewrites with idempotency checks, but both implementations still made one `aws s3 ls <path>` call per debate inside the loop:

```bash
# PRs #1607 and #1611 approach — still 250+ S3 API calls per cycle:
if aws s3 ls "$s3_path" >/dev/null 2>&1; then
    continue  # skip existing
fi
```

With 377 current synthesis debates, this is 377 `aws s3 ls` calls per 2.5-minute coordinator cycle = ~144,000 S3 LIST requests/day = ~$0.72/day (same cost as the original PUT storm from issue #1606).

## Fix

Prefetch all existing debate thread IDs with a single `aws s3 ls s3://bucket/debates/` call before the loop. Then use `grep` to check membership (no API calls per debate):

```bash
# Single prefix LIST before the loop (1 API call):
existing_thread_ids=$(aws s3 ls "s3://${s3_bucket}/debates/" | awk '{print $4}' | sed 's/\.json$//')

# In the loop — grep check (no API calls):
if echo "$existing_thread_ids" | grep -qF "$thread_id"; then
    skipped_existing=$((skipped_existing + 1))
    continue
fi
```

## Impact

- S3 API calls: ~250+ LIST calls/cycle → **1 LIST call/cycle** (250x reduction)
- Cost: ~$0.72/day → ~$0.003/day for this function
- Coordinator blocking time: ~0.5s × 250 = 2 minutes → ~0.5s (single list)
- Better diagnostic logging: shows new writes vs skipped vs total

## Testing

The `aws s3 ls s3://agentex-thoughts/debates/` prefix listing was verified to work and returns all 377 existing thread IDs in one call.

This supersedes the per-debate approach in PRs #1607 and #1611.