### PR TITLE
fix(coordinator): release ghost assignments when job not found (closes #1638)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -889,6 +889,19 @@ cleanup_stale_assignments() {
                 fi
             fi
 
+            # Issue #1638: Job not found — release ghost assignment immediately.
+            # When raw_job_json is empty, the Job resource doesn't exist (was deleted or
+            # never created). job_completion_epoch would be 0, bypassing the TTL check below
+            # and keeping the assignment as "Pending: PR likely pending" forever.
+            # Root cause: the TTL check requires job_completion_epoch > 0, which is only true
+            # for jobs that were found but have already completed. For missing jobs, we must
+            # explicitly detect the empty-json case and release right away.
+            if [ -z "$raw_job_json" ] || ! echo "$raw_job_json" | jq -e '.metadata.name' >/dev/null 2>&1; then
+                echo "[$(date -u +%H:%M:%S)] Not found: $agent_name → job missing (deleted or never created), releasing ghost assignment for issue #$issue"
+                stale_count=$((stale_count + 1))
+                continue
+            fi
+
             # Issue #1556: Job completed, but check if issue is closed before releasing claim.
             # Race condition: Worker opens PR → Job completes → Coordinator releases claim
             # → Second worker claims same issue → duplicate PR.


### PR DESCRIPTION
## Summary

Fixes the critical bug where coordinator ghost assignments block all work when planner batches complete.

## Problem

When an agent's Job is deleted (normal completion + TTL cleanup), `cleanup_stale_assignments()` permanently keeps the assignment as "Pending: PR likely pending" — blocking the issue from being claimed by new agents indefinitely.

**Root cause:** The TTL check (issue #1610) requires `job_completion_epoch > 0`:
```bash
if [ "$job_completion_epoch" -gt 0 ] && [ "$job_age" -gt "$STALE_PR_WAIT_TTL" ]; then
    # Release
else
    # "Pending: PR likely pending" ← ALWAYS HIT when job not found
```

When `kubectl get job` returns nothing (job deleted), `raw_job_json` is empty → `job_completion_epoch=0` → TTL check skipped → assignment kept forever.

**Evidence (2026-03-10):** 11 ghost assignments from completed planners blocked all 11 open issues. New agents could not claim any work.

## Fix

Added explicit job-not-found detection before the TTL logic:

```bash
# Issue #1638: Job not found — release ghost assignment immediately.
if [ -z "$raw_job_json" ] || ! echo "$raw_job_json" | jq -e '.metadata.name' >/dev/null 2>&1; then
    echo "Not found: $agent_name → job missing, releasing ghost assignment for issue #$issue"
    stale_count=$((stale_count + 1))
    continue
fi
```

When the Job resource doesn't exist, we now release the assignment immediately on the next 30s cleanup cycle.

## Changes

- `images/runner/coordinator.sh`: Added 13-line job-not-found guard before TTL check

Closes #1638