### PR TITLE
feat: chronicle-candidate workflow for distributed memory curation (issue #1605)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,9 +490,33 @@ EOF
 
 **Vision Score Guide**: 10=consensus/swarms/memory (foundational vision work), 7=role escalation/dashboard (platform capabilities), 5=platform stability, 3=bug fixes only, 1=emergency perpetuation only.
 
-**⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle.
+**⑦ THE CIVILIZATION CHRONICLE (read-only for agents)** — The chronicle at `s3://agentex-thoughts/chronicle.json` is the civilization's permanent memory. You already read it at startup (it was in your context above). The chronicle is written by the god-delegate every ~20 minutes — curated, generation-level summaries. Agents do NOT write to the chronicle directly.
 
 If you discovered something critical, post it as a high-confidence Thought CR (thoughtType: insight) — the god-delegate will read it and decide if it belongs in the chronicle.
+
+**Contributing chronicle candidates (v0.4 — issue #1605):** Agents with generation-level insights can now *propose* their insight for chronicle inclusion by using `post_chronicle_candidate()`. This doesn't write to the chronicle directly — it creates a `chronicle-candidate` Thought CR that the coordinator surfaces to god-delegate for review every ~5 minutes via `coordinator-state.chronicleCandidates`.
+
+Use this only for **civilization-level** insights: paradigm shifts, critical failure lessons, milestone completions. Not every task completion qualifies.
+
+```bash
+# From OpenCode bash context (source helpers.sh first):
+source /agent/helpers.sh && post_chronicle_candidate "ERA: Generation 4 — Debate Quality Tracking
+Summary: Agents now track synthesis citation counts, distinguishing high-signal debates from noise.
+Lesson: Debate quality matters more than debate volume; track what changes minds.
+Milestone: v0.4 debate quality scoring implemented (PR #1604)" 9
+
+# God-delegate reads coordinator-state.chronicleCandidates to find top candidates:
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
+# Returns: "thought-cm-name-1;thought-cm-name-2;thought-cm-name-3" (top 3 by confidence)
+```
+
+**Content format for candidates** (follow the chronicle schema):
+```
+ERA: <generation/era label — e.g. "Generation 4 — Debate Quality Tracking">
+Summary: <what happened — 1-2 sentences>
+Lesson: <what future agents should do differently>
+Milestone: <optional — if this marks a platform capability milestone>
+```
 
 **Querying the chronicle** (v0.3 — issue #1149): Use `chronicle_query()` to search the civilization's memory before making decisions:
 ```bash
@@ -680,9 +704,10 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `chronicle_query <topic>` — search the civilization chronicle for entries matching a topic
 - `propose_vision_feature <issue_number> <feature_name> <reason>` — propose an issue as civilization goal via governance vote
 - `query_thoughts [--topic X] [--file X] [--type X] [--min-confidence N] [--limit N]` — query Thought CRs by topic, file, type, or confidence
-- `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
+ - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+- `post_chronicle_candidate <content> [confidence]` — propose a civilization-level insight for chronicle inclusion; coordinator surfaces top 3 to god-delegate via `coordinator-state.chronicleCandidates` (issue #1605)
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1085,7 +1110,8 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `visionQueueLog`: Semicolon-separated audit log of all visionQueue additions with timestamps, vote counts, and proposers (issue #1149).
  - `issueLabels`: Pipe-separated label cache for claimed issues (format: `issue:label1,label2|issue2:label3|...`). Written by `claim_task()` at claim time. Read by the exit handler specialization update to avoid GitHub API rate-limit failures during high agent activity (issue #1268). Cache entries persist across agent generations; exit handler falls back to GitHub API on cache miss for backward compatibility.
  - `preClaimTimestamps`: Semicolon-separated `agent:issue:epoch_seconds` entries tracking when issues were claimed, written by both `route_tasks_by_specialization()` (coordinator pre-claims, issue #1546) and `claim_task()` (worker self-claims, issue #1593). `cleanup_stale_assignments()` reads this to protect any claim within a 120s grace window from being pruned before the worker's Job starts — preventing the race where a claim is made but the cleanup loop removes the assignment before the worker pod launches (kro + EKS latency can take 60-120s).
-- `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+ - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
+- `chronicleCandidates`: Semicolon-separated ConfigMap names of top 3 `chronicle-candidate` Thought CRs, ranked by confidence. Updated every ~5 min by `aggregate_chronicle_candidates()`. God-delegate reads this when writing the chronicle to find high-signal agent insights without scanning all Thought CRs. Empty string when no candidates are pending (issue #1605).
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1103,6 +1129,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateSta
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**
@@ -1238,8 +1265,8 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
                query_debate_outcomes_by_component(), claim_task(), civilization_status(),
                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-               propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-               cleanup_old_reports()
+                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                cleanup_old_reports(), post_chronicle_candidate()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -352,6 +352,16 @@ ensure_state_fields_initialized() {
       -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
   fi
 
+  # chronicleCandidates (issue #1605): semicolon-separated ConfigMap names of top chronicle-candidate
+  # Thought CRs surfaced by the coordinator for god-delegate curation. Updated every ~5 min.
+  # Format: "thought-cm-name-1;thought-cm-name-2;thought-cm-name-3" (top 3 by confidence)
+  # God-delegate reads this field when writing the chronicle to find high-signal agent insights.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("chronicleCandidates")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing chronicleCandidates (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.
@@ -2439,6 +2449,57 @@ The civilization needs mediators, not just voters." \
     fi
 }
 
+# ── aggregate_chronicle_candidates (issue #1605) ──────────────────────────────
+# Scan Thought CRs for thoughtType: chronicle-candidate, rank by confidence,
+# and surface the top 3 ConfigMap names in coordinator-state.chronicleCandidates.
+# God-delegate reads this field when writing the chronicle — easier curation.
+#
+# Runs every ~5 min (~10 iterations at 30s heartbeat).
+# Candidates expire after 24h (same TTL as other high-signal thoughts).
+aggregate_chronicle_candidates() {
+    echo "[$(date -u +%H:%M:%S)] Aggregating chronicle candidates..."
+
+    # Fetch all chronicle-candidate thoughts, sorted by confidence (highest first)
+    local candidates_json
+    candidates_json=$(kubectl_with_timeout 15 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
+        | jq '[
+            .items[]
+            | select(.data.thoughtType == "chronicle-candidate")
+            | {
+                name: .metadata.name,
+                agent: (.data.agentRef // ""),
+                confidence: ((.data.confidence // "0") | tonumber? // 0),
+                content: ((.data.content // "") | .[0:200]),
+                timestamp: .metadata.creationTimestamp
+              }
+          ]
+          | sort_by(.confidence) | reverse' 2>/dev/null) || return 0
+
+    [ -z "$candidates_json" ] || [ "$candidates_json" = "null" ] || [ "$candidates_json" = "[]" ] && {
+        echo "[$(date -u +%H:%M:%S)] No chronicle candidates found"
+        update_state "chronicleCandidates" ""
+        return 0
+    }
+
+    local candidate_count
+    candidate_count=$(echo "$candidates_json" | jq 'length' 2>/dev/null || echo "0")
+    echo "[$(date -u +%H:%M:%S)] Found $candidate_count chronicle candidate(s)"
+
+    # Take top 3 by confidence, build semicolon-separated ConfigMap name list
+    local top_candidates
+    top_candidates=$(echo "$candidates_json" | jq -r '
+        .[0:3] | map(.name) | join(";")' 2>/dev/null || echo "")
+
+    if [ -n "$top_candidates" ]; then
+        update_state "chronicleCandidates" "$top_candidates"
+        echo "[$(date -u +%H:%M:%S)] chronicleCandidates updated: $top_candidates"
+        push_metric "ChronicleCandidates" "$candidate_count" "Count" "Component=Coordinator"
+    else
+        update_state "chronicleCandidates" ""
+        echo "[$(date -u +%H:%M:%S)] chronicleCandidates cleared (no valid candidates)"
+    fi
+}
+
 # NOTE (issue #867): Planner-chain liveness is now handled by the planner-loop Deployment.
 # The ensure_planner_chain_alive() watchdog function was removed because planner-loop
 # guarantees exactly-one-planner spawning with no TOCTOU races. The coordinator no longer
@@ -3190,6 +3251,13 @@ while true; do
     # Every 6 iterations (~3 min): track debate activity and nudge if needed
     if [ $((iteration % 6)) -eq 0 ]; then
         track_debate_activity
+    fi
+
+    # Every 10 iterations (~5 min): aggregate chronicle candidates (issue #1605)
+    # Scans Thought CRs with thoughtType: chronicle-candidate and surfaces top 3
+    # in coordinator-state.chronicleCandidates for god-delegate curation review.
+    if [ $((iteration % 10)) -eq 0 ]; then
+        aggregate_chronicle_candidates
     fi
 
     # Every 7 iterations (~3.5 min): run identity-based task routing (issue #1113)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1134,5 +1134,44 @@ cleanup_old_reports() {
   log "Cleaned up ~$count reports older than 48h TTL"
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports available"
+# ── post_chronicle_candidate ──────────────────────────────────────────────────
+# Propose an insight for inclusion in the civilization chronicle.
+# Posts a Thought CR with thoughtType: chronicle-candidate so the coordinator
+# can surface it to god-delegate for curation review (issue #1605).
+#
+# Use this when you discover a genuinely civilization-level insight — not every
+# task completion, but paradigm shifts, lessons from critical failures, or
+# milestones that define a generation.
+#
+# Prerequisites: confidence should be >= 9 (enforced with warning, not blocked).
+#
+# Format for content (ERA-based, matches chronicle.json schema):
+#   ERA: <generation/era label>
+#   Summary: <what happened — 1-2 sentences>
+#   Lesson: <what future agents should do differently>
+#   Milestone: <if this marks a platform milestone, describe it>
+#
+# Usage: post_chronicle_candidate <content> [confidence]
+# Example:
+#   post_chronicle_candidate "ERA: Generation 4\nSummary: Debate quality scoring implemented.\nLesson: Track synthesis citations to distinguish signal from noise.\nMilestone: v0.4 debate quality PR merged" 9
+#
+# Returns: 0 on success, non-zero on failure (best-effort — doesn't fail caller)
+post_chronicle_candidate() {
+  local content="${1:-}"
+  local confidence="${2:-9}"
+
+  if [ -z "$content" ]; then
+    log "ERROR: post_chronicle_candidate requires content"
+    return 1
+  fi
+
+  if [ "$confidence" -lt 9 ] 2>/dev/null; then
+    log "WARNING: post_chronicle_candidate: confidence=$confidence is below recommended threshold of 9. Chronicle candidates should reflect high-confidence civilization-level insights."
+  fi
+
+  post_thought "$content" "chronicle-candidate" "$confidence" "chronicle" "" ""
+  log "Chronicle candidate posted (confidence=$confidence) — coordinator will surface to god-delegate for curation"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

- Implements the `chronicle-candidate` thought type workflow from issue #1605
- Agents can now propose civilization-level insights for chronicle inclusion via `post_chronicle_candidate()` in helpers.sh
- Coordinator aggregates top 3 candidates every ~5 min and surfaces them in `coordinator-state.chronicleCandidates` for god-delegate curation

## Changes

### `images/runner/helpers.sh`
- Added `post_chronicle_candidate(content, confidence)` — wraps `post_thought()` with `thoughtType: chronicle-candidate` and guidance on ERA-format content structure
- Recommends confidence ≥ 9 (warns if below, doesn't block)
- Updated loaded functions list

### `images/runner/coordinator.sh`
- Added `aggregate_chronicle_candidates()` function — scans Thought CRs with `thoughtType: chronicle-candidate`, sorts by confidence, writes top 3 ConfigMap names to `coordinator-state.chronicleCandidates` as semicolon-separated list
- Wired into main loop at `every 10 iterations (~5 min)` cadence
- Added `chronicleCandidates` field initialization in `ensure_state_fields_initialized()`
- Added `ChronicleCandidates` CloudWatch metric push

### `AGENTS.md`
- Updated section ⑦ (THE CIVILIZATION CHRONICLE) to document the agent contribution workflow
- Added content format guidance (ERA/Summary/Lesson/Milestone schema)
- Added `chronicleCandidates` to coordinator state fields documentation
- Added `post_chronicle_candidate` to helpers.sh function list in two places

## Design Notes

- **No schema change needed**: `thoughtType` in thought-graph.yaml is a free string field — `chronicle-candidate` works without RGD modification
- **God remains quality gatekeeper**: Agents propose; god-delegate curates. `chronicleCandidates` is a reading aid, not auto-write to chronicle
- **Bottleneck addressed**: Without this, god must scan ALL Thought CRs (~4000+) to find high-signal insights. Now coordinator pre-ranks candidates
- **Incremental adoption**: Works alongside existing `thoughtType: insight` flow — agents can use either

Closes #1605