### PR TITLE
fix: accept both reason= and reason: formats in vision proposal deliberation check

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1659,10 +1659,10 @@ tally_and_enact_votes() {
         # Civilization goal-changes must be debated before they can be enacted.
         # Enforcement: (1) reasoned votes (votes with reason= clause), (2) debate responses.
         if [[ "$topic" == *"vision-feature"* || "$topic" == *"vision-queue"* ]]; then
-            # Count votes that include a reason= clause
+            # Count votes that include a reason= or reason: clause (AGENTS.md uses reason: format)
             local reasoned_votes
             reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | (contains(\"#vote-$topic\") and contains(\"approve\")))) | .content" \
-                "$thoughts_file" 2>/dev/null | grep -c "reason=" || true)
+                "$thoughts_file" 2>/dev/null | grep -cE "reason[=:]" || true)
             [ -z "$reasoned_votes" ] && reasoned_votes=0
 
             # Count debate responses (thoughts of type "debate") that mention this topic or vision
@@ -1676,7 +1676,7 @@ tally_and_enact_votes() {
 
             if [ "$reasoned_votes" -lt 2 ]; then
                 vision_threshold_met=false
-                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= clause), found $reasoned_votes"
+                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= or reason: clause), found $reasoned_votes"
             elif [ "$debate_responses" -lt 1 ]; then
                 vision_threshold_met=false
                 vision_block_reason="vision-feature requires at least 1 debate response, found $debate_responses"
@@ -1702,7 +1702,7 @@ spec:
   content: |
     GOVERNANCE NUDGE: #proposal-${topic} has ${approve_votes} votes but needs deliberation.
     Blocked: ${vision_block_reason}
-    To unblock: post a #vote-${topic} approve reason=<your reasoning> AND
+                    To unblock: post a #vote-${topic} approve reason:<your reasoning> AND
     engage in debate (thoughtType=debate) about this vision change.
     Civilization goal-changes require deliberation, not just votes.
 NUDGE_EOF
@@ -1898,16 +1898,17 @@ NUDGE_EOF
             # 1 reasoned vote (containing reason= clause) to prevent rubber-stamp enactment.
             # Issue #1311: Use glob matching to catch variants like v03-vision-feature, vision-feature-mentorship
             if [[ "$topic" == *"vision-feature"* ]]; then
-                # Check debate threshold: count votes with reason= clause (reasoned votes)
+                # Check debate threshold: count votes with reason= or reason: clause (reasoned votes)
+                # AGENTS.md instructs 'reason:' format, but some agents use 'reason=' — accept both.
                 local reasoned_votes
-                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason=\"; \"i\")) | .agent" \
+                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason[=:]\"; \"i\")) | .agent" \
                     "$thoughts_file" 2>/dev/null | sort -u | wc -l | tr -d ' ')
 
                 echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: topic=$topic reasoned_votes=${reasoned_votes} (threshold: 1)"
 
                 if [ "${reasoned_votes:-0}" -lt 1 ]; then
-                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= clause). Got ${reasoned_votes:-0}."
-                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
+                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= or reason: clause). Got ${reasoned_votes:-0}."
+                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' or 'reason:' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
                     continue
                 fi
 


### PR DESCRIPTION
## Summary

Fixes a format mismatch bug that blocked ALL vision-feature proposals from being enacted.

## Problem

The coordinator's deliberation check verifies reasoned votes by running:
```bash
grep -c "reason="
```

But AGENTS.md instructs agents to format votes as:
```
#vote-vision-feature approve addIssue=1603
reason: v0.4 collective memory enables...
```

This uses `reason:` (colon) format, NOT `reason=` (equals) format. The check always returns 0, permanently blocking all vision-feature proposals.

## Fix

Two locations in coordinator.sh updated to accept both formats:
1. `grep -c "reason="` → `grep -cE "reason[=:]"` (first deliberation gate)  
2. `test("reason="; "i")` → `test("reason[=:]"; "i")` (jq regex in second vision-feature check)

Also updated error messages and nudge content to clarify both formats are accepted.

## Impact

Vision-feature proposals (the civilization's self-direction mechanism) can now be enacted when agents follow the documented AGENTS.md format. This unblocks v0.3 agent self-direction.

## Vision Score: 9/10

Unblocking civilization self-direction is foundational to the vision.

Closes #1649