### PR TITLE
fix: skip routingCyclesWithZeroSpec increment when all queue issues are pre-claimed (closes #1675)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2777,6 +2777,13 @@ route_tasks_by_specialization() {
     local specialized_count=0
     local generic_count=0
     local routing_log=""
+    # Issue #1675: track unassigned issues seen — routing should only trigger
+    # routingCyclesWithZeroSpec escalation when there WERE unassigned issues
+    # to route (but no specialized agent was found). If all issues are already
+    # assigned, the cycle counter must NOT increment (routing "succeeded" by
+    # having nothing to do). Without this, a busy system with all tasks
+    # pre-claimed generates false-positive "v0.2 routing regression" issues.
+    local unassigned_count=0
 
     # Issue #1430: Pre-fetch issueLabels cache to avoid per-issue GitHub API calls
     # Cache format: "issue:label1,label2|issue2:label3|..."
@@ -2802,6 +2809,9 @@ route_tasks_by_specialization() {
            echo "$normalized_active_assignments" | grep -q ":${issue_num},"; then
             continue
         fi
+
+        # Count unassigned issues seen this cycle (issue #1675: needed for false-positive prevention)
+        unassigned_count=$((unassigned_count + 1))
 
         # Get issue labels for scoring — use cache first (issue #1430: rate-limit resilient)
         local issue_labels=""
@@ -2900,11 +2910,22 @@ route_tasks_by_specialization() {
     # diagnose WHY and post a blocker thought for visibility. This surfaces
     # the v0.2 success criterion ("coordinator routes at least 1 task based on
     # agent specialization") to god-observers.
+    #
+    # Issue #1675: Only count a cycle as a routing "failure" when there WERE
+    # unassigned issues available for routing. When all issues in the queue
+    # were already assigned, the cycle is a "no-op" (not a failure) and must
+    # NOT increment routingCyclesWithZeroSpec — otherwise a busy system with
+    # all tasks pre-claimed generates false-positive v0.2 regression issues.
     local total_specialized
     total_specialized=$(get_state "specializedAssignments")
     [[ "$total_specialized" =~ ^[0-9]+$ ]] || total_specialized=0
 
     if [ "$total_specialized" -eq 0 ]; then
+        # Issue #1675: skip escalation if there were no unassigned issues to route
+        if [ "$unassigned_count" -eq 0 ]; then
+            echo "[$(date -u +%H:%M:%S)] v0.2 VALIDATION: all queue issues already assigned — routing was a no-op (skipping zero-cycle increment)"
+            return 0
+        fi
         # Diagnose root cause: check active agents for specialization data
         local active_agents_list
         active_agents_list=$(get_state "activeAgents")


### PR DESCRIPTION
## Summary

Fixes a false-positive escalation in the v0.2 specialization routing validation. When all issues in the task queue are already assigned to agents, the routing cycle is a no-op (not a failure) — but the old code still incremented `routingCyclesWithZeroSpec`, eventually auto-filing misleading GitHub issues claiming v0.2 routing had regressed.

## Root Cause

In `route_tasks_by_specialization()`, the v0.2 milestone validation block checked `specializedAssignments == 0` and incremented `routingCyclesWithZeroSpec` regardless of whether there were any unassigned issues available for routing.

On a busy system where workers self-claim tasks via `claim_task()` before the coordinator's routing cycle fires, ALL issues in the queue may already be assigned. This leaves `specialized_count=0` and `generic_count=0` for the cycle, which the old code treated as a routing failure.

After 5 such cycles, the coordinator would:
1. Post a BLOCKER thought claiming "v0.2 routing regression"
2. File a GitHub issue (like #1675) with diagnosis "No active agents registered in coordinator"
3. The diagnosis was often inaccurate (agents WERE registered, just all tasks pre-claimed)

## Fix

Add `unassigned_count` to track how many issues in the queue were NOT already assigned during the routing loop. If `unassigned_count == 0` when the v0.2 validation runs, log a no-op message and return early — skipping the `routingCyclesWithZeroSpec` increment.

This only suppresses the false-positive case. If there ARE unassigned issues but no specialized routing fires, the escalation still works correctly.

## Changes

- `images/runner/coordinator.sh`: Add `unassigned_count` variable; increment after the "skip if already assigned" check; early-return from v0.2 validation when `unassigned_count=0`

## Testing

The fix is a pure logic change in coordinator.sh. It:
- Does not affect routing behavior when unassigned issues exist
- Prevents false-positive `routingCyclesWithZeroSpec` increments when all tasks are pre-claimed
- CI validates entrypoint.sh and coordinator.sh syntax

Closes #1675