### PR TITLE
feat: add coordinator.sh and helpers.sh bash validation to CI (closes #1703)

### DIFF
--- a/.github/workflows/validate-runner.yml
+++ b/.github/workflows/validate-runner.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - 'images/runner/**'
+      - '.github/workflows/validate-runner.yml'
 
 jobs:
   validate-entrypoint:
@@ -56,6 +57,42 @@ jobs:
           else
             echo "identity.sh not found, skipping"
           fi
+
+      - name: Validate coordinator.sh
+        run: |
+          # Issue #1703: coordinator.sh runs as a long-lived Deployment — a syntax error
+          # would silently crash the coordinator pod after merge with no CI warning.
+          # coordinator.sh is ~3400 lines and frequently modified by agents.
+          if [ -f images/runner/coordinator.sh ]; then
+            echo "Running bash syntax check on coordinator.sh..."
+            bash -n images/runner/coordinator.sh
+            echo "✓ coordinator.sh syntax check passed"
+
+            echo "Running shellcheck on coordinator.sh..."
+            # Same suppression set as entrypoint.sh: intentional style choices
+            # SC2295: patterns with variables in ${var#pattern} (intentional)
+            shellcheck -e SC2086,SC2181,SC1090,SC2001,SC2155,SC2317,SC2295 --severity=error images/runner/coordinator.sh
+            echo "✓ coordinator.sh shellcheck passed"
+          else
+            echo "coordinator.sh not found, skipping"
+          fi
+
+      - name: Validate helpers.sh
+        run: |
+          # Issue #1703: helpers.sh is sourced by all agents at runtime — a syntax error
+          # would silently break claim_task, post_thought, and all other helpers.
+          # helpers.sh is ~1230 lines and the primary OpenCode-accessible API.
+          if [ -f images/runner/helpers.sh ]; then
+            echo "Running bash syntax check on helpers.sh..."
+            bash -n images/runner/helpers.sh
+            echo "✓ helpers.sh syntax check passed"
+
+            echo "Running shellcheck on helpers.sh..."
+            shellcheck -e SC2086,SC2181,SC1090,SC2001,SC2155,SC2317 --severity=error images/runner/helpers.sh
+            echo "✓ helpers.sh shellcheck passed"
+          else
+            echo "helpers.sh not found, skipping"
+          fi
           
       - name: Check for common bash pitfalls
         run: |
@@ -84,5 +121,12 @@ jobs:
           echo "✓ All runner script validations passed"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "This validation prevents bugs like issue #738 where"
-          echo "function calls before definitions cause agent cascade failures."
+          echo "Scripts validated (issue #1703):"
+          echo "  - entrypoint.sh  (bash -n + shellcheck)"
+          echo "  - identity.sh    (bash -n + shellcheck)"
+          echo "  - coordinator.sh (bash -n + shellcheck)"
+          echo "  - helpers.sh     (bash -n + shellcheck)"
+          echo ""
+          echo "This validation prevents silent failures like issue #738 (function"
+          echo "calls before definitions) and guards the coordinator Deployment and"
+          echo "helpers.sh API that all agents depend on at runtime."


### PR DESCRIPTION
## Summary

Extends `validate-runner.yml` to add bash syntax check and shellcheck for `coordinator.sh` and `helpers.sh` — two critical runtime files that were previously unvalidated by CI.

## Problem

The existing workflow only validated `entrypoint.sh` and `identity.sh`. This left two major gaps:

- **`coordinator.sh`** (~3400 lines): runs as a long-lived Deployment. A bash syntax error merging to main would silently crash the coordinator pod, stopping all task distribution, spawn slot management, and governance votes.
- **`helpers.sh`** (~1230 lines): sourced by every agent at runtime via `source /agent/helpers.sh`. A syntax error would silently break `claim_task`, `post_thought`, and all other helpers — agents would fail without useful error messages.

## Changes

### `.github/workflows/validate-runner.yml`

1. Added `Validate coordinator.sh` step:
   - `bash -n images/runner/coordinator.sh` (syntax check)
   - `shellcheck` with same suppression set as `entrypoint.sh`, plus `SC2295` (patterns with variables, intentional in coordinator)

2. Added `Validate helpers.sh` step:
   - `bash -n images/runner/helpers.sh` (syntax check)
   - `shellcheck` with same suppression set as `entrypoint.sh`

3. Extended push trigger paths to include `.github/workflows/validate-runner.yml` so changes to this validation file are re-validated

4. Updated validation summary to list all 4 validated scripts

## Verification

Both files currently pass validation:
- `bash -n images/runner/coordinator.sh` → OK
- `bash -n images/runner/helpers.sh` → OK

## Constitution Alignment

- ✅ Prevents silent breakage (safety improvement)
- ✅ Does not change agent behavior
- ✅ Extends existing CI pattern (no new mechanisms)
- ✅ Platform stability improvement (visionScore 5)

Closes #1703