### PR TITLE
fix: decouple CI restart steps from ConfigMap update outcome (closes #1699)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -103,20 +103,27 @@ jobs:
           echo "::warning::Workaround: kubectl create configmap coordinator-script --from-file=coordinator.sh=images/runner/coordinator.sh -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -"
 
       - name: Restart coordinator deployment to pick up new image
-        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
+        if: github.ref == 'refs/heads/main'
         run: |
-          # Rolling restart — coordinator picks up new :latest image AND updated ConfigMap
-          # This ensures fixes to coordinator.sh take effect immediately after merge.
-          # The ConfigMap was already updated in the previous step. The restart forces
-          # immediate ConfigMap reload (instead of waiting 60s for kubelet propagation).
-          # (issue #1226: coordinator ran stale image missing critical bug fixes)
+          # Rolling restart — coordinator picks up new :latest image.
+          # NOTE: Decoupled from ConfigMap update success (issue #1699).
+          # The ConfigMap update step uses continue-on-error:true, so its `outcome`
+          # is 'failure' when IAM permissions are missing even if the job continues.
+          # Conditioning on outcome=='success' caused restarts to ALWAYS be skipped,
+          # meaning new Docker images (helpers.sh, entrypoint.sh changes) were never
+          # deployed to running coordinator/planner-loop containers.
+          # If ConfigMap update succeeded: coordinator gets new image AND updated script.
+          # If ConfigMap update failed: coordinator gets new image only (script stays stale
+          # until #1421 IAM fix or agent-side sync via issue #1682 kicks in).
           kubectl rollout restart deployment/coordinator -n agentex
           kubectl rollout status deployment/coordinator -n agentex --timeout=120s
-          echo "Coordinator restarted successfully — running latest image and script"
+          echo "Coordinator restarted successfully — running latest image"
 
       - name: Restart planner-loop to pick up new image
-        if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
+        if: github.ref == 'refs/heads/main'
         run: |
+          # NOTE: Decoupled from ConfigMap update success (issue #1699) — same rationale
+          # as coordinator restart above. Planner-loop must always get new runner image.
           echo "Triggering planner-loop rollout to pick up updated runner image..."
           kubectl rollout restart deployment/planner-loop -n agentex
           kubectl rollout status deployment/planner-loop -n agentex --timeout=120s


### PR DESCRIPTION
## Summary

- Remove the dependency on `steps.update-coordinator-configmap.outcome == 'success'` from coordinator and planner-loop restart steps
- Both restart steps now run on all main branch merges regardless of ConfigMap update result

## Problem

The coordinator and planner-loop restart steps were conditioned on the ConfigMap update step succeeding. Since that step uses `continue-on-error: true` (issue #1421 — IAM permissions missing), its `outcome` is `failure` even when the CI job continues. The condition evaluated to false, causing both restart steps to **always be skipped**.

**Impact:** New Docker images (helpers.sh, entrypoint.sh changes, coordinator.sh updates) were never deployed to running Deployments after merges to main. The planner-loop was observed running 19+ hours on a stale image despite multiple merges.

## Fix

Changed both restart step conditions from:
```yaml
if: github.ref == 'refs/heads/main' && steps.update-coordinator-configmap.outcome == 'success'
```
to:
```yaml
if: github.ref == 'refs/heads/main'
```

**Behavior after fix:**
- ConfigMap update succeeds: coordinator gets new image AND updated script (ideal case)
- ConfigMap update fails: coordinator gets new image only (script stays stale until issue #1421 IAM fix or agent-side sync from issue #1682)
- Either way: new Docker image changes are always deployed immediately on merge

## Testing

This is a CI workflow fix. Correctness verified by code review — the `outcome` vs `conclusion` semantics of `continue-on-error` steps are documented in GitHub Actions docs.

Closes #1699