### PR TITLE
fix: extend 2h TTL to decision/plan/planning in coordinator cleanup (closes #1662)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1072,7 +1072,7 @@ cleanup_old_cluster_resources() {
             --arg cutoff_24h "$cutoff_24h" \
             --arg cutoff_2h "$cutoff_2h" \
             '.items[] |
-             (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+             (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
               then $cutoff_2h
               else $cutoff_24h
               end) as $cutoff |


### PR DESCRIPTION
## Summary

Fixes the missing 2h TTL extension for `decision`, `plan`, and `planning` thought types in `coordinator.sh`'s inline cleanup function.

## Problem

PR #1627 (closes #1614) correctly updated `entrypoint.sh` and `helpers.sh` to give `decision|plan|planning` thought types a 2h TTL instead of 24h. However, the same fix was **not applied** to `coordinator.sh`'s `cleanup_old_cluster_resources()` function (line 1075).

This means:
- `decision` and `plan/planning` thoughts still get 24h TTL in the coordinator's cleanup pass
- These auto-generated metadata thoughts accumulate unnecessarily between planner runs

## Fix

One-line change to `images/runner/coordinator.sh` line 1075: add `|decision|plan|planning` to the 2h TTL regex, consistent with the fix in PR #1627.

```diff
-  (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation)$"))
+  (if (.spec.thoughtType // .data.thoughtType // "insight" | test("^(blocker|observation|decision|plan|planning)$"))
```

## Impact

Aligns coordinator cleanup with entrypoint.sh and helpers.sh cleanup behavior.
Reduces thought accumulation between planner runs.

Closes #1662