### PR TITLE
ci: add bidirectional AGENTS.md/helpers.sh check (issue #1670)

### DIFF
--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -12,20 +12,21 @@ on:
 
 jobs:
   lint-agents-md:
-    name: Check AGENTS.md documents all helpers.sh functions
+    name: Check AGENTS.md and helpers.sh are in sync (bidirectional)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Check AGENTS.md lists all public helpers.sh functions
         run: |
+          echo "=== CHECK 1: helpers.sh functions must be documented in AGENTS.md ==="
           echo "Extracting public function names from images/runner/helpers.sh..."
 
           # Extract public function names (skip internal functions starting with _)
           # Matches lines like: function_name() { or function_name ()
           functions=$(grep -E '^[a-zA-Z][a-zA-Z0-9_]*\(\)' images/runner/helpers.sh | sed 's/().*//')
 
-          echo "Found functions:"
+          echo "Found functions in helpers.sh:"
           echo "$functions"
           echo ""
 
@@ -47,3 +48,52 @@ jobs:
 
           echo "All public helpers.sh functions are documented in AGENTS.md"
           echo "Functions checked: $(echo "$functions" | wc -w)"
+
+      - name: Check AGENTS.md Provides section matches actual helpers.sh functions
+        run: |
+          echo ""
+          echo "=== CHECK 2: AGENTS.md Provides section must match actual helpers.sh functions ==="
+          echo "Extracting functions from the helpers.sh Provides: block in AGENTS.md..."
+
+          # Extract function names from the Provides: block in the Agent Pod Spec section.
+          # The anchor 'Provides: post_thought' is specific to the helpers.sh listing —
+          # it avoids false matches from 'Provides:' in the Prime Directive section.
+          # We collect lines until the closing ``` of the code block.
+          provides_functions=$(awk '/Provides: post_thought/{found=1} found{print} /^```/{if(found){exit}}' AGENTS.md \
+            | grep -oE '[a-zA-Z][a-zA-Z0-9_]+\(\)' \
+            | sed 's/()//' \
+            | sort -u)
+
+          echo "Functions claimed in AGENTS.md Provides section:"
+          echo "$provides_functions"
+          echo ""
+
+          if [ -z "$provides_functions" ]; then
+            echo "ERROR: No functions found in AGENTS.md Provides section."
+            echo "Check that AGENTS.md still contains a line starting with:"
+            echo "  Provides: post_thought(),"
+            echo "in the Agent Pod Spec section."
+            exit 1
+          fi
+
+          # Verify each claimed function actually exists in helpers.sh
+          missing=""
+          for fn in $provides_functions; do
+            if ! grep -qE "^${fn}\(\)|^function ${fn}" images/runner/helpers.sh; then
+              missing="$missing\n  - $fn"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "ERROR: AGENTS.md claims helpers.sh provides these functions, but they are NOT implemented:"
+            printf "%b\n" "$missing"
+            echo ""
+            echo "This means AGENTS.md documents non-existent functions."
+            echo "Agents using 'source /agent/helpers.sh && <function>' will get silent failures."
+            echo "Either add the missing functions to helpers.sh or remove them from the Provides section."
+            echo "This check prevents issue #1646-style documentation/implementation gaps."
+            exit 1
+          fi
+
+          echo "All functions in AGENTS.md Provides section are implemented in helpers.sh"
+          echo "Functions verified: $(echo "$provides_functions" | wc -w)"


### PR DESCRIPTION
## Summary

Extends `lint-agents-md.yml` with a second check that prevents issue #1646-style gaps where AGENTS.md documents functions that don't exist in helpers.sh.

## Problem

The existing CI check only validates one direction: that functions in `helpers.sh` are documented in `AGENTS.md`. It does NOT check the reverse.

This allowed PR #1634 to document `post_chronicle_candidate()` in AGENTS.md while omitting the implementation from helpers.sh. Agents calling `source /agent/helpers.sh && post_chronicle_candidate` would get silent failures.

## Fix

Added **Check 2** to the CI workflow:

1. Parses the `Provides:` block from AGENTS.md's Agent Pod Spec section
2. Verifies each claimed function name is actually implemented in `helpers.sh`
3. Fails CI with a clear error listing all missing implementations

Uses a specific awk anchor (`Provides: post_thought`) to target the correct section and avoid false matches from other `Provides:` text in the Prime Directive.

## Testing

Verified locally:
- Check 1: All 18 helpers.sh functions are documented in AGENTS.md ✓
- Check 2: All 16 functions in AGENTS.md Provides section exist in helpers.sh ✓

To test that the check catches a real gap: add a function name to AGENTS.md's Provides section without implementing it in helpers.sh — CI will fail with a clear error.

## Impact

Prevents the class of bug where AGENTS.md advertises non-existent helper functions, ensuring agents can always trust the `Provides:` section as an accurate API contract.

Closes #1670