### PR TITLE
feat: dynamic component detection using any *.sh/*.yaml and PR diff (closes #1684)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,8 +294,14 @@ is injected after `MENTORSHIP_BLOCK`.
 
 **What you receive (workers only, when coordinator assigns an issue):**
 - `COMPONENT_CONTEXT_BLOCK` — past debates indexed by file/component, injected after `MENTORSHIP_BLOCK`
-- Files detected: coordinator.sh, entrypoint.sh, helpers.sh, identity.sh, planner-loop.sh, *.yaml
+- Files detected: any `*.sh`, `*.yaml`, `*.yml` file mentioned in the issue body/title (dynamic — issue #1684)
+- Also detects files from open PRs linked to the issue (PR diff-based detection — issue #1684)
 - Knowledge graph is built by `record_debate_outcome()` when `component` param is provided (issue #1609)
+
+**Detection strategy (issue #1684 — dynamic, not hardcoded):**
+1. Extract any `*.sh`, `*.yaml`, or `*.yml` file patterns from the issue title + body text
+2. If fewer than 2 files found, also query open PRs linked to the issue via GitHub API to get PR diff file list
+3. Merge results (de-duplicated, max 5 components) and query knowledge graph for each
 
 **Example COMPONENT_CONTEXT_BLOCK in prompt:**
 ```

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3361,15 +3361,49 @@ if [ "$AGENT_ROLE" = "worker" ] && [ "${COORDINATOR_ISSUE:-0}" != "0" ] && [ -n 
     local_issue_title=$(echo "$issue_api_response" | jq -r '.title // ""' 2>/dev/null || echo "")
   fi
 
-  # Extract *.sh and *.yaml file mentions from the issue content
+  # Extract *.sh and *.yaml file mentions from the issue content (issue #1684: dynamic detection)
   local_components_raw=""
   if [ -n "$local_issue_body" ] || [ -n "$local_issue_title" ]; then
     combined_text="${local_issue_title} ${local_issue_body}"
-    # Extract common agentex file names (.sh, .yaml, .yml, .json patterns)
-    # Also capture bare component names like "coordinator", "entrypoint", "helpers"
+    # Dynamic detection: match ANY *.sh, *.yaml, *.yml file mentioned in the issue body/title.
+    # This replaces the previous hardcoded list (issue #1684) so new platform files are
+    # automatically detected without maintaining a static allowlist.
     local_components_raw=$(echo "$combined_text" | \
-      grep -oE '\b(coordinator\.sh|entrypoint\.sh|helpers\.sh|identity\.sh|planner-loop\.sh|agent-graph\.yaml|task-graph\.yaml|message-graph\.yaml|thought-graph\.yaml|report-graph\.yaml|swarm-graph\.yaml|coordinator-graph\.yaml|planner-loop-graph\.yaml)\b' | \
+      grep -oE '\b[a-zA-Z0-9._-]+(\.sh|\.yaml|\.yml)\b' | \
+      grep -v '^\.' | \
       sort -u | head -5 || true)
+    log "Issue #1684: Dynamic component detection found: $(echo "$local_components_raw" | tr '\n' ' ' || echo 'none')"
+  fi
+
+  # Phase 3b (issue #1684): If issue body detection found nothing or found few files,
+  # also check any open PRs linked to this issue via GitHub API to discover actual changed files.
+  # This is the "PR diff" approach: we look at the PR's changed file list, not just the issue text.
+  if [ -z "$local_components_raw" ] || [ "$(echo "$local_components_raw" | wc -l)" -lt 2 ]; then
+    linked_pr_components=""
+    # Search for open PRs that mention this issue number (title or body contains #ISSUE)
+    linked_pr_files=$(gh api "repos/${REPO}/pulls?state=open&per_page=20" \
+      --jq ".[] | select(.body // \"\" | test(\"#${COORDINATOR_ISSUE}([^0-9]|$)\")) | .number" \
+      2>/dev/null | head -3 || echo "")
+    if [ -n "$linked_pr_files" ]; then
+      while IFS= read -r pr_num; do
+        [ -z "$pr_num" ] && continue
+        # Fetch files changed in this PR via REST API
+        pr_changed=$(gh api "repos/${REPO}/pulls/${pr_num}/files?per_page=30" \
+          --jq '.[].filename' 2>/dev/null | \
+          grep -oE '[^/]+(\.sh|\.yaml|\.yml)$' | \
+          sort -u | head -5 || echo "")
+        if [ -n "$pr_changed" ]; then
+          linked_pr_components="${linked_pr_components}
+${pr_changed}"
+          log "Issue #1684: PR #${pr_num} changed files added to component context: $(echo "$pr_changed" | tr '\n' ' ')"
+        fi
+      done <<< "$linked_pr_files"
+    fi
+    if [ -n "$linked_pr_components" ]; then
+      # Merge with issue-body detections, de-duplicate, cap at 5
+      local_components_raw=$(printf "%s\n%s" "$local_components_raw" "$linked_pr_components" | \
+        sort -u | grep -v '^$' | head -5 || true)
+    fi
   fi
 
   # Build context from knowledge graph if we found relevant components


### PR DESCRIPTION
## Summary

Improves Phase 3 of the component knowledge graph (issue #1645) by replacing the hardcoded filename list with a dynamic detection approach (issue #1684).

## Problem

PR #1647 uses a hardcoded grep pattern to extract component names:
```bash
grep -oE '\b(coordinator\.sh|entrypoint\.sh|helpers\.sh|identity\.sh|...)\b'
```

This is brittle — new platform files won't be detected until someone manually updates the list.

## Changes

### `images/runner/entrypoint.sh`
Two-phase dynamic detection (replaces hardcoded list):

**Phase 1 — Issue text extraction (dynamic):**
```bash
grep -oE '\b[a-zA-Z0-9._-]+(\.sh|\.yaml|\.yml)\b'
```
Matches ANY `.sh`, `.yaml`, or `.yml` file in the issue body/title — no allowlist needed.

**Phase 2 — Linked PR diff (new):**
When issue text detection finds fewer than 2 components, query GitHub API for open PRs that reference this issue number, then fetch the list of files changed in those PRs. This catches cases where the issue body doesn't list specific files but a PR already exists with relevant changes.

### `AGENTS.md`
- Updated component context documentation to describe the new dynamic detection strategy
- Removed reference to "known files" list

## Constitution Alignment
- ✅ Follow-up enhancement to existing governance-approved feature (Phase 3 of #1609)
- ✅ No behavioral change when no debates exist (graceful no-op)
- ✅ Reduces maintenance burden (no manual list to update)
- ✅ Better accuracy for new components

## Dependency
This PR builds on `issue-1645-component-knowledge-graph-phase3` (PR #1647). Should be merged after PR #1647 or rebased onto main once PR #1647 merges.

Closes #1684

## Vision Score: 7/10
Improves the v0.4 Collective Memory feature — agents working on new platform files will now benefit from component context without any manual updates to the detection code.