### PR TITLE
perf: batch pre-fetch thought CM names for orphan detection in unresolvedDebates (closes #1667)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1197,11 +1197,18 @@ prune_orphaned_unresolved_debates() {
         -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || true)
     [ -z "$current_unresolved" ] && return 0
 
+    # Issue #1667: Pre-fetch all existing thought CM names in one batch query to avoid
+    # N individual kubectl get calls (one per unresolved entry). With 98+ entries this
+    # is a significant performance improvement over the per-entry approach.
+    local existing_thought_names
+    existing_thought_names=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+        -l agentex/thought -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
     local pruned_count=0
     local valid_entries=""
     while IFS= read -r thread_id; do
         [ -z "$thread_id" ] && continue
-        if kubectl_with_timeout 5 get configmap "$thread_id" -n "$NAMESPACE" >/dev/null 2>&1; then
+        if echo " $existing_thought_names " | grep -qF " $thread_id "; then
             [ -n "$valid_entries" ] \
                 && valid_entries="${valid_entries},${thread_id}" \
                 || valid_entries="$thread_id"
@@ -2418,15 +2425,20 @@ track_debate_activity() {
             [.[] | select(.type == "debate") | select(.content | test("synthes(is|ize)"; "i")) | .parent]
             | unique | .[]' 2>/dev/null || true)
 
+        # Issue #1667: Pre-fetch all existing thought CM names in one batch query to avoid
+        # N individual kubectl get calls (one per disagree thread) for orphan detection.
+        local existing_thought_names_tda
+        existing_thought_names_tda=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" \
+            -l agentex/thought -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
         # Build list of unresolved thread IDs (in disagree but not in resolved)
         while IFS= read -r thread_id; do
             [ -z "$thread_id" ] && continue
             # Skip empty/null parentRefs
             [ "$thread_id" = "null" ] && continue
-            # Issue #1667: Skip orphaned entries where parent CM was deleted by cleanup_old_thoughts().
-            # When a parent thought is deleted, its parentRef entry in unresolvedDebates becomes stale.
-            # Filter these out to prevent unbounded accumulation of orphaned thread IDs.
-            if ! kubectl_with_timeout 5 get configmap "$thread_id" -n "$NAMESPACE" >/dev/null 2>&1; then
+            # Issue #1667: Skip orphaned entries where the parent CM was already deleted.
+            # Uses pre-fetched batch list to avoid N individual kubectl get calls.
+            if ! echo " $existing_thought_names_tda " | grep -qF " $thread_id "; then
                 echo "[$(date -u +%H:%M:%S)] Skipping orphaned debate thread: $thread_id (parent CM deleted)"
                 continue
             fi


### PR DESCRIPTION
## Summary

Fixes #1667: coordinator-state.unresolvedDebates accumulates orphaned entries referencing deleted thought CMs.

This PR builds on the existing fix in `issue-1667-filter-orphaned-debate-threads` by replacing the N individual `kubectl get configmap` calls (one per unresolved debate thread) with a single batch `kubectl list` query using the `agentex/thought` label selector.

## Problem

When `cleanup_old_thoughts()` deletes parent thought CMs, debate thoughts that reference them via `parentRef` survive in the cluster. `track_debate_activity()` was adding these orphaned parentRefs to `coordinator-state.unresolvedDebates`, causing unbounded accumulation (98 entries, 7% orphaned observed 2026-03-10).

## Approach

The existing fix used `kubectl_with_timeout 5 get configmap "$thread_id"` per thread — O(N) API calls. With 98+ entries this is 98 individual API calls per coordinator cycle (~30 seconds).

This PR pre-fetches all existing thought CM names in **one batch list query** before the loop, then does an in-memory `grep -F` check per thread — O(1) API calls regardless of `unresolvedDebates` size.

## Changes

### `images/runner/coordinator.sh`

- `prune_orphaned_unresolved_debates()`: pre-fetch all thought CM names with one `kubectl list`, replace per-entry `kubectl get` with in-memory string match
- `track_debate_activity()`: same optimization for the inline orphan filter in the disagree thread loop

## Performance Impact

- Before: N individual `kubectl get configmap` calls per prune cycle (N = entries in unresolvedDebates, was 98)
- After: 1 batch `kubectl list` + N in-memory `grep -F` checks

Since both functions already filter with `agentex/thought` label, no regression risk from fetching the broader list.

Closes #1667