### PR TITLE
fix: use SI_SCORE as visionScore in Report CR instead of hardcoded 8 (closes #1725)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4013,7 +4013,9 @@ if [ "$OPENCODE_EXIT" -eq 0 ]; then
   patch_task_status "Done" "Completed successfully"
   post_message "broadcast" "Done: $TASK_TITLE (agent=$AGENT_NAME)" "status"
   post_thought "Task finished. Successor should be spawned." "observation" 9
-  post_report 8 "$TASK_TITLE completed successfully" "" "" "" "" 0
+  # Issue #1725: post_report() for SUCCESS is deferred to AFTER section 11.2 (self-improvement audit)
+  # so that visionScore reflects the actual SI_SCORE computed from debate, synthesis, vision-issues,
+  # and N+2 coordination — not a hardcoded "8". Failure case below is still immediate (no audit needed).
 else
   log "OpenCode exited with code $OPENCODE_EXIT"
   patch_task_status "Done" "exit=$OPENCODE_EXIT"
@@ -4138,6 +4140,37 @@ if [ "$PRS_OPENED" -gt 0 ] && [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_id
 fi
 
 log "Self-improvement audit complete: score=$SI_SCORE/10 (debate=$DEBATE_RESPONSES synthesis-persisted=$SYNTHESIS_PERSISTED_FLAG vision-issues=$VISION_ISSUES n2=$N2_COORDINATION)"
+
+# Issue #1725: File Report CR for successful runs HERE (after SI_SCORE is computed).
+# This ensures visionScore in the Report reflects actual vision-aligned behavior:
+#   - debate participation (+3), synthesis to S3 (+3), vision issues (+3), N+2 (+1)
+# Previously, post_report was called in section 11 with hardcoded score=8 before SI_SCORE existed.
+# The failure path (section 11 above) still calls post_report immediately with score=3
+# since the audit doesn't run for failed agents.
+if [ "$OPENCODE_EXIT" -eq 0 ]; then
+  # Build work done summary from audit data
+  REPORT_WORK_DONE="$TASK_TITLE completed. Audit: $SI_DETAILS"
+  # Build issues/PRs string for the report
+  # COORDINATOR_ISSUE is available here (set at line 3050 before OpenCode runs)
+  # WORKED_ISSUE is not computed yet (section 11.4) — use COORDINATOR_ISSUE as fallback
+  REPORT_ISSUE_NUM="${COORDINATOR_ISSUE:-0}"
+  REPORT_ISSUES=""
+  if [ "$ISSUES_CREATED" -gt 0 ] && [ "$REPORT_ISSUE_NUM" != "0" ] && [ -n "$REPORT_ISSUE_NUM" ]; then
+    REPORT_ISSUES="#${REPORT_ISSUE_NUM}"
+  elif [ "$ISSUES_CREATED" -gt 0 ]; then
+    REPORT_ISSUES="${ISSUES_CREATED} issue(s) filed"
+  fi
+  REPORT_PR=""
+  if [ "$PRS_OPENED" -gt 0 ]; then
+    # Get the PR number(s) opened this session for reporting
+    REPORT_PR=$(gh pr list --repo "$REPO" --state all --author "@me" --limit 10 \
+      --json number,createdAt \
+      | jq -r --arg start "$AGENT_START_ISO" \
+        '[.[] | select(.createdAt >= $start)] | .[].number' 2>/dev/null | \
+        head -3 | sed 's/^/PR #/' | tr '\n' ' ' | sed 's/ $//' || echo "")
+  fi
+  post_report "$SI_SCORE" "$REPORT_WORK_DONE" "$REPORT_ISSUES" "$REPORT_PR" "" "" 0
+fi
 
 # ── 11.3. CI WAIT — wait for CI on PRs opened this session ───────────────────
 # The agent who opened a PR has the most context to fix a CI failure.


### PR DESCRIPTION
## Summary

- `post_report()` was called in section 11 with a hardcoded `visionScore=8` (success) or `3` (failure), BEFORE the self-improvement audit (section 11.2) computed `SI_SCORE`
- Every Report CR ever filed had `visionScore: 8` regardless of actual vision-aligned behavior
- Fix: defer the success `post_report()` call to AFTER section 11.2 where `SI_SCORE` is computed

Closes #1725

## Problem

```bash
# section 11 (line ~4016):
post_report 8 "$TASK_TITLE completed..."  # hardcoded 8 ← BUG

# section 11.2 (line ~4092) — runs AFTER section 11:
SI_SCORE=0
if [ "$DEBATE_RESPONSES" -gt 0 ]; then SI_SCORE=$((SI_SCORE + 3)); fi   # +3 debate
if [ "$SYNTHESIS_PERSISTED_FLAG" -eq 1 ]; then SI_SCORE=$((SI_SCORE + 3)); fi  # +3 synthesis
if [ "$VISION_ISSUES" -gt 0 ]; then SI_SCORE=$((SI_SCORE + 3)); fi  # +3 vision issues
if [ "$N2_COORDINATION" -eq 1 ]; then SI_SCORE=$((SI_SCORE + 1)); fi  # +1 N+2
# SI_SCORE never reaches post_report ← BUG
```

## Fix

1. Remove `post_report 8` from section 11 success block (replaced with a comment explaining deferral)
2. Keep `post_report 3` in section 11 failure block (audit doesn't run for failures)
3. Add new `post_report "$SI_SCORE"` call AFTER section 11.2, with actual audit data in workDone

## Impact

- Report CRs now have accurate `visionScore` (0-10) reflecting debate, synthesis, vision-issues, N+2
- god-observer sees real civilization health metrics instead of constant 8
- Reputation tracking (`reputationHistory`) stores actual computed scores
- Specialization routing bonus for high-vision agents (`reputationAverage >= 7`) is now meaningful

## Files Changed

`images/runner/entrypoint.sh` — sections 11 and 11.2