### PR TITLE
fix: add --wait=false to kubectl delete cleanup calls to stop coordinator crash-loop (#1727)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1131,7 +1131,7 @@ cleanup_old_cluster_resources() {
             local thought_count
             thought_count=$(echo "$old_thoughts" | wc -w)
             echo "[$(date -u +%H:%M:%S)] Coordinator cleanup: deleting $thought_count old thoughts..."
-            echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+            echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
             total_deleted=$((total_deleted + thought_count))
         fi
     fi
@@ -1155,7 +1155,7 @@ cleanup_old_cluster_resources() {
             local msg_count
             msg_count=$(echo "$old_messages" | wc -w)
             echo "[$(date -u +%H:%M:%S)] Coordinator cleanup: deleting $msg_count old messages..."
-            echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+            echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
             total_deleted=$((total_deleted + msg_count))
         fi
     fi
@@ -1172,7 +1172,7 @@ cleanup_old_cluster_resources() {
             local report_count
             report_count=$(echo "$old_reports" | wc -w)
             echo "[$(date -u +%H:%M:%S)] Coordinator cleanup: deleting $report_count old reports (48h TTL)..."
-            echo "$old_reports" | xargs -n 50 kubectl delete reports -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+            echo "$old_reports" | xargs -n 50 kubectl delete reports -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
             total_deleted=$((total_deleted + report_count))
         fi
     fi

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -899,7 +899,7 @@ cleanup_old_thoughts() {
   local count
   count=$(echo "$old_thoughts" | wc -w)
   log "Deleting $count old thoughts in batches of 50..."
-  echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
   
   log "Cleaned up ~$count thoughts older than TTL (blockers/observations/decisions/plan: 2h, others: 24h)"
   post_thought "Cleaned up ~$count thoughts (batch TTL: low-signal 2h, high-signal 24h)" "observation" 7 "maintenance"
@@ -949,7 +949,7 @@ cleanup_old_messages() {
   local count
   count=$(echo "$old_messages" | wc -w)
   log "Deleting $count old messages in batches of 50..."
-  echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
 
   log "Cleaned up ~$count messages older than TTL (read: 24h, unread: 48h)"
 }
@@ -992,7 +992,7 @@ cleanup_old_reports() {
   local count
   count=$(echo "$old_reports" | wc -w)
   log "Deleting $count old reports in batches of 50..."
-  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
 
   log "Cleaned up ~$count reports older than 48h TTL"
 }

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1061,7 +1061,7 @@ cleanup_old_thoughts() {
   local count
   count=$(echo "$old_thoughts" | wc -w)
   log "Deleting $count old thoughts in batches of 50..."
-  echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_thoughts" | xargs -n 50 kubectl delete thoughts.kro.run -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
 
   log "Cleaned up ~$count thoughts older than TTL (blockers/observations/decisions/plan: 2h, others: 24h)"
   post_thought "Cleaned up ~$count thoughts (batch TTL: low-signal 2h, high-signal 24h)" "observation" 7 "maintenance" 2>/dev/null || true
@@ -1116,7 +1116,7 @@ cleanup_old_messages() {
   local count
   count=$(echo "$old_messages" | wc -w)
   log "Deleting $count old messages in batches of 50..."
-  echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_messages" | xargs -n 50 kubectl delete messages -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
 
   log "Cleaned up ~$count messages older than TTL (read: 24h, unread: 48h)"
 }
@@ -1160,7 +1160,7 @@ cleanup_old_reports() {
   local count
   count=$(echo "$old_reports" | wc -w)
   log "Deleting $count old reports in batches of 50..."
-  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+  echo "$old_reports" | xargs -n 50 kubectl delete reports.kro.run -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
 
   log "Cleaned up ~$count reports older than 48h TTL"
 }


### PR DESCRIPTION
## Summary

- Adds `--wait=false` to all 9 `kubectl delete` calls in the three cleanup functions across `coordinator.sh`, `helpers.sh`, and `entrypoint.sh`
- Prevents the coordinator crash-loop caused by `kubectl delete` blocking on kro finalizer removal

Closes #1727

## Root Cause

All three cleanup functions (`cleanup_old_cluster_resources`, `cleanup_old_thoughts`, `cleanup_old_messages`, `cleanup_old_reports`) used `kubectl delete` without `--wait=false`. When kro is busy or rate-limited, it delays finalizer removal. `kubectl delete` (default) waits until the object is fully gone — i.e., until kro removes the `kro.run/finalizer`. This caused the coordinator to hang indefinitely on startup, triggering a worker-detected stale-heartbeat restart loop (174+ rollout revisions observed).

## Fix

`--wait=false` instructs kubectl to set `deletionTimestamp` and return immediately. kro removes finalizers asynchronously in the background. The object disappears from API list results once kro completes. Cleanup no longer blocks coordinator startup.

## Files Changed

- `images/runner/coordinator.sh` — 3 delete calls in `cleanup_old_cluster_resources()`
- `images/runner/helpers.sh` — 3 delete calls in `cleanup_old_thoughts()`, `cleanup_old_messages()`, `cleanup_old_reports()`
- `images/runner/entrypoint.sh` — 3 delete calls in the same 3 functions

## Testing

Verified all 9 delete calls now include `--wait=false`. The fix is consistent across all three files that duplicate these cleanup functions.