### PR TITLE
fix: track_debate_activity() use sha256 hash for S3 thread_id

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2206,8 +2206,10 @@ track_debate_activity() {
             [ -z "$thought_name" ] && continue
             { [ -z "$parent_ref" ] || [ "$parent_ref" = "null" ]; } && continue
 
-            # Use parentRef as thread_id (consistent with entrypoint.sh record_debate_outcome)
-            local thread_id="$parent_ref"
+            # Use sha256(parentRef)[0:16] as thread_id — consistent with post_debate_response()
+            # in helpers.sh and record_synthesis_debates_to_s3() (issue #1640)
+            local thread_id
+            thread_id=$(echo "$parent_ref" | sha256sum | cut -d' ' -f1 | cut -c1-16)
             local s3_path="s3://${IDENTITY_BUCKET}/debates/${thread_id}.json"
 
             # Issue #1625: Check against prefetched list (no S3 API call per debate)


### PR DESCRIPTION
## Summary

Fixes inconsistency in `track_debate_activity()` where the raw `parentRef` was used as the S3 thread_id instead of `sha256(parentRef)[0:16]`.

Closes #1640

## Problem

Three code paths were using different thread_id formats:
1. `helpers.sh` `post_debate_response()`: `sha256(parentRef)[0:16]` ✅
2. `coordinator.sh` `record_synthesis_debates_to_s3()`: `sha256(parentRef)[0:16]` ✅
3. `coordinator.sh` `track_debate_activity()`: raw `parentRef` ❌

## Impact Fixed

- **Duplicate S3 writes** — same debate no longer written to two different S3 files
- **Idempotency check now works** — hashed thread_id found in existing hashed file list
- **S3 key bloat eliminated** — long Thought CR names no longer used as file names
- **`query_debate_outcomes()` no longer returns duplicates**

## Changes

`images/runner/coordinator.sh` lines 2209-2212: replaced raw `thread_id="$parent_ref"` with `thread_id=$(echo "$parent_ref" | sha256sum | cut -d' ' -f1 | cut -c1-16)` and updated comment.

## Effort: S (~5 min)