### PR TITLE
fix: reject planner claims in claim_task() and cleanup ghost planner assignments

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -863,6 +863,16 @@ cleanup_stale_assignments() {
         local issue
         issue=$(echo "${pair##*:}" | tr -d '[:space:]')
 
+        # Issue #1669: Immediately release any assignment made by a planner.
+        # Planners spawn workers for issues — they should never hold implementation claims.
+        # Ghost planner assignments block workers from claiming the same issues.
+        # Detect planner agents by name prefix (planner-* naming convention).
+        if echo "$agent_name" | grep -q "^planner"; then
+            echo "[$(date -u +%H:%M:%S)] Ghost planner: $agent_name → issue #$issue claimed by planner, releasing immediately (planners should spawn workers, not claim)"
+            stale_count=$((stale_count + 1))
+            continue
+        fi
+
         local job_active
         # Issue #1170: Suppress jq parse errors from kubectl non-JSON output.
         # Issue #1260: Root cause fix — capture kubectl output first, use empty-object fallback.

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -406,6 +406,15 @@ claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
 
+  # Issue #1669: Planners should spawn workers for issues, not claim them directly.
+  # Planner assignments become ghost entries that block workers from claiming the same issues,
+  # because planners exit after spawning workers (not after implementing the issue).
+  local calling_role="${AGENT_ROLE:-}"
+  if [ "$calling_role" = "planner" ]; then
+    log "Coordinator: planners should not claim issues — spawn a worker for issue #$issue instead (role=$calling_role)"
+    return 1
+  fi
+
   # Issue #1672: Check if an open PR already exists for this issue before claiming.
   # The coordinator's task queue refresh (refresh_task_queue) already skips issues
   # with open PRs, but agents that self-select via direct claim_task() bypass that check.


### PR DESCRIPTION
## Summary

Fixes the ghost planner assignment problem where planners claim issues via `claim_task()` and leave behind stale assignments that block workers from claiming the same issues.

Closes #1669

## Problem

Planners were calling `claim_task()` to claim issues before spawning workers. Since planners exit after spawning workers (not after implementing the issue), their assignments became ghost entries that persisted until the coordinator's cleanup loop detected no active Job. During this window, workers were blocked from claiming the same issues.

Evidence from AGENTS.md description:
- `planner-gen4-1773121713:1614` — issue closed but planner assignment persisted
- `planner-gen4-1773164569:1593` — issue closed but planner assignment persisted

## Changes

### `images/runner/helpers.sh`
- `claim_task()`: Added early return with clear error message when `AGENT_ROLE=planner`
- Planners see: "planners should not claim issues — spawn a worker instead"
- This prevents new ghost assignments from being created

### `images/runner/coordinator.sh`  
- `cleanup_stale_assignments()`: Added planner name prefix check (`planner-*`) to immediately release any existing ghost assignments
- This handles backward-compatibility: existing ghost assignments from before this fix are cleaned up within the next coordinator iteration (~30s)

## Why Two-Pronged Fix

1. **Prevention** (helpers.sh): Stops planners from creating new ghost assignments
2. **Cleanup** (coordinator.sh): Releases any existing ghost planner assignments that were created before this fix, without waiting for the 4-hour TTL

## Testing

The coordinator's `cleanup_stale_assignments()` runs every ~30s. Any existing planner assignments in `activeAssignments` will be released at the next coordinator iteration after this code deploys.