### PR TITLE
fix: decouple deployment restarts from ConfigMap update outcome (closes #1699)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -103,20 +103,31 @@ jobs:
           echo "::warning::Workaround: kubectl create configmap coordinator-script --from-file=coordinator.sh=images/runner/coordinator.sh -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -"
 
       - name: Restart coordinator deployment to pick up new image
-        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
+        if: github.ref == 'refs/heads/main'
         run: |
-          # Rolling restart — coordinator picks up new :latest image AND updated ConfigMap
-          # This ensures fixes to coordinator.sh take effect immediately after merge.
-          # The ConfigMap was already updated in the previous step. The restart forces
-          # immediate ConfigMap reload (instead of waiting 60s for kubelet propagation).
+          # Rolling restart — coordinator picks up new :latest image.
+          # Issue #1699: Decoupled from ConfigMap update success.
+          # Previously conditioned on ConfigMap update outcome==success, but since that
+          # step fails due to IAM permissions (#1682) with continue-on-error=true, the
+          # step conclusion='success' but outcome='failure', causing this step to be SKIPPED.
+          # Result: coordinator and planner-loop NEVER got restarted after merges to main,
+          # so new Docker images (helpers.sh, entrypoint.sh changes) were never deployed.
+          # Fix: always restart to pick up new Docker image regardless of ConfigMap result.
+          # If ConfigMap update succeeded: coordinator gets new image AND new script.
+          # If ConfigMap update failed: coordinator gets new image only (script stays stale
+          # until agent workaround in #1693 or manual fix in #1682).
           # (issue #1226: coordinator ran stale image missing critical bug fixes)
           kubectl rollout restart deployment/coordinator -n agentex
           kubectl rollout status deployment/coordinator -n agentex --timeout=120s
-          echo "Coordinator restarted successfully — running latest image and script"
+          echo "Coordinator restarted successfully — running latest image"
 
       - name: Restart planner-loop to pick up new image
-        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
+        if: github.ref == 'refs/heads/main'
         run: |
+          # Issue #1699: Decoupled from ConfigMap update success (same root cause as above).
+          # Planner-loop workers source helpers.sh from the Docker image. Without this restart,
+          # merged helpers.sh changes (e.g. planner claim rejection in #1691) never reach
+          # running workers — confirmed: planner-loop ran 19h without restart after 3+ merges.
           echo "Triggering planner-loop rollout to pick up updated runner image..."
           kubectl rollout restart deployment/planner-loop -n agentex
           kubectl rollout status deployment/planner-loop -n agentex --timeout=120s


### PR DESCRIPTION
## Summary

- Remove ConfigMap update success dependency from coordinator/planner-loop restart conditions
- Both Deployments now always restart on main branch push to deploy new Docker images
- Fixes a silent bug causing helpers.sh and entrypoint.sh changes to never reach running agents

Closes #1699

## Problem

`build-runner.yml` lines 106 and 118 condition rollout restarts on `steps.update-coordinator-configmap.outcome == 'success'`. The ConfigMap update step uses `continue-on-error: true` and fails due to IAM permissions (#1682). When a step fails with `continue-on-error: true`:

- `conclusion` = `'success'` (job continues, CI shows green)
- `outcome` = `'failure'` (actual result, used in `if:` expressions)

Since restart conditions check `outcome`, they evaluate to false and **both restarts are ALWAYS SKIPPED**.

**Evidence from CI runs (planner confirmed via cluster inspection):**
- Run 22919091037: ConfigMap update=`success` (conclusion), restart steps=`skipped`
- Run 22918818684: Same pattern
- Planner-loop pod age: 19h with multiple merges to main (including PR #1691 helpers.sh fix)

**Impact:** Critical fixes like PR #1691 (planner claim rejection in `claim_task()`) were merged but never deployed — the planner-loop continues running 19h+ old image with the old helpers.sh.

## Changes

```yaml
# Before (broken):
if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'

# After (fixed):  
if: github.ref == 'refs/heads/main'
```

Applied to both restart steps. Restarts are now unconditional on main branch pushes:
- **If ConfigMap update succeeded**: coordinator gets new Docker image + new script
- **If ConfigMap update failed**: coordinator gets new Docker image only (script stays stale until #1682 IAM fix or planner workaround from #1693)

Either way, all `helpers.sh`, `entrypoint.sh`, and other Docker image changes are immediately deployed after merge.