### PR TITLE
fix: add bidirectional CI check — AGENTS.md Provides functions must exist in helpers.sh (closes #1670)

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -47,3 +47,40 @@ jobs:
 
           echo "All public helpers.sh functions are documented in AGENTS.md"
           echo "Functions checked: $(echo "$functions" | wc -w)"
+
+      - name: Check AGENTS.md Provides section matches helpers.sh implementations
+        run: |
+          echo "Extracting function names from AGENTS.md 'Provides:' section..."
+
+          # Extract function names from the Provides: line(s) in the Agent Pod Spec section
+          # The Provides: section lists functions as: func1(), func2(), func3()
+          # We extract from the range "Provides:" through the closing ``` of that code block.
+          provides_functions=$(sed -n '/Provides:/,/```/p' AGENTS.md | \
+            grep -oE '[a-zA-Z][a-zA-Z0-9_]*\(\)' | \
+            sed 's/()//' | \
+            grep -v '^$' | \
+            sort -u)
+
+          echo "Functions claimed in AGENTS.md Provides section:"
+          echo "$provides_functions"
+          echo ""
+
+          missing_impl=""
+          for fn in $provides_functions; do
+            # Check if function is implemented in helpers.sh
+            if ! grep -qE "^${fn}\(\)|^function ${fn}" images/runner/helpers.sh; then
+              missing_impl="$missing_impl\n  - $fn"
+            fi
+          done
+
+          if [ -n "$missing_impl" ]; then
+            echo "ERROR: AGENTS.md Provides section lists functions NOT implemented in helpers.sh:"
+            printf "%b\n" "$missing_impl"
+            echo ""
+            echo "Either add the function to helpers.sh or remove it from the Provides section in AGENTS.md."
+            echo "This bidirectional check prevents documentation claiming non-existent functions (issue #1670)."
+            exit 1
+          fi
+
+          echo "All AGENTS.md Provides functions are implemented in helpers.sh"
+          echo "Functions checked: $(echo "$provides_functions" | wc -w)"


### PR DESCRIPTION
## Summary

Adds a bidirectional CI check to prevent documentation-implementation gaps like issue #1646.

## Problem

The existing `lint-agents-md.yml` workflow only validates **one direction**: functions in `helpers.sh` must be documented in `AGENTS.md`. It does NOT validate the reverse: functions that `AGENTS.md` claims are available via `helpers.sh` must actually be implemented there.

This one-directional check allowed issue #1646 to occur: a PR documented `post_chronicle_candidate()` in AGENTS.md's Provides section but omitted the function from `helpers.sh`. CI passed despite agents being misled about available functions.

## Changes

- Adds a new step "Check AGENTS.md Provides section matches helpers.sh implementations" to `lint-agents-md.yml`
- Extracts function names from AGENTS.md's `Provides:` section using `sed` + `grep`
- Verifies each claimed function exists as an implementation in `helpers.sh`
- CI fails with a clear error message if any claimed function is missing

## Validation

Tested locally:
- Current state: all 16 functions in the Provides section are implemented → passes ✓
- With simulated `post_chronicle_candidate()` added to Provides but not helpers.sh → correctly fails ✓

Closes #1670

Co-authored-by: agentex-bot <agentex@pnz1990.bot>