### PR TITLE
fix: prevent false-positive routing escalation during system startup

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3156,8 +3156,17 @@ route_tasks_by_specialization() {
         done
 
         local blocker_reason
+        # Issue #1716: Skip escalation when agents_checked=0 (transient startup condition).
+        # When no agents have registered yet, this is NOT a routing failure — it's normal
+        # system startup. Incrementing zero_cycles for this case causes false-positive
+        # escalations and issue filing during cold starts. Only count cycles where agents
+        # exist but routing still fails (agents_with_spec=0 or low match scores).
         if [ "$agents_checked" -eq 0 ]; then
             blocker_reason="No active agents registered in coordinator. Routing cannot fire."
+            echo "[$(date -u +%H:%M:%S)] v0.2 VALIDATION: specializedAssignments=0 — $blocker_reason (TRANSIENT — not incrementing zero_cycles counter)"
+            push_metric "V02RoutingBlocker" 1 "Count" "Component=Coordinator" "Reason=no-agents"
+            # Skip counter increment and escalation — this is a normal startup condition
+            return 0
         elif [ "$agents_with_spec" -eq 0 ]; then
             blocker_reason="No active agent has specializationLabelCounts data. Workers must complete at least 1 labeled issue to build specialization. Current agents: $agents_checked checked, 0 with spec data."
         else
@@ -3170,6 +3179,7 @@ route_tasks_by_specialization() {
         # Issue #1568: Track consecutive routing cycles with zero specialization.
         # Increment counter; escalate with blocker thought + GitHub issue after 5 cycles.
         # This ensures routing regressions are self-reported within ~35 minutes.
+        # Issue #1716: Counter only increments when agents exist but routing still fails.
         local zero_cycles
         zero_cycles=$(get_state "routingCyclesWithZeroSpec")
         [[ "$zero_cycles" =~ ^[0-9]+$ ]] || zero_cycles=0


### PR DESCRIPTION
## Summary

Fixes #1716 — coordinator files escalation issues when `agents_checked=0`, but this is a transient startup condition, not a routing failure.

## Problem

`route_tasks_by_specialization()` in coordinator.sh increments the `routingCyclesWithZeroSpec` counter even when NO agents have registered yet (agents_checked=0). After 5 consecutive cycles (~35 minutes during a cold start or low-activity period), this triggers automatic issue filing for "v0.2 routing regression" — a false positive.

The issue description says "No active agents registered in coordinator. Routing cannot fire." This is expected during system startup when workers are still spawning, not a routing failure requiring escalation.

## Root Cause

Lines 3159-3177 in coordinator.sh:
- Check if `agents_checked=0`
- Increment `zero_cycles` counter regardless
- File GitHub issue after 5 cycles

This treats a **transient startup condition** as a **permanent routing failure**.

## Fix

Skip counter increment and return early when `agents_checked=0`. Only count cycles where:
- Agents exist but have no specialization data (`agents_with_spec=0`), OR
- Agents have spec data but routing still fails (low match scores)

This preserves the escalation mechanism for true routing regressions while eliminating false positives during normal system startup.

## Changes

- **coordinator.sh lines 3158-3178**: Add early return when `agents_checked=0`
- Add comment explaining why this is a transient condition
- Add distinct metric tag `Reason=no-agents` for observability

## Impact

- ✅ Eliminates spurious "v0.2 regression" issues during coordinator startup
- ✅ Eliminates spurious issues during low-activity periods (all workers idle)
- ✅ Preserves escalation when agents exist but routing genuinely fails
- ✅ Reduces GitHub issue noise and coordinator state churn

## Testing

Verified that:
1. Current coordinator state shows `specializedAssignments=3` and `routingCyclesWithZeroSpec=0` (the issue auto-resolved as agents registered)
2. The issue was filed 2 minutes ago when coordinator was starting up
3. With this fix, the coordinator would have skipped incrementing the counter during those early cycles

Closes #1716