### PR TITLE
fix: prevent planner-role agents from claiming issues in coordinator (closes #1669)

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -401,6 +401,14 @@ claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
 
+  # Issue #1669: Planners should spawn workers for issues, not claim them directly.
+  # Planner claims create ghost assignments (planner exits before implementing,
+  # leaving stale activeAssignments entries that block workers).
+  if [ "${AGENT_ROLE:-}" = "planner" ]; then
+    log "Coordinator: SKIPPING claim for issue #$issue — planners spawn workers, not claim issues. Use spawn_task_and_agent instead."
+    return 1
+  fi
+
   local max_attempts=5
   local attempt=0
 


### PR DESCRIPTION
## Summary

Prevents planner-role agents from claiming issues via \`claim_task()\`, eliminating a recurring source of ghost assignments that block workers.

Closes #1669

## Problem

Planners frequently appeared in \`coordinator-state.activeAssignments\` after calling \`claim_task()\`. Since planners exit after spawning workers (not after implementing), their assignments became ghost entries persisting 30+ minutes and blocking workers from picking up the same issues.

Observed examples:
- \`planner-gen4-1773121713:1614\` — issue #1614 CLOSED but planner assignment blocked work
- \`planner-gen4-1773164569:1593\` — issue #1593 CLOSED but assignment persisted  
- \`planner-gen4-1773120689:1609\` — issue #1609 CLOSED but assignment persisted

## Fix

Added a planner role check at the start of \`claim_task()\` in \`images/runner/helpers.sh\`:

```bash
if [ "${AGENT_ROLE:-}" = "planner" ]; then
    log "Coordinator: SKIPPING claim for issue #$issue — planners spawn workers, not claim issues. Use spawn_task_and_agent instead."
    return 1
fi
```

When a planner tries to call \`claim_task()\`, it now gets a clear log message explaining the correct pattern (\`spawn_task_and_agent\`) and returns failure, preventing the ghost assignment.

## Impact

- Eliminates ghost planner assignments at the source
- Workers can claim any available issue without being blocked by planner ghosts
- Clear error message guides planners to correct \`spawn_task_and_agent\` usage
- No behavioral change for workers/reviewers/architects

## Testing

The change is minimal — 8 lines added, role check only fires for \`AGENT_ROLE=planner\`.