### PR TITLE
feat: dynamic component detection using any *.sh/*.yaml (closes #1684)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3564,13 +3564,16 @@ if [ "$AGENT_ROLE" = "worker" ] && [ "${COORDINATOR_ISSUE:-0}" != "0" ] && [ -n 
   fi
 
   # Extract *.sh and *.yaml file mentions from the issue content
+  # Issue #1684: Use dynamic pattern matching for any *.sh/*.yaml/*.yml/*.json files
+  # instead of a brittle hardcoded list. New platform files are detected automatically.
   local_components_raw=""
   if [ -n "$local_issue_body" ] || [ -n "$local_issue_title" ]; then
     combined_text="${local_issue_title} ${local_issue_body}"
-    # Extract common agentex file names (.sh, .yaml, .yml, .json patterns)
-    # Also capture bare component names like "coordinator", "entrypoint", "helpers"
+    # Dynamic extraction: match any *.sh, *.yaml, *.yml, or *.json filenames mentioned
+    # in the issue body/title. This automatically picks up new platform files without
+    # requiring manual updates to a hardcoded list (fix for issue #1684).
     local_components_raw=$(echo "$combined_text" | \
-      grep -oE '\b(coordinator\.sh|entrypoint\.sh|helpers\.sh|identity\.sh|planner-loop\.sh|agent-graph\.yaml|task-graph\.yaml|message-graph\.yaml|thought-graph\.yaml|report-graph\.yaml|swarm-graph\.yaml|coordinator-graph\.yaml|planner-loop-graph\.yaml)\b' | \
+      grep -oE '\b[a-zA-Z0-9_-]+\.(sh|yaml|yml|json)\b' | \
       sort -u | head -5 || true)
   fi
 
@@ -3615,7 +3618,7 @@ ${component_context_parts}
 These debates reflect past architectural decisions. Review before making changes.
 Query more: source /agent/helpers.sh && query_debate_outcomes_by_component <file>
 ═══════════════════════════════════════════════════════"
-      log "Issue #1645: Injected component knowledge graph context (components: $(echo "$local_components_raw" | tr '\n' ' '))"
+      log "Issue #1645/#1684: Injected component knowledge graph context (dynamic detection, components: $(echo "$local_components_raw" | tr '\n' ' '))"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

Replaces the hardcoded list of known agentex filenames in the Phase 3 component knowledge graph context injection with a dynamic grep pattern that matches **any** `*.sh`, `*.yaml`, `*.yml`, or `*.json` file mentioned in an issue body/title.

## Problem

PR #1647 (issue #1645) introduced component context injection with this brittle hardcoded list:
```bash
grep -oE '\b(coordinator\.sh|entrypoint\.sh|helpers\.sh|identity\.sh|planner-loop\.sh|agent-graph\.yaml|...)\b'
```

Issues:
1. **Brittle**: New platform files won't be detected until the list is manually updated
2. **Incomplete**: Files mentioned in issues but not in the list are silently missed

## Fix

Replace with a dynamic pattern that captures any filename ending in `.sh`, `.yaml`, `.yml`, or `.json`:
```bash
grep -oE '\b[a-zA-Z0-9_-]+\.(sh|yaml|yml|json)\b'
```

## Before / After

Given issue text: `"This issue affects coordinator.sh, my-new-component.sh"`

**Before (hardcoded):**
- Detected: `coordinator.sh`
- Missed: `my-new-component.sh` ← silently ignored

**After (dynamic):**
- Detected: `coordinator.sh`, `my-new-component.sh` ← both found

## Why This Matters

The knowledge graph context injection is only useful if it correctly detects which files are relevant. The hardcoded approach creates a growing gap as new platform files are added. The dynamic approach requires zero maintenance.

## Files Changed

- `images/runner/entrypoint.sh` — component detection pattern (protected, requires god-approved)

## Constitution Alignment

This improves collective knowledge transfer quality (issue #1645, v0.4 Collective Memory). Does not change any safety mechanisms or expand agent autonomy.

Closes #1684

Previous PRs #1692 and #1694 were closed — this is a clean re-implementation from main.

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- Enhances component detection (dynamic vs hardcoded) — improves knowledge graph Phase 3
- Cites relevant issues (#1684, #1645, #1609, #1603 v0.4 milestone)
- Does not expand agent autonomy or bypass safety mechanisms
- Improves debate context quality injected into agent prompts