### PR TITLE
fix: reject claim_task() for issues with existing open PRs (closes #1672)

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -382,8 +382,13 @@ fi
 # specialization tracking can find it even after coordinator cleanup removes the
 # activeAssignments entry (fix for issue #1252: WORKED_ISSUE=0 race condition).
 #
+# Issue #1672: Also checks for existing open PRs before claiming. The coordinator's
+# task queue (refresh_task_queue) already skips issues with open PRs, but agents that
+# self-select via claim_task() directly bypass that check. This pre-claim PR check
+# prevents duplicate implementations when multiple agents race for the same issue.
+#
 # Usage: claim_task <issue_number>
-# Returns: 0 if claim succeeded, 1 if already claimed by another agent or on error
+# Returns: 0 if claim succeeded, 1 if already claimed, has open PR, or on error
 #
 # IMPORTANT: In OpenCode bash tool context, this function runs in a fresh subprocess.
 # COORDINATOR_ISSUE cannot be set in the parent entrypoint.sh process from here.
@@ -400,6 +405,23 @@ fi
 claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
+
+  # Issue #1672: Check if an open PR already exists for this issue before claiming.
+  # The coordinator's task queue refresh (refresh_task_queue) already skips issues
+  # with open PRs, but agents that self-select via direct claim_task() bypass that check.
+  # This pre-claim PR check prevents duplicate PR implementations when multiple agents
+  # see the same open issue and race to claim it after a stale assignment is released.
+  local github_repo="${REPO:-pnz1990/agentex}"
+  local open_pr_url
+  open_pr_url=$(gh api "/repos/${github_repo}/pulls?state=open&per_page=100" 2>/dev/null | \
+    jq -r --arg n "$issue" \
+    '.[] | select(.body // "" | test("(C|c)loses? #\($n)\\b|(F|f)ixes? #\($n)\\b|(R|r)esolves? #\($n)\\b")) | .html_url' \
+    2>/dev/null | head -1)
+  if [ -n "$open_pr_url" ]; then
+    log "Coordinator: issue #$issue already has open PR — skipping to prevent duplicate implementation (PR: $open_pr_url)"
+    push_metric "TaskClaimBlockedByPR" 1
+    return 1
+  fi
 
   local max_attempts=5
   local attempt=0


### PR DESCRIPTION
## Summary

Prevents duplicate PR implementations by adding a pre-claim open PR check to `claim_task()` in `helpers.sh`.

Closes #1672

## Problem

Issue #1649 (reason= format fix) accumulated **5 duplicate open PRs** in a single day despite the coordinator's existing PR-dedup mechanism. The coordinator's `refresh_task_queue()` already skips issues with open PRs when building the task queue (issue #1384), but agents that self-select issues via direct `claim_task()` bypass this check entirely.

When a stale planner assignment on issue #1649 was released by the coordinator cleanup loop, multiple waiting planners all tried `claim_task(1649)` in rapid succession. The CAS gate prevents concurrent double-claiming, but sequential claimants (each getting the claim after the previous stale one is released) each saw the issue as claimable and opened their own PRs.

## Fix

Added a pre-claim check in `claim_task()` (helpers.sh, ~line 406):
1. Before the CAS loop, query GitHub API for open PRs referencing this issue
2. Pattern: `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive)
3. If a PR exists → return 1 (reject claim), log reason, emit `TaskClaimBlockedByPR` metric
4. If no PR → proceed with normal CAS claim

## Why This Location

`claim_task()` is the single entry point for ALL agent issue claims (coordinator pre-claims, worker self-claims, planner step-② claims). Fixing it here ensures consistent PR-dedup regardless of how an agent discovered the issue.

## Changes

- `images/runner/helpers.sh`: Added 15-line PR check at start of `claim_task()` body
- Updated function comment to document the new behavior

## Impact

- Eliminates the most common source of duplicate PRs
- One GitHub API call per `claim_task()` invocation (cached at coordinator level already; this adds per-agent call)
- Graceful degradation: if `gh api` fails, `open_pr_url` is empty and claim proceeds normally