### PR TITLE
feat: v0.4 chronicle-candidate workflow for distributed memory curation (closes #1605)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -680,6 +680,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+- `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for civilization chronicle (v0.4, issue #1605). Coordinator aggregates top 3 by confidence in coordinator-state.chronicleCandidates for god-delegate curation. Only use for generation-level insights (confidence=9 required)
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1080,7 +1081,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
  - `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
  - `preClaimTimestamps`: Semicolon-separated `agent:issue:epoch_seconds` entries tracking when coordinator pre-claimed issues via `route_tasks_by_specialization()`. `cleanup_stale_assignments()` reads this to protect pre-claims within a 120s grace window from being pruned before the worker's Job starts — preventing the race where coordinator routes an issue to a specialized worker but the cleanup loop removes the assignment before the worker pod launches (issue #1546).
-- `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+ - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+- `chronicleCandidates`: Semicolon-separated Thought ConfigMap names for agent-proposed chronicle entries (issue #1605, v0.4 Collective Memory). Aggregated by `aggregate_chronicle_candidates()` every ~3 min. Holds top 3 `chronicle-candidate` thoughts sorted by confidence (≥9 required). God-delegate reads this field when writing the next chronicle entry for efficient curation without reviewing all Thought CRs.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1228,12 +1230,13 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - kubectl (for reading/writing CRs)
   - gh CLI (authenticated via GITHUB_TOKEN secret)
   - aws CLI (Bedrock via Pod Identity — no credentials needed)
-  - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
+   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
                claim_task(), civilization_status(), write_planning_state(), post_planning_thought(),
                 plan_for_n_plus_2(), chronicle_query(), propose_vision_feature(), query_thoughts(),
-                cleanup_old_thoughts(), cleanup_old_messages(), cleanup_old_reports()
+                cleanup_old_thoughts(), cleanup_old_messages(), cleanup_old_reports(),
+                post_chronicle_candidate()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -352,6 +352,15 @@ ensure_state_fields_initialized() {
       -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
   fi
 
+  # chronicleCandidates (issue #1605): semicolon-separated Thought ConfigMap names for
+  # agent-proposed chronicle entries. Aggregated by aggregate_chronicle_candidates() every
+  # ~3 min (every 6 iterations). God-delegate reads this when writing the next chronicle entry.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("chronicleCandidates")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing chronicleCandidates (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -2070,6 +2079,56 @@ EOF
 }
 
 # Track debate activity — count debate threads, surface unresolved disagreements
+# ── aggregate_chronicle_candidates (issue #1605) ─────────────────────────────
+#
+# Aggregate Thought CRs with thoughtType=chronicle-candidate and surface the
+# top 3 (by confidence score) in coordinator-state.chronicleCandidates.
+#
+# The god-delegate reads chronicleCandidates when writing the next chronicle entry,
+# making human curation faster while preserving quality control.
+#
+# v0.4 Collective Memory: agents propose their own insights for the civilization
+# chronicle rather than relying solely on god to curate everything.
+#
+# Implementation:
+#   1. Read all Thought CRs with thoughtType=chronicle-candidate
+#   2. Sort by confidence (highest first)
+#   3. Take top 3 ConfigMap names
+#   4. Patch coordinator-state.chronicleCandidates (semicolon-separated names)
+aggregate_chronicle_candidates() {
+    # Fetch chronicle-candidate thoughts using label selector to avoid OOM
+    local candidates_json
+    candidates_json=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+        -l agentex/thought -o json 2>/dev/null | \
+        jq '[.items[] | select(.data.thoughtType == "chronicle-candidate") | {
+            name: .metadata.name,
+            confidence: ((.data.confidence // "7") | tonumber),
+            agent: (.data.agentRef // ""),
+            content: ((.data.content // "") | .[0:200]),
+            createdAt: .metadata.creationTimestamp
+        }] | sort_by(-.confidence, .createdAt) | .[0:3]' 2>/dev/null || echo "[]")
+
+    if [ -z "$candidates_json" ] || [ "$candidates_json" = "[]" ] || [ "$candidates_json" = "null" ]; then
+        # No candidates found — keep existing chronicleCandidates field as-is
+        return 0
+    fi
+
+    # Extract top candidate names
+    local top_candidates
+    top_candidates=$(echo "$candidates_json" | jq -r '.[].name' 2>/dev/null | tr '\n' ';' | sed 's/;$//')
+
+    if [ -z "$top_candidates" ]; then
+        return 0
+    fi
+
+    local candidate_count
+    candidate_count=$(echo "$candidates_json" | jq 'length' 2>/dev/null || echo "0")
+
+    echo "[$(date -u +%H:%M:%S)] Chronicle candidates: $candidate_count found, top 3 surfaced (issue #1605)"
+    update_state "chronicleCandidates" "$top_candidates"
+    push_metric "ChroniceCandidates" "$candidate_count" "Count" "Component=Coordinator"
+}
+
 track_debate_activity() {
     local all_cm
     # Issue #687: Use kubectl_with_timeout to prevent 120s hangs during cluster connectivity issues
@@ -2234,6 +2293,11 @@ DEBATE_EOF
         fi
     fi
     # ── End Issue #1161 ───────────────────────────────────────────────────────
+
+    # ── Issue #1605: Aggregate chronicle-candidate thoughts ──────────────────
+    # After processing debate activity, also aggregate chronicle candidates so
+    # god-delegate can find agent-proposed chronicle entries efficiently.
+    aggregate_chronicle_candidates
 
     # If there are unresolved disagreements and no synthesis attempts, post a nudge
     if [ "$disagree_count" -gt 0 ] && [ "$synthesize_count" -eq 0 ]; then

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -967,5 +967,57 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ─────────────────────────────────────────────────
+# Post a chronicle-candidate Thought CR to propose an insight for civilization chronicle.
+# Issue #1605 (v0.4 Collective Memory milestone): agents surface high-value insights
+# for god-curated inclusion in the chronicle, reducing the god bottleneck while
+# maintaining quality control.
+#
+# How it works:
+#   1. Agent posts a Thought CR with thoughtType=chronicle-candidate and confidence>=9
+#   2. Coordinator aggregates top candidates in coordinator-state.chronicleCandidates
+#   3. God-delegate reads chronicleCandidates when writing the next chronicle entry
+#
+# Usage: post_chronicle_candidate <era_description> <summary> <lesson_learned> [milestone]
+# Example:
+#   post_chronicle_candidate \
+#     "Generation 4 — Debate Quality Tracking" \
+#     "Agents now track synthesis citation counts to distinguish high-signal debates." \
+#     "High-quality debates produce insights that persist in future routing decisions." \
+#     "v0.4 debate quality scoring implemented"
+#
+# Returns: 0 on success, 1 on invalid input (confidence < 9 not allowed)
+post_chronicle_candidate() {
+  local era="${1:-}"
+  local summary="${2:-}"
+  local lesson="${3:-}"
+  local milestone="${4:-}"
+
+  if [ -z "$era" ] || [ -z "$summary" ] || [ -z "$lesson" ]; then
+    log "post_chronicle_candidate: era, summary, and lesson are required"
+    return 1
+  fi
+
+  # Chronicle candidates must have high confidence (>=9) to filter noise
+  local confidence=9
+
+  local content="ERA: ${era}
+Summary: ${summary}
+Lesson: ${lesson}"
+
+  if [ -n "$milestone" ]; then
+    content="${content}
+Milestone: ${milestone}"
+  fi
+
+  content="${content}
+Proposed by: ${AGENT_NAME}"
+
+  post_thought "$content" "chronicle-candidate" "$confidence" "chronicle" "" ""
+
+  log "Posted chronicle-candidate: era='$era' (confidence=$confidence)"
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the v0.4 Collective Memory milestone feature: **agent-contributed chronicle candidates** (issue #1605, part of #1603).

The civilization chronicle is currently entirely god-curated, creating a bottleneck as agent count grows. This PR enables agents to propose their own high-value insights for inclusion in the chronicle, while keeping god as quality-control gatekeeper.

## Changes

### `images/runner/helpers.sh`
- New `post_chronicle_candidate(era, summary, lesson, milestone)` function
- Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9 (required)
- Available via `source /agent/helpers.sh` in OpenCode bash context
- Updated loaded message to include `post_chronicle_candidate` in function list

### `images/runner/coordinator.sh`
- New `aggregate_chronicle_candidates()` function called every ~3min (inside `track_debate_activity()`)
- Reads all `chronicle-candidate` Thought CRs, sorts by confidence (highest first)
- Patches `coordinator-state.chronicleCandidates` with top 3 ConfigMap names (semicolon-separated)
- God-delegate can now read `coordinator-state.chronicleCandidates` for efficient chronicle curation
- Initializes `chronicleCandidates` state field at coordinator startup

### `AGENTS.md`
- Documents `post_chronicle_candidate()` in the helper functions list with usage note
- Documents `chronicleCandidates` field in Coordinator State section
- Updates helpers.sh Provides: list to include `post_chronicle_candidate()`

## Usage

```bash
# An agent discovers a generation-level insight worth chronicling:
source /agent/helpers.sh && post_chronicle_candidate \
  "Generation 4 — Debate Quality Tracking" \
  "Agents now track synthesis citation counts to distinguish high-signal debates." \
  "High-quality debates produce insights that persist in future routing decisions." \
  "v0.4 debate quality scoring implemented (PR #1626)"

# God-delegate reads candidates for chronicle curation:
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
# → "thought-worker-abc-123;thought-planner-xyz-456;thought-ada-789"

# God reviews each candidate and includes worthy ones in the next chronicle entry
```

## Vision Alignment (visionScore: 8)

This is a v0.4 Collective Memory feature that reduces the god bottleneck while maintaining quality control. The civilization can now contribute to its own permanent memory, moving from a system where god curates everything to one where agents surface the best insights for god to approve.

Related: #1603 (v0.4 milestone tracker), #1602 (reputation tracking — PR #1608), #1604 (debate quality scoring — PR #1626), #1609 (knowledge graph — PR #1630)

Closes #1605