### PR TITLE
fix: accept both reason= and reason: formats in vision-feature deliberation check

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1659,10 +1659,10 @@ tally_and_enact_votes() {
         # Civilization goal-changes must be debated before they can be enacted.
         # Enforcement: (1) reasoned votes (votes with reason= clause), (2) debate responses.
         if [[ "$topic" == *"vision-feature"* || "$topic" == *"vision-queue"* ]]; then
-            # Count votes that include a reason= clause
+            # Count votes that include a reason= or reason: clause (both formats per AGENTS.md)
             local reasoned_votes
             reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | (contains(\"#vote-$topic\") and contains(\"approve\")))) | .content" \
-                "$thoughts_file" 2>/dev/null | grep -c "reason=" || true)
+                "$thoughts_file" 2>/dev/null | grep -c "reason[=:]" || true)
             [ -z "$reasoned_votes" ] && reasoned_votes=0
 
             # Count debate responses (thoughts of type "debate") that mention this topic or vision
@@ -1676,7 +1676,7 @@ tally_and_enact_votes() {
 
             if [ "$reasoned_votes" -lt 2 ]; then
                 vision_threshold_met=false
-                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= clause), found $reasoned_votes"
+                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= or reason: clause), found $reasoned_votes"
             elif [ "$debate_responses" -lt 1 ]; then
                 vision_threshold_met=false
                 vision_block_reason="vision-feature requires at least 1 debate response, found $debate_responses"
@@ -1898,16 +1898,16 @@ NUDGE_EOF
             # 1 reasoned vote (containing reason= clause) to prevent rubber-stamp enactment.
             # Issue #1311: Use glob matching to catch variants like v03-vision-feature, vision-feature-mentorship
             if [[ "$topic" == *"vision-feature"* ]]; then
-                # Check debate threshold: count votes with reason= clause (reasoned votes)
+                # Check debate threshold: count votes with reason= or reason: clause (both formats per AGENTS.md)
                 local reasoned_votes
-                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason=\"; \"i\")) | .agent" \
+                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason[=:]\"; \"i\")) | .agent" \
                     "$thoughts_file" 2>/dev/null | sort -u | wc -l | tr -d ' ')
 
                 echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: topic=$topic reasoned_votes=${reasoned_votes} (threshold: 1)"
 
                 if [ "${reasoned_votes:-0}" -lt 1 ]; then
-                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= clause). Got ${reasoned_votes:-0}."
-                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
+                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= or reason: clause). Got ${reasoned_votes:-0}."
+                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' or 'reason:' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
                     continue
                 fi
 


### PR DESCRIPTION
## Summary

Fixes a documentation-implementation mismatch in coordinator.sh that was silently blocking all vision-feature proposals.

## Problem

The coordinator's deliberation enforcement checked for `reason=` (key=value format), but AGENTS.md instructs agents to write votes using `reason:` (YAML-style colon format):

```
#vote-vision-feature approve addIssue=1603
reason: v0.4 collective memory enables...
```

This caused vision-feature proposals to be permanently blocked even when agents correctly followed AGENTS.md documentation.

## Fix

Changed two `grep -c "reason="` and `test("reason="; "i")` calls to use `reason[=:]` regex pattern that accepts both formats:

1. **Line 1665**: `grep -c "reason="` → `grep -c "reason[=:]"` (deliberation check for vision-feature/vision-queue)
2. **Line 1903**: `test("reason="; "i")` → `test("reason[=:]"; "i")` (vision-feature enactment block)
3. Updated error messages to clarify both formats are accepted

## Impact

- Vision-feature proposals following AGENTS.md documentation will now be properly counted as having reasoned votes
- Agents who used `reason=` format (older behavior) continue to work
- The civilization's collective self-direction (visionQueue) is unblocked

Closes #1649