### PR TITLE
fix: correct inverted tally cutoff logic to use broader 24h window (closes #1712)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1506,17 +1506,20 @@ tally_and_enact_votes() {
      # and ensures vote totals are complete even after coordinator restart (voteRegistry reset).
      local cutoff_24h
      cutoff_24h=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
-     if [ -n "$last_tally_ts" ] && [ -n "$cutoff_24h" ]; then
-       # Use the EARLIER of (lastTallyTimestamp - 5min buffer) and (now - 24h)
-       # The 5-min buffer handles clock skew and thoughts created just before last tally.
-       local last_tally_minus5m
-       last_tally_minus5m=$(date -u -d "${last_tally_ts} -5 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$cutoff_24h")
-       # Compare: use 24h window if lastTallyTimestamp is older than 24h
-       if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
-         tally_cutoff_ts="$cutoff_24h"
-       else
-         tally_cutoff_ts="$last_tally_minus5m"
-       fi
+      if [ -n "$last_tally_ts" ] && [ -n "$cutoff_24h" ]; then
+        # Use the EARLIER of (lastTallyTimestamp - 5min buffer) and (now - 24h)
+        # The 5-min buffer handles clock skew and thoughts created just before last tally.
+        # Using the EARLIER (broader) window ensures proposals posted hours ago are still tallied.
+        # Issue #1712: Previous code used LATER (narrower) window — inverted logic caused proposals
+        # older than ~5 min to fall out of the tally window, freezing vote counts permanently.
+        local last_tally_minus5m
+        last_tally_minus5m=$(date -u -d "${last_tally_ts} -5 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$cutoff_24h")
+        # Compare: use EARLIER of (lastTally - 5min) and (now - 24h) to get broader window
+        if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
+          tally_cutoff_ts="$last_tally_minus5m"  # lastTally - 5min is further back (broader)
+        else
+          tally_cutoff_ts="$cutoff_24h"  # 24h floor is further back (broader)
+        fi
      else
        tally_cutoff_ts="$cutoff_24h"
      fi


### PR DESCRIPTION
## Summary

Fixes #1712 — coordinator tally function had inverted comparison logic, causing proposals older than ~5 minutes to never be tallied again.

## Problem

`tally_and_enact_votes()` was supposed to use the EARLIER of `(lastTallyTimestamp - 5min)` and `(now - 24h)` as the cutoff for loading vote thoughts. But the if/else branches were swapped, effectively using the LATER (narrower) timestamp instead.

**Result:** After the coordinator has been running for any meaningful time, the effective window is just `lastTallyTimestamp - 5min`. Proposals posted hours ago fall outside this window and their vote counts freeze permanently.

**Observed impact:** The `#proposal-audit-role-aware` proposal had 18 approve vote thoughts in the cluster (posted over 8 hours) but `voteRegistry_audit-role-aware` showed only `approve=2` — frozen since the proposal aged out of the tally window.

## Fix

Swapped the if/else branches in the cutoff selection logic:

```bash
# BEFORE (buggy): if last_tally_minus5m < cutoff_24h → use cutoff_24h (narrower)
# AFTER (fixed):  if last_tally_minus5m < cutoff_24h → use last_tally_minus5m (broader)
```

Now the EARLIER (broader) timestamp is always used, ensuring all proposals/votes within the last 24 hours are consistently tallied on every cycle.

## Changes

- `images/runner/coordinator.sh`: 2-line swap of if/else branches in `tally_and_enact_votes()` + 5 lines of clarifying comments

Closes #1712