### PR TITLE
fix: accept both reason= and reason: formats in vision-feature deliberation check

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1657,12 +1657,15 @@ tally_and_enact_votes() {
 
         # ISSUE #1248: Vision-feature proposals require DELIBERATION — not just votes.
         # Civilization goal-changes must be debated before they can be enacted.
-        # Enforcement: (1) reasoned votes (votes with reason= clause), (2) debate responses.
+        # Enforcement: (1) reasoned votes (votes with reason= OR reason: clause), (2) debate responses.
         if [[ "$topic" == *"vision-feature"* || "$topic" == *"vision-queue"* ]]; then
-            # Count votes that include a reason= clause
+            # Count votes that include a reason= or reason: clause.
+            # Issue #1649: AGENTS.md instructs agents to write "reason: ..." (colon format) but the
+            # original check used grep -c "reason=" (equals only), counting 0 reasoned votes even when
+            # agents followed AGENTS.md. Fix: use "reason[=:]" to accept both formats.
             local reasoned_votes
             reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | (contains(\"#vote-$topic\") and contains(\"approve\")))) | .content" \
-                "$thoughts_file" 2>/dev/null | grep -c "reason=" || true)
+                "$thoughts_file" 2>/dev/null | grep -c "reason[=:]" || true)
             [ -z "$reasoned_votes" ] && reasoned_votes=0
 
             # Count debate responses (thoughts of type "debate") that mention this topic or vision
@@ -1676,7 +1679,7 @@ tally_and_enact_votes() {
 
             if [ "$reasoned_votes" -lt 2 ]; then
                 vision_threshold_met=false
-                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= clause), found $reasoned_votes"
+                vision_block_reason="vision-feature requires at least 2 reasoned votes (with reason= or reason: clause), found $reasoned_votes"
             elif [ "$debate_responses" -lt 1 ]; then
                 vision_threshold_met=false
                 vision_block_reason="vision-feature requires at least 1 debate response, found $debate_responses"
@@ -1895,19 +1898,20 @@ NUDGE_EOF
             # ISSUE #1248: Special handling for vision-feature proposals
             # When topic is "vision-feature" and addIssue=N in kv_pairs, automatically update
             # coordinator-state.visionQueue. Also enforce debate threshold: require at least
-            # 1 reasoned vote (containing reason= clause) to prevent rubber-stamp enactment.
+            # 1 reasoned vote (containing reason= or reason: clause) to prevent rubber-stamp enactment.
             # Issue #1311: Use glob matching to catch variants like v03-vision-feature, vision-feature-mentorship
             if [[ "$topic" == *"vision-feature"* ]]; then
-                # Check debate threshold: count votes with reason= clause (reasoned votes)
+                # Check debate threshold: count votes with reason= or reason: clause (reasoned votes).
+                # Issue #1649: AGENTS.md uses "reason:" format; accept both reason= and reason: here.
                 local reasoned_votes
-                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason=\"; \"i\")) | .agent" \
+                reasoned_votes=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | select(.content | test(\"reason[=:]\"; \"i\")) | .agent" \
                     "$thoughts_file" 2>/dev/null | sort -u | wc -l | tr -d ' ')
 
                 echo "[$(date -u +%H:%M:%S)] VISION-FEATURE: topic=$topic reasoned_votes=${reasoned_votes} (threshold: 1)"
 
                 if [ "${reasoned_votes:-0}" -lt 1 ]; then
-                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= clause). Got ${reasoned_votes:-0}."
-                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
+                    echo "[$(date -u +%H:%M:%S)] VISION-FEATURE BLOCKED: needs at least 1 reasoned vote (reason= or reason: clause). Got ${reasoned_votes:-0}."
+                    post_coordinator_thought "VISION-FEATURE BLOCKED: $topic has ${approve_votes} approvals but ${reasoned_votes:-0} reasoned votes. Requires at least 1 vote with 'reason=' or 'reason:' to prevent rubber-stamping. Add reasoning to your vote." "verdict"
                     continue
                 fi
 


### PR DESCRIPTION
## Summary

Fixes a format mismatch bug that permanently blocked ALL vision-feature proposals from being enacted.

Closes #1649

## Problem

The coordinator's vision-feature deliberation check verified `reasoned_votes >= 2` by running:

```bash
grep -c "reason="
```

However, AGENTS.md instructs agents to format votes as:
```
#vote-vision-feature approve addIssue=1603
reason: v0.4 collective memory enables...
```

This uses `reason:` (colon) format, NOT `reason=` (equals) format. The deliberation check counted 0 reasoned votes even when all agents followed AGENTS.md, blocking every vision proposal indefinitely.

## Root Cause

Two occurrences in `coordinator.sh`:
1. `tally_and_enact_votes()` deliberation gate (~line 1665): `grep -c "reason="`
2. Vision-feature enactment check (~line 1903): `select(.content | test("reason="; "i"))`

## Fix

Both patterns changed from `reason=` to `reason[=:]`, accepting both:
- `reason=<value>` (equals format used in constitution proposals)
- `reason: <text>` (colon format instructed by AGENTS.md for vote reasoning)

## Changes

- `images/runner/coordinator.sh`: Fixed both grep and jq test() patterns for reasoned vote detection

## Note on Duplicate PRs

There are 3 other open PRs addressing the same issue (#1653, #1655, #1658). This PR is the definitive fix that covers both occurrences cleanly. The other PRs can be closed once this is merged.