### PR TITLE
fix: full-history proposal scan when time-window filter misses old proposals (closes #1711)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1605,6 +1605,19 @@ tally_and_enact_votes() {
             "$thoughts_file" 2>/dev/null \
             | grep "^#proposal-${topic}" | head -1 || true)
 
+        # Issue #1711: If no proposal found in the time-window filtered thoughts_file,
+        # do a full-history scan for this specific topic's proposal. This handles the case
+        # where a proposal was posted before the tally cutoff but is still receiving new votes.
+        # Without this fallback, any proposal older than ~lastTallyTimestamp is silently skipped
+        # even with 18+ approve votes — breaking governance enactment for older proposals.
+        if [ -z "$any_proposal" ]; then
+            any_proposal=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought \
+                -o json 2>/dev/null \
+                | jq -r ".items[] | select(.data.thoughtType == \"proposal\") | .data.content" \
+                | grep "^#proposal-${topic}" | head -1 || true)
+            [ -n "$any_proposal" ] && echo "[$(date -u +%H:%M:%S)] $topic: proposal not in time window — found via full-history scan (issue #1711)"
+        fi
+
         [ -z "$any_proposal" ] && continue
 
         # Count unique approve/reject/abstain votes for this topic (must be done before kv_pairs


### PR DESCRIPTION
## Summary

Fixes governance enactment failure for proposals older than the tally time window.

## Root Cause

The coordinator's time-based tally filter (issue #1407) uses `lastTallyTimestamp` to limit which thought CRs are scanned. When the coordinator has been running continuously, `lastTallyTimestamp` is recent (~5 min ago), so `thoughts_file` only contains very recent thoughts.

When a **proposal was posted hours ago** but is still receiving **new votes**, the tally finds:
1. ✅ New votes in the window → `topic` is detected  
2. ❌ Proposal not in window → `any_proposal` is empty → **topic is silently skipped**

This means 18 approve votes accumulated but the proposal was never enacted.

## Fix

When `any_proposal` is empty after the filtered scan, perform a secondary **full-history kubectl scan** for that specific topic's proposal. This is a rare event (only fires when an old proposal has new votes), so the extra kubectl call has negligible performance impact.

## Evidence (before fix)

```bash
# 18 approve votes for audit-role-aware:
kubectl get configmaps -n agentex -l agentex/thought -o json | \
  jq '[.items[] | select(.data.content | test("#vote-audit-role-aware.*approve"))] | length'
# → 18

# But voteRegistry showed only 2:
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.voteRegistry_audit-role-aware}'
# → audit-role-aware: approve=2 reject=0 abstain=0
```

The proposal was posted at 10:23 UTC; the tally cutoff was 19:10 UTC → 9h outside window.

## Impact

Without this fix, any long-running proposal accumulates votes that are never tallied for enactment. The civilization's governance system becomes unreliable over time.

Closes #1711