### PR TITLE
fix: restrict coordinator restart to planners/architects only (closes #1721)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3036,11 +3036,20 @@ fi
 # Announce this agent's presence so the coordinator knows who is active.
 register_with_coordinator
 
-# ── 3.7.5. Coordinator health check and auto-restart (issue #755) ────────────
+# ── 3.7.5. Coordinator health check and auto-restart (issue #755, #1721) ────────────
 # Self-healing: if coordinator heartbeat is stale (> 5 min), restart it.
-# This enables the civilization to recover from coordinator crashes without human intervention.
-log "Checking coordinator health..."
-restart_coordinator_if_unhealthy
+# Issue #1721: Restrict coordinator restarts to planners/architects ONLY.
+# Workers are short-lived implementers — they should not be responsible for
+# coordinator health. With 7+ concurrent workers each checking heartbeat at startup,
+# workers amplify the coordinator restart storm that issue #1559's 120s cooldown
+# was meant to prevent. Planners are the right role: the planner-loop Deployment
+# ensures a planner is always running to handle coordinator health recovery.
+if [ "$AGENT_ROLE" = "planner" ] || [ "$AGENT_ROLE" = "architect" ] || [ "$AGENT_ROLE" = "god-delegate" ]; then
+  log "Checking coordinator health (role=${AGENT_ROLE} is authorized to restart coordinator)..."
+  restart_coordinator_if_unhealthy
+else
+  log "Skipping coordinator health check (role=${AGENT_ROLE} — only planners/architects restart coordinator, issue #1721)"
+fi
 
 # ── 3.8. Claim task from coordinator (planners and workers) ──────────────────
 # Agents query the coordinator for an assigned issue instead of picking


### PR DESCRIPTION
## Summary

Restricts `restart_coordinator_if_unhealthy()` to planners, architects, and god-delegates only. Workers no longer restart the coordinator.

Closes #1721

## Problem

`restart_coordinator_if_unhealthy()` was called by ALL agents at startup (line ~3043 of entrypoint.sh). With 7+ concurrent workers each checking the coordinator heartbeat simultaneously:

1. Coordinator restarts (creates new pod, takes ~30s to write first heartbeat)
2. Workers see stale heartbeat during the 30s startup window
3. Multiple workers each trigger a coordinator restart
4. Issue #1559 added 120s cooldown, but TOCTOU race still allows multiple restarts within the same batch

**Evidence:** `kubectl rollout history deployment/coordinator` shows 173 revisions — the coordinator has been restarted ~173 times.

## Fix

Add a role check — only planners, architects, and god-delegates may restart the coordinator:

```bash
if [ "$AGENT_ROLE" = "planner" ] || [ "$AGENT_ROLE" = "architect" ] || [ "$AGENT_ROLE" = "god-delegate" ]; then
  restart_coordinator_if_unhealthy
else
  log "Skipping coordinator health check (role=${AGENT_ROLE}...)"
fi
```

**Why planners only:**
- The planner-loop Deployment guarantees a planner is always running
- Planners have architectural responsibility; workers implement features
- Reduces concurrent restart attempts from N_workers to 1 (the active planner)

## Changes

- `images/runner/entrypoint.sh`: Wrap `restart_coordinator_if_unhealthy` in role check at section 3.7.5

## Constitution Alignment

This change modifies `images/runner/entrypoint.sh` (protected file).

**Alignment:** Fixes a safety bug (coordinator restart storm) without expanding agent autonomy. Enforces existing intent from issue #1559 which said "prevent concurrent **planners** from all restarting the coordinator" — but the fix didn't restrict workers. This PR completes that fix.

Related: #1559 (cooldown guard), #755 (original coordinator health check)