### PR TITLE
fix: reset routingCyclesWithZeroSpec on coordinator startup to prevent false-positive escalations

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -346,11 +346,14 @@ ensure_state_fields_initialized() {
    # specializedAssignments=0. When it reaches 5, coordinator escalates with a blocker thought
    # AND files a GitHub issue to ensure the regression is visible and self-reported.
    # Reset to 0 when specializedAssignments increments (routing is working).
-  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("routingCyclesWithZeroSpec")' >/dev/null 2>&1; then
-    [ "$silent" = "false" ] && echo "  Initializing routingCyclesWithZeroSpec (was absent)"
-    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
-      -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
-  fi
+   # Issue #1731: ALWAYS reset to 0 on coordinator startup. "Consecutive cycles" only makes
+   # sense within a single coordinator run — stale counts from prior runs (especially after
+   # crash-loops, issue #1727) carry over and cause false-positive escalations when the new
+   # coordinator picks up the accumulated count and increments past the threshold immediately.
+   # Each coordinator restart is a clean slate for the "consecutive routing failure" counter.
+  [ "$silent" = "false" ] && echo "  Resetting routingCyclesWithZeroSpec to 0 on startup (issue #1731)"
+  kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+    -p '{"data":{"routingCyclesWithZeroSpec":"0"}}' 2>/dev/null || true
 
   # chronicleCandidates (issue #1605): semicolon-separated Thought ConfigMap names for
   # agent-proposed chronicle entries. Aggregated by aggregate_chronicle_candidates() every


### PR DESCRIPTION
## Summary

Fixes #1731 — coordinator files false-positive 'v0.2 routing regression' issues after crash-loop restarts.

## Problem

The `routingCyclesWithZeroSpec` counter tracks consecutive routing cycles where `specializedAssignments=0`. When it reaches 5, the coordinator escalates by filing a GitHub issue. However, this counter was ONLY initialized if absent on startup — it was **never reset on restart**.

When the coordinator crash-loops (issue #1727), stale count values accumulate across restarts. A new coordinator instance reads the stale counter (e.g., 25 from a prior run), increments it by 1, and immediately files an escalation issue — even if the underlying routing regression was already fixed.

## Root Cause

Timeline for issue #1731:
1. Coordinator was crash-looping (issue #1727) 
2. Fix for issue #1716 (skip transient startup when `agents_checked=0`) was merged in PR #1718 at 19:50 UTC
3. The stale counter value of 25 persisted in `coordinator-state` ConfigMap
4. New coordinator started, read 25, incremented to 26 (any routing cycle with `agents_with_spec=0` or `agents_checked>0` triggers increment), filed issue #1731 at 20:08 UTC
5. The "regression" was a false positive caused by stale counter accumulation across restarts

## Fix

**Always reset `routingCyclesWithZeroSpec` to 0 on coordinator startup.**

"Consecutive cycles" only makes semantic sense within a single coordinator run. Cycles from different coordinator instances (across restarts) are NOT actually consecutive — a coordinator restart is a clean slate for routing failure detection.

## Why This Is Safe

- The escalation mechanism still works within a single coordinator run (5+ cycles → file issue)
- Reset on startup does NOT suppress genuine regressions that persist across multiple coordinator lifetimes — each run has 5 cycles to detect the problem
- Prevents the crash-loop + stale-counter interaction that generates spurious GitHub issues

## Changes

- `images/runner/coordinator.sh` line 349: Replace conditional initialization with unconditional reset on startup, with comment explaining issue #1731 root cause

Closes #1731