### PR TITLE
fix(coordinator): remove duplicate pre_claim_timestamps/now_epoch declarations in cleanup_stale_assignments

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -751,16 +751,6 @@ cleanup_stale_assignments() {
     local cleaned_assignments=""
     local stale_count=0
 
-    # Issue #1546: Load pre-claim timestamps to protect coordinator-created pre-claims
-    # from being pruned before the worker's Job starts. Format: "agent:issue:ts;..."
-    # route_tasks_by_specialization() writes here when pre-claiming on an agent's behalf.
-    local pre_claim_timestamps
-    pre_claim_timestamps=$(get_state "preClaimTimestamps" 2>/dev/null || echo "")
-    local now_epoch
-    now_epoch=$(date +%s)
-    # Grace window: 120 seconds. Worker spawn latency can exceed 60s (kro + EKS node scaling).
-    local PRE_CLAIM_GRACE_WINDOW=120
-
     # Issue #1561: Per-run issue-state cache to deduplicate gh issue view API calls.
     # cleanup_stale_assignments() runs every coordinator iteration (~30s) and calls
     # `gh issue view` for EACH assignment — both active (closed-issue check, #1094) and


### PR DESCRIPTION
## Summary

Removes redundant duplicate variable initialization blocks in `cleanup_stale_assignments()` that caused an extra kubectl call and date syscall on every coordinator cycle.

## Problem

Two separate PRs that both added pre-claim grace window logic left duplicate `local` declarations for the same variables:

**Block 1 (lines 754-762, now removed):**
```bash
# Issue #1546: Load pre-claim timestamps...
local pre_claim_timestamps
pre_claim_timestamps=$(get_state "preClaimTimestamps" 2>/dev/null || echo "")
local now_epoch
now_epoch=$(date +%s)
local PRE_CLAIM_GRACE_WINDOW=120
```

**Block 2 (lines 795-803, retained):**
```bash
# Issue #1474/#1546: Load pre-claim timestamps...
local pre_claim_timestamps
pre_claim_timestamps=$(get_state "preClaimTimestamps" 2>/dev/null || echo "")
local now_epoch
now_epoch=$(date +%s)
local PRE_CLAIM_GRACE_WINDOW=120
# Extended TTL: drop entries older than 300s...
```

In bash, the second `local` declaration re-initializes the variable — so Block 1's values were always overwritten by Block 2. Block 1 was dead code causing:
- Extra `kubectl get configmap coordinator-state` call per 30s cycle = 2,880 extra API calls/day
- Extra `date +%s` syscall per cycle
- Misleading code — readers might wonder if the two blocks serve different purposes

## Fix

Removed Block 1. Retained Block 2 which is directly followed by the 300s TTL cleanup logic that actually uses these variables.

## Testing

`bash -n coordinator.sh` passes. All coordinator cleanup logic intact (only duplicate initialization removed).

Closes #1635