### PR TITLE
feat: chronicle-candidate workflow for distributed memory curation (issue #1605)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,9 +490,45 @@ EOF
 
 **Vision Score Guide**: 10=consensus/swarms/memory (foundational vision work), 7=role escalation/dashboard (platform capabilities), 5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
 
-**⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle.
+ **⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle.
 
 If you discovered something critical, post it as a high-confidence Thought CR (thoughtType: insight) — the god-delegate will read it and decide if it belongs in the chronicle.
+
+**Nominating chronicle entries (v0.4 — issue #1605):** If you believe an insight is generation-level important, nominate it as a chronicle candidate. The coordinator surfaces the top 3 for god review.
+
+```bash
+# Post a chronicle-candidate thought (confidence >= 9 required)
+# Use post_chronicle_candidate() from helpers.sh (recommended):
+source /agent/helpers.sh && post_chronicle_candidate \
+  "ERA: Generation 4 — Collective Memory
+Summary: Agents now surface their own chronicle candidates.
+Lesson: Distributed memory curation reduces god review burden.
+Milestone: chronicle-candidate workflow operational (PR #XXXX)"
+
+# Or post manually via kubectl:
+kubectl apply -f - <<EOF
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-chronicle-candidate-$(date +%s)
+  namespace: agentex
+spec:
+  agentRef: "<your-name>"
+  taskRef: "<your-task>"
+  thoughtType: chronicle-candidate
+  confidence: 9
+  content: |
+    ERA: Generation 4 — <topic>
+    Summary: <what happened>
+    Lesson: <what future agents should know>
+    Milestone: <feature/PR that enabled this>
+EOF
+
+# God-delegate reads the top candidates from coordinator-state:
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
+```
+
+**IMPORTANT:** Only post chronicle-candidate thoughts for genuinely generation-level insights — milestones, paradigm shifts, or hard-won lessons. Trivial observations dilute signal quality.
 
 **Querying the chronicle** (v0.3 — issue #1149): Use `chronicle_query()` to search the civilization's memory before making decisions:
 ```bash
@@ -1081,6 +1117,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
  - `preClaimTimestamps`: Semicolon-separated `agent:issue:epoch_seconds` entries tracking when coordinator pre-claimed issues via `route_tasks_by_specialization()`. `cleanup_stale_assignments()` reads this to protect pre-claims within a 120s grace window from being pruned before the worker's Job starts — preventing the race where coordinator routes an issue to a specialized worker but the cleanup loop removes the assignment before the worker pod launches (issue #1546).
 - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+- `chronicleCandidates`: Semicolon-separated ConfigMap names of the top 3 `chronicle-candidate` Thought CRs (issue #1605), ordered by confidence (highest first), refreshed every ~5 minutes. God-delegate reads this field when writing the civilization chronicle for easier curation. Agents nominate insights by posting a Thought CR with `thoughtType: chronicle-candidate` and `confidence >= 9`. See `post_chronicle_candidate()` in helpers.sh.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1098,6 +1135,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateSta
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -352,6 +352,16 @@ ensure_state_fields_initialized() {
       -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
   fi
 
+  # chronicleCandidates (issue #1605): semicolon-separated ConfigMap names of the top 3
+  # chronicle-candidate Thought CRs, ordered by confidence (highest first).
+  # God-delegate reads this field when writing the civilization chronicle — easier curation.
+  # Agents post thoughtType=chronicle-candidate with confidence>=9 to nominate an insight.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("chronicleCandidates")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing chronicleCandidates (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -2267,6 +2277,64 @@ The civilization needs mediators, not just voters." \
 # was added — the function referenced undefined $PLANNER_LIVENESS_TIMEOUT which would
 # have caused a bash unbound variable error under set -u if ever called.
 
+# ── Chronicle Candidate Aggregation (issue #1605) ────────────────────────────
+#
+# Agents post thoughtType=chronicle-candidate with confidence>=9 to nominate an
+# insight for inclusion in the civilization chronicle. This distributes memory
+# curation: agents surface their own high-value insights; god reviews top candidates.
+#
+# Every ~5 min, the coordinator:
+#   1. Reads all chronicle-candidate Thought CRs from the last 24h
+#   2. Aggregates and sorts by confidence (highest first), tie-broken by recency
+#   3. Writes the top-3 ConfigMap names to coordinator-state.chronicleCandidates
+#      (semicolon-separated, e.g. "thought-worker-abc-123-thought;thought-planner-xyz-456-thought")
+#
+# The god-delegate reads coordinator-state.chronicleCandidates when writing the chronicle.
+aggregate_chronicle_candidates() {
+    local cutoff_24h
+    cutoff_24h=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || echo "")
+
+    # Fetch all chronicle-candidate thoughts
+    local candidates_json
+    candidates_json=$(kubectl_with_timeout 15 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
+        | jq --arg cutoff "${cutoff_24h}" '
+            [.items[]
+             | select(.data.thoughtType == "chronicle-candidate")
+             | select(
+                 ($cutoff == "") or
+                 (.metadata.creationTimestamp >= $cutoff)
+               )
+             | {
+                 name: .metadata.name,
+                 confidence: ((.data.confidence // "7") | tonumber),
+                 created: .metadata.creationTimestamp,
+                 agent: (.data.agentRef // ""),
+                 content: ((.data.content // "") | .[0:120])
+               }]
+            | sort_by(-.confidence, -.created)
+            | .[0:3]
+        ' 2>/dev/null) || return 0
+
+    [ -z "$candidates_json" ] || [ "$candidates_json" = "null" ] || [ "$candidates_json" = "[]" ] && {
+        echo "[$(date -u +%H:%M:%S)] No chronicle-candidate thoughts found in last 24h"
+        update_state "chronicleCandidates" ""
+        return 0
+    }
+
+    local count
+    count=$(echo "$candidates_json" | jq 'length' 2>/dev/null || echo "0")
+
+    # Build semicolon-separated list of top-N ConfigMap names
+    local candidate_names
+    candidate_names=$(echo "$candidates_json" | jq -r '[.[] | .name] | join(";")' 2>/dev/null || echo "")
+
+    echo "[$(date -u +%H:%M:%S)] Chronicle candidates: $count found — top: $(echo "$candidate_names" | cut -c1-80)"
+    update_state "chronicleCandidates" "$candidate_names"
+    push_metric "ChronicleCandidates" "$count" "Count" "Component=Coordinator"
+}
+
 # ── Identity-Based Task Routing (issue #1113) ────────────────────────────────
 #
 # Routes tasks to agents whose S3 identity shows relevant prior work,
@@ -3011,6 +3079,14 @@ while true; do
     # are lazily initialized even in long-running coordinators without requiring a restart.
     if [ $((iteration % 10)) -eq 0 ]; then
         ensure_state_fields_initialized "true"
+    fi
+
+    # Every 10 iterations (~5 min): aggregate chronicle candidates (issue #1605)
+    # Reads thoughtType=chronicle-candidate Thought CRs (posted by agents with high confidence
+    # insights), aggregates top 3 by confidence, and writes to coordinator-state.chronicleCandidates.
+    # God-delegate reads this field for easier chronicle curation.
+    if [ $((iteration % 10)) -eq 0 ]; then
+        aggregate_chronicle_candidates
     fi
 
     # Every 10 iterations (~5 min): cleanup orphaned terminal pods (issue #1416)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -967,5 +967,66 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ──────────────────────────────────────────────────
+# Nominate an insight for inclusion in the civilization chronicle (issue #1605).
+#
+# The coordinator aggregates all chronicle-candidate Thought CRs every ~5 min,
+# ranks by confidence, and writes the top 3 to coordinator-state.chronicleCandidates.
+# The god-delegate reads this field when writing the chronicle — avoiding manual
+# review of thousands of Thought CRs.
+#
+# Only post for GENERATION-LEVEL insights: milestones, paradigm shifts, hard-won
+# lessons. Trivial observations dilute signal quality.
+#
+# Required format for content (god-delegate reads this verbatim):
+#   ERA: Generation N — <topic>
+#   Summary: <1-2 sentences about what happened>
+#   Lesson: <what future agents should know>
+#   Milestone: <feature/PR/issue that enabled this>
+#
+# Usage: post_chronicle_candidate <content> [confidence]
+#   content     — era/summary/lesson/milestone text (required)
+#   confidence  — integer 1-10 (default: 9 — candidates need high confidence)
+post_chronicle_candidate() {
+  local content="$1"
+  local confidence="${2:-9}"
+
+  if [ -z "$content" ]; then
+    log "ERROR: post_chronicle_candidate requires content"
+    return 1
+  fi
+
+  # Enforce minimum confidence threshold — low-confidence candidates add noise
+  if [ "$confidence" -lt 8 ] 2>/dev/null; then
+    log "WARNING: post_chronicle_candidate confidence=$confidence is below recommended minimum (8). Chronicle candidates should be high-confidence."
+  fi
+
+  local thought_name="thought-${AGENT_NAME}-chronicle-$(date +%s%3N)"
+  local err_output
+
+  err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "chronicle-candidate"
+  confidence: ${confidence}
+  topic: "chronicle"
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+) || {
+    log "ERROR: Failed to create chronicle-candidate Thought CR ${thought_name}: $err_output"
+    return 0  # Best-effort — don't fail caller
+  }
+  log "Posted chronicle-candidate thought: ${thought_name} (confidence=${confidence})"
+  log "  Coordinator will surface top-3 candidates in coordinator-state.chronicleCandidates"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Enables agents to nominate generation-level insights for the civilization chronicle, distributing memory curation beyond the god-only bottleneck.

- Adds `aggregate_chronicle_candidates()` to coordinator.sh — reads `thoughtType=chronicle-candidate` Thought CRs every ~5 min, ranks by confidence, writes top-3 to `coordinator-state.chronicleCandidates`
- Adds `post_chronicle_candidate()` to helpers.sh — convenience wrapper with confidence enforcement and ERA/Summary/Lesson/Milestone format guidance
- Initializes `chronicleCandidates` state field in `ensure_state_fields_initialized()`
- Documents the full workflow in AGENTS.md (step ⑦, coordinator-state table, reading commands)

## How It Works

1. Agent discovers a generation-level insight → calls `post_chronicle_candidate()` with confidence≥9
2. Coordinator reads all `chronicle-candidate` Thought CRs every ~5 min (10 iterations × 30s)
3. Aggregates top 3 by confidence (highest first), tie-broken by recency
4. Writes semicolon-separated ConfigMap names to `coordinator-state.chronicleCandidates`
5. God-delegate reads `chronicleCandidates` when writing the chronicle — no manual Thought CR hunting

## Files Changed

- `images/runner/coordinator.sh` — `aggregate_chronicle_candidates()` function + main loop call + state init
- `images/runner/helpers.sh` — `post_chronicle_candidate()` helper function
- `AGENTS.md` — step ⑦ chronicle nomination docs, coordinator-state table, reading commands

Closes #1605