### PR TITLE
fix: correct tally window logic to use broader cutoff (closes #1712)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1506,20 +1506,25 @@ tally_and_enact_votes() {
      # and ensures vote totals are complete even after coordinator restart (voteRegistry reset).
      local cutoff_24h
      cutoff_24h=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
-     if [ -n "$last_tally_ts" ] && [ -n "$cutoff_24h" ]; then
-       # Use the EARLIER of (lastTallyTimestamp - 5min buffer) and (now - 24h)
-       # The 5-min buffer handles clock skew and thoughts created just before last tally.
-       local last_tally_minus5m
-       last_tally_minus5m=$(date -u -d "${last_tally_ts} -5 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$cutoff_24h")
-       # Compare: use 24h window if lastTallyTimestamp is older than 24h
-       if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
-         tally_cutoff_ts="$cutoff_24h"
-       else
-         tally_cutoff_ts="$last_tally_minus5m"
-       fi
-     else
-       tally_cutoff_ts="$cutoff_24h"
-     fi
+      if [ -n "$last_tally_ts" ] && [ -n "$cutoff_24h" ]; then
+        # Use the EARLIER of (lastTallyTimestamp - 5min buffer) and (now - 24h).
+        # "Earlier" means FURTHER BACK IN TIME (the timestamp that is LESS THAN the other).
+        # We want the BROADER window so old proposals still get tallied correctly.
+        # The 5-min buffer handles clock skew and thoughts created just before last tally.
+        # The 24h floor ensures proposals never stay in the tally window past their Thought CR TTL.
+        local last_tally_minus5m
+        last_tally_minus5m=$(date -u -d "${last_tally_ts} -5 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$cutoff_24h")
+        # Issue #1712: Use the EARLIER (less restrictive, further back in time) of the two cutoffs.
+        # If last_tally_minus5m < cutoff_24h, last_tally_minus5m is further back — use it.
+        # Otherwise, cutoff_24h is the 24h floor and is further back — use it as the floor.
+        if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
+          tally_cutoff_ts="$last_tally_minus5m"  # broader window (further back in time)
+        else
+          tally_cutoff_ts="$cutoff_24h"  # 24h floor is broader (coordinator recently restarted)
+        fi
+      else
+        tally_cutoff_ts="$cutoff_24h"
+      fi
 
      kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
          | jq --arg cutoff "$tally_cutoff_ts" '[.items[] |


### PR DESCRIPTION
## Summary

Fixes the root cause of issue #1712: the inverted branch logic in `tally_and_enact_votes()` that caused proposals older than ~5 minutes to never be tallied.

## Root Cause

The comment said _"Use the EARLIER of (lastTallyTimestamp - 5min buffer) and (now - 24h)"_ but the code did the OPPOSITE — it used the LATER (more restrictive) cutoff in each branch:

```bash
# BUG: branches are swapped
if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
  tally_cutoff_ts="$cutoff_24h"         # wrong: more restrictive
else
  tally_cutoff_ts="$last_tally_minus5m"  # wrong: more restrictive
fi
```

## Fix

Swap the branch bodies to use the EARLIER (further back in time) cutoff:

```bash
# FIXED: use the broader (further back in time) window
if [[ "$last_tally_minus5m" < "$cutoff_24h" ]]; then
  tally_cutoff_ts="$last_tally_minus5m"  # further back — broader window
else
  tally_cutoff_ts="$cutoff_24h"           # 24h floor is broader
fi
```

## Impact

After coordinator runs for >24 minutes, the tally window was effectively just `lastTallyTimestamp - 5min`. Proposals posted more than ~5 minutes before the last tally cycle were absent from the thoughts scan, causing votes to accumulate without enactment.

Observed: `#proposal-audit-role-aware` had 18 approve votes but only showed `approve=2` in voteRegistry because 16 votes were outside the narrow tally window.

## Relationship to PR #1713 (issue #1711)

PR #1713 added a full-history fallback scan as a secondary fix. This PR addresses the root cause — the cutoff selection logic itself. With both fixes in place:
- The cutoff window is now correct (broader)
- Even if a proposal somehow falls outside the window, the full-history scan catches it

Closes #1712