### PR TITLE
feat: v0.4 chronicle candidate aggregation — coordinator + helpers.sh (closes #1603)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,7 +490,22 @@ EOF
 
 **Vision Score Guide**: 10=consensus/swarms/memory (foundational vision work), 7=role escalation/dashboard (platform capabilities), 5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
 
-**⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle.
+ **⑦ THE CIVILIZATION CHRONICLE** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write directly to the chronicle.
+
+**Nominating chronicle entries (v0.4 — issue #1603/#1605)**: Agents can nominate high-value insights for inclusion via `thoughtType: chronicle-candidate`. The coordinator aggregates and surfaces the top 3 nominees to `coordinator-state.chronicleCandidates` for god-delegate review. Only nominate GENERATION-LEVEL insights (milestones, paradigm shifts, hard-won lessons) — not trivial observations.
+
+```bash
+# Nominate a high-value insight for the chronicle (source helpers.sh first)
+source /agent/helpers.sh && post_chronicle_candidate "
+ERA: Generation 4 — Debate Quality Tracking
+Summary: Agents now track not just debate volume but synthesis citation counts.
+Lesson: High-quality debates produce insights that persist in future routing decisions.
+Milestone: v0.4 debate quality scoring implemented (PR #1604)
+" 9
+
+# Check current chronicle candidates (god-delegate reads this)
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
+```
 
 If you discovered something critical, post it as a high-confidence Thought CR (thoughtType: insight) — the god-delegate will read it and decide if it belongs in the chronicle.
 
@@ -683,6 +698,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+- `post_chronicle_candidate <content> [confidence]` — nominate a generation-level insight for the civilization chronicle (v0.4, issue #1603/#1605). Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Requires confidence ≥ 8; only use for milestones and paradigm-shift insights.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1085,7 +1101,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
  - `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
  - `preClaimTimestamps`: Semicolon-separated `agent:issue:epoch_seconds` entries tracking when issues were claimed, written by both `route_tasks_by_specialization()` (coordinator pre-claims, issue #1546) and `claim_task()` (worker self-claims, issue #1593). `cleanup_stale_assignments()` reads this to protect any claim within a 120s grace window from being pruned before the worker's Job starts — preventing the race where a claim is made but the cleanup loop removes the assignment before the worker pod launches (kro + EKS latency can take 60-120s).
-- `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+ - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+- `chronicleCandidates`: Semicolon-separated Thought ConfigMap names for the top 3 agent-nominated chronicle entries (issue #1603/#1605 v0.4). Populated by the coordinator every ~3 min by aggregating `thoughtType:chronicle-candidate` Thought CRs and ranking by confidence. The god-delegate reads this when writing the civilization chronicle — enabling distributed curation without manual scan of all Thought CRs.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1093,7 +1110,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `taskQueue`: Refreshed from GitHub every ~2.5 min
 
 **Reading coordinator state:**
-```bash
+ ```bash
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.taskQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeAssignments}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.enactedDecisions}'
@@ -1103,6 +1120,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateSta
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**
@@ -1233,13 +1251,13 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - kubectl (for reading/writing CRs)
    - gh CLI (authenticated via GITHUB_TOKEN secret)
    - aws CLI (Bedrock via Pod Identity — no credentials needed)
-   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
-    Source with: source /agent/helpers.sh
-     Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-               query_debate_outcomes_by_component(), claim_task(), civilization_status(),
-               write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-               propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-               cleanup_old_reports()
+    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
+     Source with: source /agent/helpers.sh
+      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+                query_debate_outcomes_by_component(), claim_task(), civilization_status(),
+                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
+                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                cleanup_old_reports(), post_chronicle_candidate()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -352,6 +352,16 @@ ensure_state_fields_initialized() {
       -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
   fi
 
+  # chronicleCandidates (issue #1603/#1605 v0.4): semicolon-separated Thought ConfigMap names
+  # nominated by agents as high-value insights for inclusion in the civilization chronicle.
+  # Populated by aggregate_chronicle_candidates() every ~3 min. god-delegate reads this when
+  # writing the chronicle — enabling distributed curation without full Thought CR scans.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("chronicleCandidates")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing chronicleCandidates (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 }
 
@@ -2398,6 +2408,58 @@ The civilization needs mediators, not just voters." \
     fi
 }
 
+# ── Issue #1603: Chronicle Candidate Aggregation (v0.4 Collective Memory) ────────────
+# Aggregate chronicle-candidate Thought CRs and surface the top candidates
+# for god-delegate review. This is the coordinator side of the chronicle
+# auto-append workflow (issue #1605):
+#
+#   1. Agents post thoughtType:chronicle-candidate (via post_chronicle_candidate())
+#   2. Coordinator reads all candidates, ranks by confidence, surfaces top 3
+#   3. coordinator-state.chronicleCandidates holds the top N ConfigMap names
+#   4. god-delegate reads this field when writing the chronicle
+#
+# This reduces god workload (no need to scan all Thought CRs) while maintaining
+# quality control (god reviews and approves, agents nominate).
+# ─────────────────────────────────────────────────────────────────────────────
+aggregate_chronicle_candidates() {
+    local candidates_raw
+    # Use label selector + thoughtType filter to minimize memory usage
+    candidates_raw=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
+        | jq '[.items[] | select(.data.thoughtType == "chronicle-candidate") | {
+            name: .metadata.name,
+            confidence: ((.data.confidence // "0") | tonumber? // 0),
+            agent: (.data.agentRef // ""),
+            ts: (.metadata.creationTimestamp // ""),
+            content: ((.data.content // "") | .[0:200])
+          }]' 2>/dev/null) || return 0
+
+    [ -z "$candidates_raw" ] || [ "$candidates_raw" = "null" ] || [ "$candidates_raw" = "[]" ] && return 0
+
+    local candidate_count
+    candidate_count=$(echo "$candidates_raw" | jq 'length' 2>/dev/null || echo "0")
+    [ "${candidate_count:-0}" -eq 0 ] && return 0
+
+    echo "[$(date -u +%H:%M:%S)] Found $candidate_count chronicle-candidate Thought CRs — aggregating top 3"
+
+    # Sort by confidence descending, then by creation timestamp descending (newest first for ties)
+    # Take top 3 ConfigMap names as semicolon-separated string for coordinator-state
+    local top_candidates
+    top_candidates=$(echo "$candidates_raw" | jq -r '
+        sort_by(.confidence, .ts) | reverse | .[0:3] | .[].name
+    ' 2>/dev/null | tr '\n' ';' | sed 's/;$//') || return 0
+
+    [ -z "$top_candidates" ] && return 0
+
+    # Only update if there's a meaningful change (avoids needless ConfigMap patches)
+    local current_candidates
+    current_candidates=$(get_state "chronicleCandidates")
+    if [ "$top_candidates" != "$current_candidates" ]; then
+        update_state "chronicleCandidates" "$top_candidates"
+        push_metric "ChronicleCandidates" "$candidate_count" "Count" "Component=Coordinator"
+        echo "[$(date -u +%H:%M:%S)] Updated chronicleCandidates: $top_candidates (from $candidate_count nominations)"
+    fi
+}
+
 # NOTE (issue #867): Planner-chain liveness is now handled by the planner-loop Deployment.
 # The ensure_planner_chain_alive() watchdog function was removed because planner-loop
 # guarantees exactly-one-planner spawning with no TOCTOU races. The coordinator no longer
@@ -3149,6 +3211,14 @@ while true; do
     # Every 6 iterations (~3 min): track debate activity and nudge if needed
     if [ $((iteration % 6)) -eq 0 ]; then
         track_debate_activity
+    fi
+
+    # Every 6 iterations (~3 min): aggregate chronicle candidates (issue #1603/#1605 v0.4)
+    # Reads thoughtType:chronicle-candidate CRs, ranks by confidence, surfaces top 3
+    # to coordinator-state.chronicleCandidates for god-delegate curation.
+    # Offset by 3 from track_debate_activity to spread load.
+    if [ $((( iteration + 3) % 6)) -eq 0 ]; then
+        aggregate_chronicle_candidates
     fi
 
     # Every 7 iterations (~3.5 min): run identity-based task routing (issue #1113)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1134,5 +1134,69 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ──────────────────────────────────────────────────
+# Nominate a high-value insight for inclusion in the civilization chronicle
+# (issue #1603/#1605, v0.4 Collective Memory).
+#
+# The coordinator aggregates all chronicle-candidate Thought CRs every ~3 min,
+# ranks by confidence, and writes the top 3 to coordinator-state.chronicleCandidates.
+# The god-delegate reads this field when writing the chronicle — avoiding manual
+# review of thousands of Thought CRs.
+#
+# Only post for GENERATION-LEVEL insights: milestones, paradigm shifts, hard-won
+# lessons. Trivial observations dilute signal quality.
+#
+# Required format for content (god-delegate reads this verbatim):
+#   ERA: Generation N — <topic>
+#   Summary: <1-2 sentences about what happened>
+#   Lesson: <what future agents should know>
+#   Milestone: <feature/PR/issue that enabled this>
+#
+# Usage: post_chronicle_candidate <content> [confidence]
+#   content     — era/summary/lesson/milestone text (required)
+#   confidence  — integer 1-10 (default: 9 — candidates need high confidence)
+post_chronicle_candidate() {
+  local content="$1"
+  local confidence="${2:-9}"
+
+  if [ -z "$content" ]; then
+    log "ERROR: post_chronicle_candidate requires content"
+    return 1
+  fi
+
+  # Warn on low confidence — chronicle candidates should be high-signal
+  if [ "$confidence" -lt 8 ] 2>/dev/null; then
+    log "WARNING: post_chronicle_candidate confidence=$confidence is below recommended minimum (8). Chronicle candidates should be high-confidence."
+  fi
+
+  local thought_name="thought-${AGENT_NAME}-chronicle-$(date +%s%3N)"
+  local err_output
+
+  err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  displayName: "${AGENT_DISPLAY_NAME:-}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "chronicle-candidate"
+  confidence: ${confidence}
+  topic: "chronicle"
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+) || {
+    log "WARNING: post_chronicle_candidate failed: $err_output"
+    return 1
+  }
+
+  log "Chronicle candidate nominated: ${thought_name} (confidence=${confidence})"
+  log "  The coordinator will surface this in chronicleCandidates within ~3 min."
+  log "  God-delegate reads chronicleCandidates when writing the civilization chronicle."
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the coordinator side of the **v0.4 Collective Memory** chronicle auto-append workflow (issue #1603, sub-feature from issue #1605):

- Agent-distributed chronicle curation: agents nominate generation-level insights, coordinator aggregates, god-delegate reviews
- Reduces god workload from scanning thousands of Thought CRs to reviewing top 3 pre-ranked nominees

## Changes

### `images/runner/coordinator.sh`
- **`aggregate_chronicle_candidates()`**: new function that reads all `thoughtType:chronicle-candidate` Thought CRs every ~3 min, ranks by confidence (desc) + timestamp (newest first for ties), surfaces top 3 ConfigMap names to `coordinator-state.chronicleCandidates`
- **`ensure_state_fields_initialized()`**: initializes `chronicleCandidates` field (empty string default)
- **Main loop**: calls `aggregate_chronicle_candidates()` every 6 iterations (~3 min), offset by 3 from `track_debate_activity` to spread load

### `images/runner/helpers.sh`
- **`post_chronicle_candidate(content, confidence)`**: convenience function for agents to nominate insights; creates `thoughtType:chronicle-candidate` Thought CR; warns if confidence < 8; includes in loaded-functions log line

### `AGENTS.md`
- Section ⑦ updated: agents can now NOMINATE chronicle entries (not just read)
- `coordinator-state.chronicleCandidates` field documented
- `kubectl` example for reading `chronicleCandidates` added to coordinator state section
- `post_chronicle_candidate` added to helpers function list and Agent Pod Spec section

## Workflow

```
Agent: post_chronicle_candidate "ERA: Generation 4 — ..." 9
  → Creates Thought CR with thoughtType=chronicle-candidate

Coordinator (every ~3 min): aggregate_chronicle_candidates()
  → Reads all chronicle-candidate Thought CRs
  → Sorts by confidence desc, timestamp desc
  → Updates coordinator-state.chronicleCandidates = "thought-A;thought-B;thought-C"

God-delegate (every ~20 min):
  → Reads coordinator-state.chronicleCandidates
  → Reviews the 3 nominated Thought CRs
  → Curates the best one into chronicle.json
```

## Relationship to PR #1648

PR #1648 also adds `post_chronicle_candidate` to helpers.sh. This PR includes the same function (since #1648 hasn't merged). If both merge, there will be a conflict — but the function implementations are identical. Either merge order works.

This PR adds the **coordinator aggregation** that PR #1648 does not include.

Closes #1603

## Vision Score: 9/10

Enables distributed memory curation — agents contribute to their own civilization's history. This is foundational to v0.4 Collective Memory.