### PR TITLE
fix: align planner-loop.sh fallback Job GitHub token to use secretKeyRef env var (closes #1643)

### DIFF
--- a/images/runner/planner-loop.sh
+++ b/images/runner/planner-loop.sh
@@ -216,8 +216,11 @@ spec:
               value: ${cluster_name}
             - name: NAMESPACE
               value: ${NAMESPACE}
-            - name: GITHUB_TOKEN_FILE
-              value: "/var/secrets/github/token"
+            - name: GITHUB_TOKEN  # env var via secretKeyRef (matches cluster live config, issue #1643)
+              valueFrom:
+                secretKeyRef:
+                  name: agentex-github-token
+                  key: token
           resources:
             requests:
               memory: "512Mi"
@@ -228,17 +231,10 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
-            - name: github-token
-              mountPath: /var/secrets/github
-              readOnly: true
       volumes:
         - name: workspace
           emptyDir:
             sizeLimit: 2Gi
-        - name: github-token
-          secret:
-            secretName: agentex-github-token
-            defaultMode: 0400
 EOF
         if [ $? -eq 0 ]; then
             echo "[$(date -u +%H:%M:%S)] Fallback Job created for $name ✓"


### PR DESCRIPTION
## Summary

Fixes the GitHub token injection in `planner-loop.sh`'s kro fallback Job template (issue #714 workaround) to use `GITHUB_TOKEN` via `secretKeyRef` — consistent with the cluster's live `agent-graph` RGD (since PR #691).

Closes #1643

## Problem

`planner-loop.sh` creates a fallback Job when kro doesn't reconcile within 15s. This fallback Job template used the old file-based token approach:

```yaml
- name: GITHUB_TOKEN_FILE
  value: "/var/secrets/github/token"
...
volumeMounts:
  - name: github-token
    mountPath: /var/secrets/github
    readOnly: true
volumes:
  - name: github-token
    secret:
      secretName: agentex-github-token
```

The live cluster's `agent-graph` RGD (generation 7, PR #691) uses env var injection:

```yaml
- name: GITHUB_TOKEN
  valueFrom:
    secretKeyRef:
      name: agentex-github-token
      key: token
```

## Changes

- `images/runner/planner-loop.sh`: Replace `GITHUB_TOKEN_FILE` + volume mount with `GITHUB_TOKEN` `secretKeyRef` in the kro fallback Job template

## Notes

- `planner-loop.sh` is NOT a protected file — no `god-approved` label required
- `entrypoint.sh` handles both `GITHUB_TOKEN` and `GITHUB_TOKEN_FILE` at runtime (lines 2948-2953), so both approaches work. This is a consistency fix to match the live cluster config.
- Related to issue #1615 (PR #1619 fixes `agent-graph.yaml`), but `planner-loop.sh` was not included in that PR.