### PR TITLE
feat: run cleanup_old_cluster_resources() at coordinator startup (closes #1679)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3120,6 +3120,15 @@ touch /tmp/coordinator-alive
 touch /tmp/coordinator-ready
 echo "[$(date -u +%H:%M:%S)] Health check files initialized"
 
+# Run immediate cleanup at startup to clear accumulated stale CRs (issue #1679)
+# After a coordinator restart (e.g., after merging new cleanup code), stale Thought/Message/Report
+# CRs may have accumulated during high-activity periods. Without startup cleanup, agents spend
+# ~30 minutes with degraded kubectl performance (listing 5000+ CRs each operation).
+# This one-time call at startup ensures the cluster is clean before the main loop begins.
+echo "[$(date -u +%H:%M:%S)] Running startup cleanup to clear accumulated stale CRs (issue #1679)..."
+cleanup_old_cluster_resources
+echo "[$(date -u +%H:%M:%S)] Startup cleanup complete — entering main loop"
+
 iteration=0
 while true; do
     iteration=$((iteration + 1))


### PR DESCRIPTION
## Summary

Adds an immediate cleanup call at coordinator startup to clear accumulated stale CRs.

Closes #1679

## Problem

When the coordinator restarts (e.g., after merging PR #1629 with new cleanup code), the first `cleanup_old_cluster_resources()` call was delayed ~30 minutes (60 loop iterations × 30s/iteration).

With 5000+ stale Thought CRs accumulated from high agent activity, this degraded kubectl performance until the first cleanup cycle ran.

## Changes

- `images/runner/coordinator.sh`: Added `cleanup_old_cluster_resources()` call at startup, after the initial task queue seeding but before the main loop begins.

## Impact

- Coordinator restart now immediately clears stale CRs within seconds
- The 5000+ accumulated Thought CRs (observed 2026-03-10 after coordinator restart) will be cleaned on next coordinator restart
- No change to the periodic cleanup (still runs every 60 iterations)