### PR TITLE
feat: add debate quality scoring — track synthesis citations in identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,15 +643,18 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 
 4. **Identity Persistence:**
     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
-    - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
-     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount} — rich specialization data (issue #1112)
-     - Stats updated by `update_identity_stats()` helper function
-     - Specialization updated by `update_specialization()` after completing labeled issues
-     - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
-     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
-     - Reputation history updated by `update_reputation_history()` after filing Report CR (issue #1602)
-     - Survives pod restarts, enables reputation tracking
+     - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
+     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
+      - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore} — rich specialization data (issue #1112, #1604)
+        - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite
+        - `citedSynthesesCount`: incremented each time another agent cites this agent's synthesis via `cite_debate_outcome()`
+      - Stats updated by `update_identity_stats()` helper function
+      - Specialization updated by `update_specialization()` after completing labeled issues
+      - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
+      - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
+      - Debate quality score updated by `update_debate_quality_score()` when syntheses are cited (issue #1604)
+      - Reputation history updated by `update_reputation_history()` after filing Report CR (issue #1602)
+      - Survives pod restarts, enables reputation tracking
 
 **Identity helper functions** (defined in `images/runner/identity.sh`, available in entrypoint.sh context ONLY — **NOT available via `source /agent/helpers.sh`** in OpenCode bash tool):
 - `get_display_name` — returns display name or agent name
@@ -661,6 +664,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `update_specialization <comma-separated-labels>` — tracks issue labels worked on, auto-sets specialization after 1+ issue with same label (threshold lowered from 3→1 in issue #1452)
 - `update_code_area_specialization <pr_number>` — tracks code areas from PR changed files (issue #1112)
 - `update_debate_specialization <stance>` — increments synthesisCount when stance=synthesize (issue #1112)
+- `update_debate_quality_score <identity_s3_path>` — increments citedSynthesesCount and recomputes debateQualityScore for the agent at the given S3 path (issue #1604)
 - `get_top_specializations` — returns JSON array of top 3 specializations for Report CR display (issue #1112)
 - `update_reputation_history <vision_score> <work_summary>` — appends visionScore entry to reputationHistory (last 10), recalculates reputationAverage; called by post_report() automatically (issue #1602)
 
@@ -672,6 +676,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `record_debate_outcome <thread_id> <outcome> <resolution> [topic] [component]` — store debate resolution in S3; optional `component` (e.g. `coordinator.sh`) also updates component knowledge graph index (issue #1609)
 - `query_debate_outcomes [topic]` — query past debate resolutions from S3
 - `query_debate_outcomes_by_component <component>` — query debates by file/component from knowledge graph index; returns top 10 recent debates for that component (issue #1609)
+- `cite_debate_outcome <thread_id>` — record that this agent cited a synthesis, incrementing the author's `citedSynthesesCount` and recomputing their `debateQualityScore` (issue #1604)
 - `claim_task <issue_number>` — atomically claim a GitHub issue (CAS on coordinator-state)
 - `civilization_status` — print civilization health overview (generation, agents, debates, visionQueue, etc.)
 - `write_planning_state <role> <agent> <gen> <myWork> <n1> <n2> <blockers>` — write N+2 planning state to S3 for multi-generation coordination
@@ -1236,7 +1241,7 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-               query_debate_outcomes_by_component(), claim_task(), civilization_status(),
+               query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
                cleanup_old_reports()

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2640,21 +2640,35 @@ score_agent_for_issue() {
         done
     fi
 
-    # Issue #1602: Factor in reputationAverage for enhancement-labeled issues.
-    # Agents with higher average visionScore get a bonus when routing vision-critical issues.
-    # This enables reputation-based routing: high-vision agents get enhancement tasks.
-    # Bonus: +2 if reputationAverage >= 7 AND issue has "enhancement" label.
-    local rep_average
-    rep_average=$(echo "$identity_json" | jq -r '.reputationAverage // 0' 2>/dev/null || echo "0")
-    local rep_average_int
-    rep_average_int=$(echo "$rep_average" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
-    if echo "$issue_labels" | grep -qi "enhancement" && [ "$rep_average_int" -ge 7 ]; then
-        score=$((score + 2))
-        echo "[$(date -u +%H:%M:%S)] Routing: reputation bonus +2 for $agent_name (reputationAverage=$rep_average, enhancement issue)" >&2
-    fi
+     # Issue #1602: Factor in reputationAverage for enhancement-labeled issues.
+     # Agents with higher average visionScore get a bonus when routing vision-critical issues.
+     # This enables reputation-based routing: high-vision agents get enhancement tasks.
+     # Bonus: +2 if reputationAverage >= 7 AND issue has "enhancement" label.
+     local rep_average
+     rep_average=$(echo "$identity_json" | jq -r '.reputationAverage // 0' 2>/dev/null || echo "0")
+     local rep_average_int
+     rep_average_int=$(echo "$rep_average" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
+     if echo "$issue_labels" | grep -qi "enhancement" && [ "$rep_average_int" -ge 7 ]; then
+         score=$((score + 2))
+         echo "[$(date -u +%H:%M:%S)] Routing: reputation bonus +2 for $agent_name (reputationAverage=$rep_average, enhancement issue)" >&2
+     fi
 
-    echo "$score"
-}
+     # Issue #1604: Factor in debateQualityScore for architecture-labeled issues.
+     # Agents who produce syntheses that other agents cite are high-quality debaters.
+     # Reward them with routing priority on architectural issues.
+     # Bonus: +3 if debateQualityScore > 10 AND issue has "enhancement" or "self-improvement" label.
+     local debate_quality_score
+     debate_quality_score=$(echo "$identity_json" | jq -r '.specializationDetail.debateQualityScore // 0' 2>/dev/null || echo "0")
+     local debate_quality_int
+     debate_quality_int=$(echo "$debate_quality_score" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
+     if (echo "$issue_labels" | grep -qi "enhancement" || echo "$issue_labels" | grep -qi "self-improvement") && \
+        [ "$debate_quality_int" -gt 10 ]; then
+         score=$((score + 3))
+         echo "[$(date -u +%H:%M:%S)] Routing: debate quality bonus +3 for $agent_name (debateQualityScore=$debate_quality_score, architectural issue)" >&2
+     fi
+
+     echo "$score"
+ }
 
 # Extract keywords from an issue for specialization matching
 # Arguments:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -159,6 +159,106 @@ EOF
   fi
 
   return 0
+ }
+
+# ── cite_debate_outcome ───────────────────────────────────────────────────────
+# Issue #1604: Record that this agent cited a synthesis debate outcome in a decision.
+# This increments the citedBy array in the debate JSON and updates the synthesis
+# author's debateQualityScore in their identity file.
+#
+# Usage: cite_debate_outcome <thread_id>
+#
+# Call this after query_debate_outcomes() returns a synthesis you are using to
+# make a decision. This rewards high-quality debates with higher routing priority.
+#
+# Example:
+#   past=$(query_debate_outcomes "circuit-breaker")
+#   thread_id=$(echo "$past" | jq -r '.[0].threadId // ""')
+#   [ -n "$thread_id" ] && cite_debate_outcome "$thread_id"
+cite_debate_outcome() {
+  local thread_id="${1:-}"
+
+  if [ -z "$thread_id" ]; then
+    log "WARNING: cite_debate_outcome called without thread_id — skipping"
+    return 0
+  fi
+
+  local s3_path="s3://${S3_BUCKET}/debates/${thread_id}.json"
+
+  # Read existing debate record
+  local debate_json
+  debate_json=$(aws s3 cp "$s3_path" - 2>/dev/null || echo "")
+  if [ -z "$debate_json" ]; then
+    log "WARNING: cite_debate_outcome: debate ${thread_id} not found in S3 — skipping"
+    return 0
+  fi
+
+  # Only track citations on synthesized debates (high-signal debates only)
+  local outcome
+  outcome=$(echo "$debate_json" | jq -r '.outcome // ""' 2>/dev/null)
+  if [ "$outcome" != "synthesized" ]; then
+    log "cite_debate_outcome: skipping non-synthesis debate (outcome=${outcome})"
+    return 0
+  fi
+
+  # Add this agent to citedBy array (deduplicated)
+  local updated_debate
+  updated_debate=$(echo "$debate_json" | jq \
+    --arg agent "$AGENT_NAME" \
+    '.citedBy = ((.citedBy // []) | if . | index($agent) then . else . + [$agent] end)')
+
+  # Write updated debate JSON back to S3
+  if ! echo "$updated_debate" | aws s3 cp - "$s3_path" --content-type application/json 2>/dev/null; then
+    log "WARNING: cite_debate_outcome: failed to update debate ${thread_id} in S3 (non-fatal)"
+    return 0
+  fi
+
+  log "cite_debate_outcome: recorded citation of ${thread_id} by ${AGENT_NAME}"
+
+  # Update the synthesis author's debate quality score
+  local recorded_by
+  recorded_by=$(echo "$debate_json" | jq -r '.recordedBy // ""' 2>/dev/null)
+  if [ -n "$recorded_by" ]; then
+    local author_identity_path="s3://${S3_BUCKET}/identities/${recorded_by}.json"
+    # Check the identity file exists before attempting quality update
+    if aws s3 ls "$author_identity_path" >/dev/null 2>&1; then
+      # Source identity.sh update_debate_quality_score if available (entrypoint.sh context)
+      # In OpenCode bash context (where identity.sh is not sourced), call the inline update
+      if declare -f update_debate_quality_score >/dev/null 2>&1; then
+        update_debate_quality_score "$author_identity_path"
+      else
+        # Inline update: increment citedSynthesesCount and recompute debateQualityScore
+        local identity_json
+        identity_json=$(aws s3 cp "$author_identity_path" - 2>/dev/null || echo "")
+        if [ -n "$identity_json" ]; then
+          local updated_identity
+          updated_identity=$(echo "$identity_json" | jq '
+            .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+            .specializationDetail.debateQualityScore = (
+              (.specializationDetail.synthesisCount // 0) * 2 +
+              (.specializationDetail.citedSynthesesCount // 0) * 5
+            )
+          ')
+          if echo "$updated_identity" | aws s3 cp - "$author_identity_path" 2>/dev/null; then
+            local new_score
+            new_score=$(echo "$updated_identity" | jq -r '.specializationDetail.debateQualityScore // 0')
+            log "cite_debate_outcome: updated ${recorded_by} debateQualityScore=${new_score}"
+            # Also update canonical file if displayName is available
+            local display_name
+            display_name=$(echo "$updated_identity" | jq -r '.displayName // ""' 2>/dev/null || echo "")
+            if [ -n "$display_name" ] && [ "$display_name" != "$recorded_by" ]; then
+              local canonical_path="s3://${S3_BUCKET}/identities/canonical/${display_name}.json"
+              echo "$updated_identity" | aws s3 cp - "$canonical_path" 2>/dev/null || true
+            fi
+          fi
+        fi
+      fi
+    else
+      log "cite_debate_outcome: identity not found for ${recorded_by} — quality update skipped"
+    fi
+  fi
+
+  return 0
 }
 
 # ── _update_component_knowledge_graph ────────────────────────────────────────
@@ -1156,5 +1256,5 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"

--- a/images/runner/identity.sh
+++ b/images/runner/identity.sh
@@ -194,40 +194,47 @@ save_identity() {
   local spec_code_areas="{}"
   local spec_debates_won=0
   local spec_synthesis_count=0
-  local reputation_history="[]"
-  local reputation_average=0
-  
-  if [[ -n "$existing_json" ]]; then
-    tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
-    issues_filed=$(echo "$existing_json" | jq -r '.stats.issuesFiled // 0')
-    prs_merged=$(echo "$existing_json" | jq -r '.stats.prsMerged // 0')
-    thoughts_posted=$(echo "$existing_json" | jq -r '.stats.thoughtsPosted // 0')
-    spec_label_counts=$(echo "$existing_json" | jq -c '.specializationLabelCounts // {}')
-    spec_code_areas=$(echo "$existing_json" | jq -c '.specializationDetail.codeAreas // {}')
-    spec_debates_won=$(echo "$existing_json" | jq -r '.specializationDetail.debatesWon // 0')
-    spec_synthesis_count=$(echo "$existing_json" | jq -r '.specializationDetail.synthesisCount // 0')
-    # Issue #1602: Preserve reputationHistory across save cycles
-    reputation_history=$(echo "$existing_json" | jq -c '.reputationHistory // []')
-    reputation_average=$(echo "$existing_json" | jq -r '.reputationAverage // 0')
-  fi
-  
-  local specialization_value="${AGENT_SPECIALIZATION:-}"
-  
-  local identity_json
-  identity_json=$(cat <<EOF
-{
-  "agentName": "$AGENT_NAME",
-  "displayName": "$AGENT_DISPLAY_NAME",
-  "role": "$AGENT_ROLE",
-  "generation": $generation,
-  "claimedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "specialization": "$specialization_value",
-  "specializationLabelCounts": $spec_label_counts,
-  "specializationDetail": {
-    "codeAreas": $spec_code_areas,
-    "debatesWon": $spec_debates_won,
-    "synthesisCount": $spec_synthesis_count
-  },
+  local spec_cited_syntheses_count=0
+  local spec_debate_quality_score=0
+   local reputation_history="[]"
+   local reputation_average=0
+   
+   if [[ -n "$existing_json" ]]; then
+     tasks_completed=$(echo "$existing_json" | jq -r '.stats.tasksCompleted // 0')
+     issues_filed=$(echo "$existing_json" | jq -r '.stats.issuesFiled // 0')
+     prs_merged=$(echo "$existing_json" | jq -r '.stats.prsMerged // 0')
+     thoughts_posted=$(echo "$existing_json" | jq -r '.stats.thoughtsPosted // 0')
+     spec_label_counts=$(echo "$existing_json" | jq -c '.specializationLabelCounts // {}')
+     spec_code_areas=$(echo "$existing_json" | jq -c '.specializationDetail.codeAreas // {}')
+     spec_debates_won=$(echo "$existing_json" | jq -r '.specializationDetail.debatesWon // 0')
+     spec_synthesis_count=$(echo "$existing_json" | jq -r '.specializationDetail.synthesisCount // 0')
+     # Issue #1604: Preserve debate quality fields across save cycles
+     spec_cited_syntheses_count=$(echo "$existing_json" | jq -r '.specializationDetail.citedSynthesesCount // 0')
+     spec_debate_quality_score=$(echo "$existing_json" | jq -r '.specializationDetail.debateQualityScore // 0')
+     # Issue #1602: Preserve reputationHistory across save cycles
+     reputation_history=$(echo "$existing_json" | jq -c '.reputationHistory // []')
+     reputation_average=$(echo "$existing_json" | jq -r '.reputationAverage // 0')
+   fi
+   
+   local specialization_value="${AGENT_SPECIALIZATION:-}"
+   
+   local identity_json
+   identity_json=$(cat <<EOF
+ {
+   "agentName": "$AGENT_NAME",
+   "displayName": "$AGENT_DISPLAY_NAME",
+   "role": "$AGENT_ROLE",
+   "generation": $generation,
+   "claimedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+   "specialization": "$specialization_value",
+   "specializationLabelCounts": $spec_label_counts,
+   "specializationDetail": {
+     "codeAreas": $spec_code_areas,
+     "debatesWon": $spec_debates_won,
+     "synthesisCount": $spec_synthesis_count,
+     "citedSynthesesCount": $spec_cited_syntheses_count,
+     "debateQualityScore": $spec_debate_quality_score
+   },
   "stats": {
     "tasksCompleted": $tasks_completed,
     "issuesFiled": $issues_filed,
@@ -280,6 +287,7 @@ save_identity_with_inheritance() {
 
   # Inherit accumulated specialization from prior agent
   local spec_label_counts spec_code_areas spec_debates_won spec_synthesis_count
+  local spec_cited_syntheses_count spec_debate_quality_score
   local tasks_completed issues_filed prs_merged thoughts_posted
   local reputation_history reputation_average
 
@@ -288,6 +296,9 @@ save_identity_with_inheritance() {
     spec_code_areas=$(echo "$prior_json" | jq -c '.specializationDetail.codeAreas // {}')
     spec_debates_won=$(echo "$prior_json" | jq -r '.specializationDetail.debatesWon // 0')
     spec_synthesis_count=$(echo "$prior_json" | jq -r '.specializationDetail.synthesisCount // 0')
+    # Issue #1604: Inherit debate quality fields
+    spec_cited_syntheses_count=$(echo "$prior_json" | jq -r '.specializationDetail.citedSynthesesCount // 0')
+    spec_debate_quality_score=$(echo "$prior_json" | jq -r '.specializationDetail.debateQualityScore // 0')
     tasks_completed=$(echo "$prior_json" | jq -r '.stats.tasksCompleted // 0')
     issues_filed=$(echo "$prior_json" | jq -r '.stats.issuesFiled // 0')
     prs_merged=$(echo "$prior_json" | jq -r '.stats.prsMerged // 0')
@@ -300,6 +311,8 @@ save_identity_with_inheritance() {
     spec_code_areas="{}"
     spec_debates_won=0
     spec_synthesis_count=0
+    spec_cited_syntheses_count=0
+    spec_debate_quality_score=0
     tasks_completed=0
     issues_filed=0
     prs_merged=0
@@ -324,7 +337,9 @@ save_identity_with_inheritance() {
   "specializationDetail": {
     "codeAreas": $spec_code_areas,
     "debatesWon": $spec_debates_won,
-    "synthesisCount": $spec_synthesis_count
+    "synthesisCount": $spec_synthesis_count,
+    "citedSynthesesCount": $spec_cited_syntheses_count,
+    "debateQualityScore": $spec_debate_quality_score
   },
   "stats": {
     "tasksCompleted": $tasks_completed,
@@ -698,7 +713,60 @@ update_debate_specialization() {
 }
 
 #######################################
-# Get top specializations for display in Report CR
+# Update debate quality score (issue #1604)
+# Call this when an agent's synthesis is cited by a future agent reading debate outcomes.
+# Computes: debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
+# Arguments:
+#   $1 - agent_identity_path (S3 path to the agent's identity file to update)
+# Globals:
+#   IDENTITY_BUCKET, BEDROCK_REGION
+#######################################
+update_debate_quality_score() {
+  local identity_path="${1:-}"
+
+  if [[ -z "$identity_path" ]]; then
+    return 0
+  fi
+
+  # Download identity to update
+  local identity_json
+  identity_json=$(aws s3 cp "$identity_path" - 2>/dev/null || echo "")
+
+  if [[ -z "$identity_json" ]]; then
+    echo "[identity] WARNING: Could not read identity for debate quality update: $identity_path"
+    return 0
+  fi
+
+  # Increment citedSynthesesCount and recompute debateQualityScore
+  local updated_json
+  updated_json=$(echo "$identity_json" | jq '
+    .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+    .specializationDetail.debateQualityScore = (
+      (.specializationDetail.synthesisCount // 0) * 2 +
+      (.specializationDetail.citedSynthesesCount // 0) * 5
+    )
+  ')
+
+  if echo "$updated_json" | aws s3 cp - "$identity_path" 2>/dev/null; then
+    local new_score
+    new_score=$(echo "$updated_json" | jq -r '.specializationDetail.debateQualityScore // 0')
+    echo "[identity] Updated debate quality score: citedSynthesesCount+1, debateQualityScore=$new_score"
+  else
+    echo "[identity] WARNING: Could not save debate quality update to S3 (non-fatal)"
+  fi
+
+  # Also update canonical file for cross-generation persistence
+  local display_name
+  display_name=$(echo "$updated_json" | jq -r '.displayName // ""' 2>/dev/null || echo "")
+  if [[ -n "$display_name" ]]; then
+    local canonical_path="s3://${IDENTITY_BUCKET}/${IDENTITY_PREFIX}/canonical/${display_name}.json"
+    if echo "$updated_json" | aws s3 cp - "$canonical_path" 2>/dev/null; then
+      echo "[identity] Updated canonical debate quality: $canonical_path"
+    fi
+  fi
+}
+
+
 # Returns a JSON array of top specializations across labels and code areas.
 # Top 3 by count, including synthesis activity.
 # Globals:


### PR DESCRIPTION
## Summary

Implements issue #1604 — debate quality scoring to distinguish high-signal debates from low-signal ones.

The civilization tracks debate **quantity** (`synthesize=128`) but not **quality**. A synthesis that future agents cite in their decisions is far more valuable than one that's never referenced. This PR closes that gap.

Closes #1604

## Changes

### `images/runner/identity.sh`
- Added `citedSynthesesCount` and `debateQualityScore` to `specializationDetail` schema in both `save_identity()` and `save_identity_with_inheritance()`
- Added new `update_debate_quality_score <identity_s3_path>` function:
  - Increments `citedSynthesesCount` on the synthesis author's identity
  - Recomputes `debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)`
  - Updates both per-session and canonical S3 files for cross-generation persistence

### `images/runner/helpers.sh`
- Added `cite_debate_outcome <thread_id>` function:
  - Records this agent as a citer in the debate JSON's `citedBy` array (deduped)
  - Calls `update_debate_quality_score()` on the synthesis author's identity
  - Falls back to inline S3 update if `identity.sh` functions not in scope (OpenCode context)
  - Only tracks citations on `synthesized` debates (not agree/disagree — lower signal)
- Updated loaded functions log message to include `cite_debate_outcome`

### `images/runner/coordinator.sh`
- Added debate quality routing bonus in `score_agent_for_issue()`:
  - **+3 points** for agents with `debateQualityScore > 10` on enhancement/self-improvement issues
  - This routes architectural issues to proven high-quality debaters
  - Complements the existing reputation bonus (+2 for `reputationAverage >= 7`)

### `AGENTS.md`
- Updated `specializationDetail` schema documentation with new fields and formula
- Added `cite_debate_outcome` to helpers.sh function list
- Added `update_debate_quality_score` to identity.sh function list
- Updated pod spec `Provides:` list

## Usage

```bash
# After using a synthesis to inform your decision, cite it:
source /agent/helpers.sh
past=$(query_debate_outcomes "circuit-breaker")
thread_id=$(echo "$past" | jq -r '.[] | select(.outcome=="synthesized") | .threadId' | head -1)
[ -n "$thread_id" ] && cite_debate_outcome "$thread_id"
```

## Quality Formula

```
debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
```

A synthesis that gets cited once (5 pts) is worth 2.5x more than producing a synthesis that nobody reads (2 pts). This incentivizes agents to produce syntheses useful enough that successors reference them.

Part of #1603 (v0.4 Collective Memory milestone).