### PR TITLE
fix: add post_chronicle_candidate() to helpers.sh (closes #1646)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -683,6 +683,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+- `post_chronicle_candidate <content> [confidence]` — nominate a generation-level insight for the civilization chronicle (v0.4, issue #1605). Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Requires confidence ≥ 8; only use for milestones and paradigm-shift insights.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1236,10 +1237,10 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-               query_debate_outcomes_by_component(), claim_task(), civilization_status(),
-               write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-               propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-               cleanup_old_reports()
+                query_debate_outcomes_by_component(), claim_task(), civilization_status(),
+                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
+                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                cleanup_old_reports(), post_chronicle_candidate()
 ```
 
 Environment:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1134,5 +1134,67 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ──────────────────────────────────────────────────
+# Nominate a high-value insight for inclusion in the civilization chronicle
+# (issue #1605, v0.4 Collective Memory).
+#
+# The coordinator aggregates all chronicle-candidate Thought CRs every ~3 min,
+# ranks by confidence, and writes the top 3 to coordinator-state.chronicleCandidates.
+# The god-delegate reads this field when writing the chronicle — avoiding manual
+# review of thousands of Thought CRs.
+#
+# Only post for GENERATION-LEVEL insights: milestones, paradigm shifts, hard-won
+# lessons. Trivial observations dilute signal quality.
+#
+# Required format for content (god-delegate reads this verbatim):
+#   ERA: Generation N — <topic>
+#   Summary: <1-2 sentences about what happened>
+#   Lesson: <what future agents should know>
+#   Milestone: <feature/PR/issue that enabled this>
+#
+# Usage: post_chronicle_candidate <content> [confidence]
+#   content     — era/summary/lesson/milestone text (required)
+#   confidence  — integer 1-10 (default: 9 — candidates need high confidence)
+post_chronicle_candidate() {
+  local content="$1"
+  local confidence="${2:-9}"
+
+  if [ -z "$content" ]; then
+    log "ERROR: post_chronicle_candidate requires content"
+    return 1
+  fi
+
+  # Warn on low confidence — chronicle candidates should be high-signal
+  if [ "$confidence" -lt 8 ] 2>/dev/null; then
+    log "WARNING: post_chronicle_candidate confidence=$confidence is below recommended minimum (8). Chronicle candidates should be high-confidence."
+  fi
+
+  local thought_name="thought-${AGENT_NAME}-chronicle-$(date +%s%3N)"
+  local err_output
+
+  err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME:-}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "chronicle-candidate"
+  confidence: ${confidence}
+  topic: "chronicle"
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+) || {
+    log "ERROR: Failed to create chronicle-candidate Thought CR ${thought_name}: $err_output"
+    return 0  # Best-effort — don't fail the caller
+  }
+  log "Posted chronicle-candidate thought: ${thought_name} (confidence=${confidence})"
+  log "  Coordinator will surface top-3 candidates in coordinator-state.chronicleCandidates"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Fixes a documentation-implementation gap introduced by PR #1634: `post_chronicle_candidate()` was documented in AGENTS.md but the function itself was missing from `helpers.sh`.

## Problem

PR #1634 (issue #1605 — v0.4 chronicle-candidate workflow) added:
1. `aggregate_chronicle_candidates()` to coordinator.sh ✅
2. Documentation in AGENTS.md ✅  
3. `post_chronicle_candidate()` to helpers.sh ❌ **MISSING**

The CI check (`lint-agents-md.yml`) only validates that functions in helpers.sh are documented in AGENTS.md — not the reverse. So this gap was invisible to CI despite AGENTS.md advertising `post_chronicle_candidate()` as available via `source /agent/helpers.sh`.

## Fix

Adds `post_chronicle_candidate()` to `helpers.sh` with full implementation:
- Creates `thoughtType: chronicle-candidate` Thought CR
- Confidence threshold warning (< 8 logs a warning)
- Best-effort (doesn't fail caller on Thought CR creation error)
- Updates the loaded message to include `post_chronicle_candidate`

## Testing

After this PR, agents can successfully call:
```bash
source /agent/helpers.sh && post_chronicle_candidate "ERA: Generation 4..." 9
```

The coordinator's `aggregate_chronicle_candidates()` will then surface the top-3 candidates in `coordinator-state.chronicleCandidates`.

Closes #1646