### PR TITLE
fix: filter orphaned debate threads from unresolvedDebates (closes #1667)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2320,6 +2320,13 @@ track_debate_activity() {
             [ -z "$thread_id" ] && continue
             # Skip empty/null parentRefs
             [ "$thread_id" = "null" ] && continue
+            # Issue #1667: Skip orphaned entries where parent CM was deleted by cleanup_old_thoughts().
+            # When a parent thought is deleted, its parentRef entry in unresolvedDebates becomes stale.
+            # Filter these out to prevent unbounded accumulation of orphaned thread IDs.
+            if ! kubectl_with_timeout 5 get configmap "$thread_id" -n "$NAMESPACE" >/dev/null 2>&1; then
+                echo "[$(date -u +%H:%M:%S)] Skipping orphaned debate thread: $thread_id (parent CM deleted)"
+                continue
+            fi
             # Check if this thread has a synthesis response
             if ! echo "$resolved_threads" | grep -qF "$thread_id"; then
                 [ -n "$unresolved_threads" ] \


### PR DESCRIPTION
## Summary

Fixes accumulation of orphaned entries in `coordinator-state.unresolvedDebates` that reference deleted thought ConfigMaps.

Closes #1667

## Problem

`track_debate_activity()` in `coordinator.sh` builds `unresolvedDebates` from the `parentRef` field of debate thoughts. When `cleanup_old_thoughts()` deletes a parent thought CM, any debate thoughts that reference it survive (they're newer), but their `parentRef` value becomes orphaned in `unresolvedDebates`.

**Impact:**
- Planners waste time looking up non-existent CMs from the unresolved list  
- `unresolvedDebates` grows unboundedly — 98 entries on 2026-03-10 with 7% orphaned
- The planner guidance `kubectl get configmaps ... select(.metadata.name == "<thread_id>")` silently returns nothing for orphaned entries

## Changes

- `images/runner/coordinator.sh`: Added existence check for parent ConfigMap before adding thread to unresolved list. Orphaned entries are skipped with a log message for visibility.

## Testing

The fix adds a `kubectl_with_timeout 5 get configmap "$thread_id"` check before each thread is added to `unresolved_threads`. This catches deleted parent CMs and skips them with a log line.