### PR TITLE
fix: enforce single-planner constraint guardrail at step 11.6 (issue #1660)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4377,7 +4377,41 @@ if echo "$BLOCKER_THOUGHTS" | grep -qiE '(structural|architecture|RGD|kro.*bug|s
   log "ROLE ESCALATION TRIGGERED: Structural issue detected in blocker thoughts"
   ESCALATED_ROLE="architect"
   post_thought "Role escalation triggered: $AGENT_ROLE → architect (structural issue found)" "decision" 9
-  post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
+   post_message "broadcast" "Role escalation: $AGENT_NAME discovered structural issue, next agent will be architect" "status"
+fi
+
+# ── 11.6. SINGLE-PLANNER CONSTRAINT GUARDRAIL (issue #1660) ───────────────────
+# Planners must NOT spawn planner successors. The planner-loop Deployment handles
+# planner perpetuation exclusively. If OpenCode spawned a planner successor despite
+# the Prime Directive instructions, delete it here and release the spawn slot.
+# This prevents the exponential proliferation chain (1→35 planners observed 2026-03-10).
+if [ "${AGENT_ROLE}" = "planner" ]; then
+  # Find all successor Agent CRs spawned by this agent that have role=planner
+  PLANNER_SUCCESSORS=$(kubectl_with_timeout 10 get agents.kro.run -n "$NAMESPACE" \
+    -l "agentex/spawned-by=$AGENT_NAME" \
+    -o json 2>/dev/null | \
+    jq -r '.items[] | select(.spec.role == "planner") | .metadata.name' 2>/dev/null || true)
+
+  if [ -n "$PLANNER_SUCCESSORS" ]; then
+    PLANNER_SUCCESSOR_COUNT=$(echo "$PLANNER_SUCCESSORS" | wc -l | tr -d ' ')
+    log "SINGLE-PLANNER VIOLATION: This planner spawned $PLANNER_SUCCESSOR_COUNT planner successor(s). Deleting to enforce constraint."
+    post_thought "Single-planner constraint violation: $AGENT_NAME spawned $PLANNER_SUCCESSOR_COUNT planner successor(s). Deleting and releasing slots. OpenCode ignored the planner-loop constraint." "blocker" 9
+
+    for planner_successor in $PLANNER_SUCCESSORS; do
+      log "Deleting rogue planner successor: $planner_successor"
+      if kubectl_with_timeout 10 delete agent.kro.run "$planner_successor" -n "$NAMESPACE" --ignore-not-found 2>/dev/null; then
+        log "Deleted planner successor: $planner_successor. Releasing spawn slot."
+        release_spawn_slot || true
+      else
+        log "WARNING: Could not delete planner successor: $planner_successor (may not exist or already deleted)"
+      fi
+      # Also delete associated Task CR if it follows naming convention task-<agent-name>
+      local_task_name="task-${planner_successor}"
+      kubectl_with_timeout 10 delete configmap "${local_task_name}-spec" -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+    done
+
+    log "Single-planner constraint enforced: $PLANNER_SUCCESSOR_COUNT planner successor(s) removed. Emergency perpetuation will spawn a worker instead."
+  fi
 fi
 
 # ── 12. EMERGENCY PERPETUATION ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add a single-planner constraint guardrail at step 11.6 of `entrypoint.sh` that runs after OpenCode completes but before emergency perpetuation (step 12).

## Problem

Despite the Prime Directive telling planners not to spawn planner successors, OpenCode agents still follow AGENTS.md which says to spawn a successor. This creates planner chains: 1→2→4→... up to 35 planners observed 2026-03-10.

The CAS spawn gate (`request_spawn_slot`) correctly prevents **concurrent** bursts, but sequential chain spawning bypasses it — each planner starts when count is just under the limit.

## Fix

**Step 11.6: SINGLE-PLANNER CONSTRAINT GUARDRAIL**

After OpenCode runs, before emergency perpetuation:
1. If this agent is a planner, scan for successor Agent CRs with `spec.role == "planner"` using label `agentex/spawned-by=$AGENT_NAME`
2. For each violating successor: delete the Agent CR, release the spawn slot, delete associated Task ConfigMap
3. Log a blocker Thought CR documenting the violation
4. Step 12 then re-queries successors, finds 0 (since planner successors were deleted), triggers emergency perpetuation which correctly spawns `NEXT_ROLE="worker"`

## Flow After Fix

```
Planner exits → step 11.6 runs:
  - Found 1 planner successor spawned by me → DELETE + release slot
  - Step 12: SPAWNED_BY_ME=0 → emergency perpetuation fires
  - NEXT_ROLE="worker" (case planner→worker at line 4518)
  - Worker spawned successfully
```

## Why This Works

The fix enforces the invariant at the infrastructure level regardless of what OpenCode decides. Even if OpenCode spawns a planner successor on every run, the guardrail removes it and recovery spawns a worker.

Closes #1660

## Related Issues

- #1076 — original single-planner constraint
- #949 — fixed emergency spawn path (but missed normal spawn path)
- #1013 — emergency spawn path fix