### PR TITLE
fix: align coordinator.sh cleanup TTL regex with PR #1627 (closes #1662)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1042,8 +1042,9 @@ cleanup_orphaned_pods() {
 # positioned for periodic cleanup to supplement planner-initiated cleanup.
 #
 # TTLs match helpers.sh cleanup_old_thoughts / cleanup_old_messages:
-#   Thought low-signal (blocker, observation): 2h TTL
-#   Thought high-signal (insight, decision, debate, proposal, vote): 24h TTL
+#   Thought low-signal (blocker, observation, decision, plan, planning): 2h TTL
+#   Thought high-signal (insight, debate, proposal, vote): 24h TTL
+# Issue #1662: align with PR #1627 fix — decision/plan/planning now use 2h TTL (was 24h)
 #   Messages (read): 24h TTL
 #   Messages (unread): 48h TTL
 #   Reports: 48h TTL
@@ -1072,7 +1073,7 @@ cleanup_old_cluster_resources() {
             --arg cutoff_24h "$cutoff_24h" \
             --arg cutoff_2h "$cutoff_2h" \
             '.items[] |
-             (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+             (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
               then $cutoff_2h
               else $cutoff_24h
               end) as $cutoff |


### PR DESCRIPTION
## Summary

Fixes the TTL gap in coordinator.sh's inline cleanup function.

## Problem

PR #1627 (closes #1614) updated `entrypoint.sh` and `helpers.sh` to give `decision|plan|planning` thought types a 2h TTL. However, `coordinator.sh`'s `cleanup_old_cluster_resources()` function was NOT updated.

This caused `decision`/`plan`/`planning` thoughts to accumulate with 24h TTL in the coordinator's periodic cleanup (~30min cadence), only being cleared when a planner calls `cleanup_old_thoughts()` from helpers.sh.

## Changes

- `coordinator.sh` `cleanup_old_cluster_resources()`: add `decision|plan|planning` to the 2h TTL regex
- Update comment block to document all low-signal thought types correctly

## Testing

The change aligns coordinator.sh's TTL behavior with the already-implemented behavior in entrypoint.sh and helpers.sh.

Closes #1662