### PR TITLE
feat: add post_chronicle_candidate() to helpers.sh and coordinator aggregation (closes #1646)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -683,6 +683,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+- `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1086,6 +1087,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
  - `preClaimTimestamps`: Semicolon-separated `agent:issue:epoch_seconds` entries tracking when issues were claimed, written by both `route_tasks_by_specialization()` (coordinator pre-claims, issue #1546) and `claim_task()` (worker self-claims, issue #1593). `cleanup_stale_assignments()` reads this to protect any claim within a 120s grace window from being pruned before the worker's Job starts — preventing the race where a claim is made but the cleanup loop removes the assignment before the worker pod launches (kro + EKS latency can take 60-120s).
 - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+- `chronicleCandidates`: Semicolon-separated Thought ConfigMap names for agent-proposed chronicle entries (issue #1605, v0.4 Collective Memory). Aggregated by `aggregate_chronicle_candidates()` inside `track_debate_activity()` every ~3 min. Holds top 3 `chronicle-candidate` Thought CRs sorted by confidence (agents use `post_chronicle_candidate()` with confidence=9). God-delegate reads this field when writing the next chronicle entry for efficient curation without reviewing all Thought CRs.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1103,6 +1105,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateSta
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**
@@ -1235,11 +1238,11 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
    - aws CLI (Bedrock via Pod Identity — no credentials needed)
    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
-     Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-               query_debate_outcomes_by_component(), claim_task(), civilization_status(),
-               write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-               propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-               cleanup_old_reports()
+      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+                query_debate_outcomes_by_component(), claim_task(), civilization_status(),
+                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
+                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                cleanup_old_reports(), post_chronicle_candidate()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -343,13 +343,22 @@ ensure_state_fields_initialized() {
   fi
 
   # routingCyclesWithZeroSpec (issue #1568): counter tracking consecutive routing cycles where
-  # specializedAssignments=0. When it reaches 5, coordinator escalates with a blocker thought
-  # AND files a GitHub issue to ensure the regression is visible and self-reported.
-  # Reset to 0 when specializedAssignments increments (routing is working).
+   # specializedAssignments=0. When it reaches 5, coordinator escalates with a blocker thought
+   # AND files a GitHub issue to ensure the regression is visible and self-reported.
+   # Reset to 0 when specializedAssignments increments (routing is working).
   if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("routingCyclesWithZeroSpec")' >/dev/null 2>&1; then
     [ "$silent" = "false" ] && echo "  Initializing routingCyclesWithZeroSpec (was absent)"
     kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
       -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
+  fi
+
+  # chronicleCandidates (issue #1605): semicolon-separated Thought ConfigMap names for
+  # agent-proposed chronicle entries. Aggregated by aggregate_chronicle_candidates() every
+  # ~3 min (inside track_debate_activity). God-delegate reads this when writing the chronicle.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("chronicleCandidates")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing chronicleCandidates (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
   fi
 
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
@@ -2242,6 +2251,55 @@ EOF
     echo "[$(date -u +%H:%M:%S)] Synthesis debate S3 sync: $writes_this_cycle new writes, $skipped_existing already-persisted skipped, 1 prefix LIST call (${synth_count} total synthesis debates)"
 }
 
+# ── aggregate_chronicle_candidates (issue #1605) ──────────────────────────────
+#
+# Aggregate Thought CRs with thoughtType=chronicle-candidate and surface the
+# top 3 (by confidence score) in coordinator-state.chronicleCandidates.
+#
+# The god-delegate reads chronicleCandidates when writing the next chronicle entry,
+# making human curation faster while preserving quality control.
+#
+# v0.4 Collective Memory: agents propose their own insights for the civilization
+# chronicle rather than relying solely on god to curate everything.
+#
+# Implementation:
+#   1. Read all Thought CRs with thoughtType=chronicle-candidate
+#   2. Sort by confidence (highest first), tie-break by recency
+#   3. Take top 3 ConfigMap names
+#   4. Patch coordinator-state.chronicleCandidates (semicolon-separated names)
+aggregate_chronicle_candidates() {
+    # Fetch chronicle-candidate thoughts using label selector to avoid OOM
+    local candidates_json
+    candidates_json=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+        -l agentex/thought -o json 2>/dev/null | \
+        jq '[.items[] | select(.data.thoughtType == "chronicle-candidate") | {
+            name: .metadata.name,
+            confidence: ((.data.confidence // "7") | tonumber),
+            agent: (.data.agentRef // ""),
+            content: ((.data.content // "") | .[0:200]),
+            createdAt: .metadata.creationTimestamp
+        }] | sort_by(-.confidence, .createdAt) | .[0:3]' 2>/dev/null || echo "[]")
+
+    if [ -z "$candidates_json" ] || [ "$candidates_json" = "[]" ] || [ "$candidates_json" = "null" ]; then
+        # No candidates found — keep existing chronicleCandidates field as-is
+        return 0
+    fi
+
+    # Extract top candidate names (semicolon-separated)
+    local top_candidates
+    top_candidates=$(echo "$candidates_json" | jq -r '.[].name' 2>/dev/null | tr '\n' ';' | sed 's/;$//')
+
+    if [ -z "$top_candidates" ]; then
+        return 0
+    fi
+
+    local candidate_count
+    candidate_count=$(echo "$candidates_json" | jq 'length' 2>/dev/null || echo "0")
+
+    echo "[$(date -u +%H:%M:%S)] Chronicle candidates: $candidate_count found, top 3 surfaced in chronicleCandidates (issue #1605)"
+    update_state "chronicleCandidates" "$top_candidates"
+}
+
 # Track debate activity — count debate threads, surface unresolved disagreements
 track_debate_activity() {
     local all_cm
@@ -2414,6 +2472,11 @@ DEBATE_EOF
         fi
     fi
     # ── End Issue #1161 ───────────────────────────────────────────────────────
+
+    # ── Issue #1605: Aggregate chronicle-candidate thoughts ──────────────────
+    # After processing debate activity, also aggregate chronicle candidates so
+    # god-delegate can find agent-proposed chronicle entries efficiently.
+    aggregate_chronicle_candidates
 
     # If there are unresolved disagreements and no synthesis attempts, post a nudge
     if [ "$disagree_count" -gt 0 ] && [ "$synthesize_count" -eq 0 ]; then

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1134,5 +1134,70 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ─────────────────────────────────────────────────
+# Post a chronicle-candidate Thought CR to propose an insight for the civilization
+# chronicle. Part of the v0.4 Collective Memory milestone (issue #1605).
+#
+# The chronicle is currently entirely god-curated, creating a bottleneck as agent
+# count grows. This function enables agents to surface high-value insights for
+# god review, distributing memory curation while maintaining quality control.
+#
+# How it works:
+#   1. Agent calls post_chronicle_candidate() with a high-value insight
+#   2. Coordinator aggregates top 3 chronicle-candidate thoughts by confidence
+#      in coordinator-state.chronicleCandidates (updated every ~3 min)
+#   3. God-delegate reads chronicleCandidates when writing the next chronicle entry
+#
+# Usage: post_chronicle_candidate <era_description> <summary> <lesson_learned> [milestone]
+#   era_description  — short tag (e.g. "Generation 4 — Debate Quality Tracking")
+#   summary          — what happened (2-3 sentences)
+#   lesson_learned   — what future agents should know from this
+#   milestone        — optional: PR/issue/feature that enabled this
+#
+# Example:
+#   post_chronicle_candidate \
+#     "Generation 4 — Debate Quality Tracking" \
+#     "Agents now track synthesis citation counts to distinguish high-signal debates." \
+#     "High-quality debates produce insights that persist in future routing decisions." \
+#     "v0.4 debate quality scoring implemented (PR #XXXX)"
+#
+# IMPORTANT: Only use for genuinely generation-level insights — milestones, paradigm
+# shifts, or hard-won lessons. Trivial observations dilute signal quality.
+# Confidence is fixed at 9 to enforce quality filtering.
+#
+# Returns: 0 on success, 1 on missing required arguments
+post_chronicle_candidate() {
+  local era="${1:-}"
+  local summary="${2:-}"
+  local lesson="${3:-}"
+  local milestone="${4:-}"
+
+  if [ -z "$era" ] || [ -z "$summary" ] || [ -z "$lesson" ]; then
+    log "ERROR: post_chronicle_candidate requires era, summary, and lesson arguments"
+    return 1
+  fi
+
+  # Chronicle candidates must have high confidence (fixed at 9) to filter noise
+  local confidence=9
+
+  local content="ERA: ${era}
+Summary: ${summary}
+Lesson: ${lesson}"
+
+  if [ -n "$milestone" ]; then
+    content="${content}
+Milestone: ${milestone}"
+  fi
+
+  content="${content}
+Proposed by: ${AGENT_NAME}"
+
+  post_thought "$content" "chronicle-candidate" "$confidence" "chronicle" "" ""
+
+  log "Posted chronicle-candidate: era='$era' (confidence=$confidence)"
+  log "  Coordinator will surface top-3 candidates in coordinator-state.chronicleCandidates"
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the missing `post_chronicle_candidate()` function in `helpers.sh` and the coordinator-side `aggregate_chronicle_candidates()` for the v0.4 Collective Memory milestone (issue #1605, #1646).

## Problem

PR #1634 (which was closed without merging) documented `post_chronicle_candidate` in AGENTS.md and added coordinator changes, but the `helpers.sh` implementation was never merged. Issue #1646 tracks this gap.

## Changes

### `images/runner/helpers.sh`
- New `post_chronicle_candidate(era, summary, lesson, [milestone])` function
- Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9 (fixed — enforces quality filter)
- Available via `source /agent/helpers.sh` in OpenCode bash context
- Updated loaded message to include `post_chronicle_candidate` in function list

### `images/runner/coordinator.sh`
- New `aggregate_chronicle_candidates()` function called inside `track_debate_activity()` every ~3 min
- Reads all `chronicle-candidate` Thought CRs, sorts by confidence (highest first), tie-broken by recency
- Patches `coordinator-state.chronicleCandidates` with top 3 ConfigMap names (semicolon-separated)
- Initializes `chronicleCandidates` state field in `ensure_state_fields_initialized()`

### `AGENTS.md`
- Documents `post_chronicle_candidate()` in the helper functions list
- Documents `chronicleCandidates` field in Coordinator State section
- Adds `chronicleCandidates` to reading coordinator state kubectl examples
- Updates helpers.sh `Provides:` list to include `post_chronicle_candidate()`

## How It Works

1. Agent discovers a generation-level insight → calls `post_chronicle_candidate(era, summary, lesson)` with confidence=9
2. Coordinator reads all `chronicle-candidate` Thought CRs every ~3 min (inside `track_debate_activity`)
3. Aggregates top 3 by confidence, writes semicolon-separated ConfigMap names to `coordinator-state.chronicleCandidates`
4. God-delegate reads `chronicleCandidates` when writing the chronicle — no manual Thought CR hunting

## Usage Example

```bash
source /agent/helpers.sh && post_chronicle_candidate \
  "Generation 4 — Collective Memory" \
  "Agents can now propose insights for the civilization chronicle via post_chronicle_candidate()." \
  "Distributed memory curation reduces the god bottleneck while maintaining quality control." \
  "v0.4 chronicle-candidate workflow operational (PR #XXXX)"
```

Closes #1646