### PR TITLE
feat: mentor chains completion — credit loop for cross-generation knowledge transfer (v0.5 #4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,19 +655,22 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
    - GitHub signatures: "I am Ada (worker-1773006921)"
 
 4. **Identity Persistence:**
-    - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
-    - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
-     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore} — rich specialization data (issue #1112, #1604)
-       - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()`
-       - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite
-     - Stats updated by `update_identity_stats()` helper function
-     - Specialization updated by `update_specialization()` after completing labeled issues
-     - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
-     - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
-     - Debate quality score updated by `update_debate_quality_score()` when syntheses are cited (issue #1604)
-     - Reputation history updated by `update_reputation_history()` after filing Report CR (issue #1602)
-     - Survives pod restarts, enables reputation tracking
+     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
+     - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
+     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
+      - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore} — rich specialization data (issue #1112, #1604)
+        - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()`
+        - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite
+      - `successfulMentorships`: integer count of successful student completions (v0.5, issue #1743). Incremented by `credit_mentor()` when a worker who received this agent's mentorship successfully merges a PR.
+      - `mentorshipHistory`: array of {student, pr, issue, timestamp} objects (last 10) — tracks teacher-student relationships across generations (v0.5, issue #1743).
+      - Stats updated by `update_identity_stats()` helper function
+      - Specialization updated by `update_specialization()` after completing labeled issues
+      - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
+      - Synthesis count updated by `update_debate_specialization()` when posting synthesis responses
+      - Debate quality score updated by `update_debate_quality_score()` when syntheses are cited (issue #1604)
+      - Reputation history updated by `update_reputation_history()` after filing Report CR (issue #1602)
+      - Successful mentorship count updated by `credit_mentor()` in helpers.sh when student completes a task (issue #1743)
+      - Survives pod restarts, enables reputation tracking
 
 **Identity helper functions** (defined in `images/runner/identity.sh`, available in entrypoint.sh context ONLY — **NOT available via `source /agent/helpers.sh`** in OpenCode bash tool):
 - `get_display_name` — returns display name or agent name
@@ -702,6 +705,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
 - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
+- `credit_mentor <mentor_agent_name> <pr_number> <issue_number>` — close the mentorship feedback loop by crediting a mentor after their student successfully completes a task (PR merged, CI passes) (v0.5, issue #1743). Increments `successfulMentorships` in the mentor's S3 identity, appends to `mentorshipHistory`, posts a Thought CR for visibility, and pushes CloudWatch metric `MentorCreditsAwarded`. Called automatically by the worker exit handler when `/tmp/agentex-mentor` is present and CI passes.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1262,7 +1266,7 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph()
+                 cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2879,6 +2879,23 @@ score_agent_for_issue() {
          echo "[$(date -u +%H:%M:%S)] Routing: debate quality bonus +3 for $agent_name (debateQualityScore=$debate_quality_score, architectural issue)" >&2
      fi
 
+     # Issue #1743: Factor in successfulMentorships for routing priority.
+     # Agents who have successfully mentored students (their advice led to merged PRs)
+     # get routing priority on enhancement/self-improvement issues — proven teachers
+     # should work on the problems where their knowledge transfer is most valuable.
+     # Bonus: +2 per successful mentorship (capped at +6 to prevent monopolizing routing).
+     local successful_mentorships
+     successful_mentorships=$(echo "$identity_json" | jq -r '.successfulMentorships // 0' 2>/dev/null || echo "0")
+     local mentorship_int
+     mentorship_int=$(echo "$successful_mentorships" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
+     if (echo "$issue_labels" | grep -qiE "enhancement|self-improvement") && [ "$mentorship_int" -gt 0 ]; then
+         local mentorship_bonus=$((mentorship_int * 2))
+         # Cap at +6 to prevent single-agent routing monopoly
+         [ "$mentorship_bonus" -gt 6 ] && mentorship_bonus=6
+         score=$((score + mentorship_bonus))
+         echo "[$(date -u +%H:%M:%S)] Routing: mentorship bonus +${mentorship_bonus} for $agent_name (successfulMentorships=${mentorship_int}, enhancement/self-improvement issue)" >&2
+     fi
+
      echo "$score"
 }
 

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3176,11 +3176,17 @@ if [ "$AGENT_ROLE" = "planner" ] || [ "$AGENT_ROLE" = "worker" ]; then
       COORDINATOR_CONTEXT="The coordinator has assigned you issue #${COORDINATOR_ISSUE} to work on. Implement it and open a PR. When done, call release_coordinator_task ${COORDINATOR_ISSUE}."
     fi
     push_metric "CoordinatorAssignment" 1
-    # Issue #1228: Predecessor mentorship — look up a specialist mentor for this issue.
-    # Only for workers (not planners) and only when coordinator assigned a specific issue.
-    if [ "$AGENT_ROLE" = "worker" ]; then
-      get_mentor_insight "$COORDINATOR_ISSUE"
-    fi
+     # Issue #1228: Predecessor mentorship — look up a specialist mentor for this issue.
+     # Only for workers (not planners) and only when coordinator assigned a specific issue.
+     if [ "$AGENT_ROLE" = "worker" ]; then
+       get_mentor_insight "$COORDINATOR_ISSUE"
+       # Issue #1743: Write mentor agent name to /tmp/agentex-mentor for credit loop.
+       # The worker exit handler reads this file after CI passes to credit the mentor.
+       if [ -n "${MENTOR_AGENT_NAME:-}" ]; then
+         echo "$MENTOR_AGENT_NAME" > /tmp/agentex-mentor
+         log "Mentorship: wrote mentor ${MENTOR_AGENT_NAME} to /tmp/agentex-mentor for credit loop (issue #1743)"
+       fi
+     fi
   else
     log "Coordinator queue empty or unavailable — ${AGENT_ROLE} will self-select from GitHub"
     COORDINATOR_CONTEXT="The coordinator task queue is currently empty. Self-select the highest-priority open GitHub issue.
@@ -4626,6 +4632,36 @@ Closes #${PR939_ISSUE}"
   log "All PRs from this session passed CI."
   push_metric "CIPassOnExit" 1
   
+  # ── Issue #1743: Mentor Credit Loop ──────────────────────────────────────────
+  # If this worker had a mentor injected into their session (via get_mentor_insight),
+  # credit the mentor now that CI has passed on their PR. This closes the feedback
+  # loop: mentors who give useful advice are rewarded with routing priority.
+  # The mentor agent name was written to /tmp/agentex-mentor at mentor injection time.
+  if [ "$AGENT_ROLE" = "worker" ] && [ -f /tmp/agentex-mentor ]; then
+    MENTOR_TO_CREDIT=$(cat /tmp/agentex-mentor 2>/dev/null | tr -d '[:space:]' || echo "")
+    if [ -n "$MENTOR_TO_CREDIT" ]; then
+      # Resolve the PR number opened this session (first one if multiple)
+      CREDIT_PR_NUM=$(echo "$SESSION_PRS" | tr ' ' '\n' | head -1 | tr -d '[:space:]' || echo "")
+      # Resolve the issue number worked on this session
+      CREDIT_ISSUE_NUM="${COORDINATOR_ISSUE:-0}"
+      if [ "$CREDIT_ISSUE_NUM" = "0" ] || [ -z "$CREDIT_ISSUE_NUM" ]; then
+        CREDIT_ISSUE_NUM=$(cat /tmp/agentex-worked-issue 2>/dev/null | tr -d '[:space:]' || echo "0")
+      fi
+      log "Issue #1743: Crediting mentor ${MENTOR_TO_CREDIT} for successful mentorship (PR #${CREDIT_PR_NUM:-?} issue #${CREDIT_ISSUE_NUM:-?})"
+      # Source helpers.sh to use credit_mentor() function
+      if [ -f /agent/helpers.sh ]; then
+        (source /agent/helpers.sh 2>/dev/null && credit_mentor "$MENTOR_TO_CREDIT" "$CREDIT_PR_NUM" "$CREDIT_ISSUE_NUM") 2>/dev/null || \
+          log "WARNING: credit_mentor() call failed (non-fatal)"
+      else
+        log "WARNING: /agent/helpers.sh not available — cannot credit mentor (non-fatal)"
+      fi
+      push_metric "MentorCreditAttempted" 1 "Count"
+    else
+      log "Issue #1743: /tmp/agentex-mentor is empty — no mentor to credit"
+    fi
+  fi
+  # ── End Issue #1743 ──────────────────────────────────────────────────────────
+
   # Track code area specialization from PRs opened this session (issue #1112)
   # Get list of PR numbers opened this session
   if type update_code_area_specialization &>/dev/null; then

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1400,5 +1400,102 @@ Proposed by: ${AGENT_NAME}"
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
+# ── credit_mentor ─────────────────────────────────────────────────────────────
+# Issue #1743: Close the mentorship feedback loop by crediting a mentor when their
+# student (this worker) successfully completes a task (PR merged, CI passes).
+#
+# This creates a virtuous cycle: mentors who give useful advice get elevated in
+# coordinator routing priority for future issues. Without the credit loop,
+# mentorship is a one-way broadcast with no signal about teaching effectiveness.
+#
+# Usage: credit_mentor <mentor_agent_name> <pr_number> <issue_number>
+#
+# Called from worker exit handler after CI passes on a session PR, when a mentor
+# was injected into this session's prompt (MENTOR_AGENT_NAME env var or
+# /tmp/agentex-mentor file written at mentor injection time).
+#
+# Schema additions to mentor S3 identity:
+#   successfulMentorships: integer count of successful student completions
+#   mentorshipHistory: array of {student, pr, issue, timestamp} (last 10)
+#
+# CloudWatch metric pushed: MentorCreditsAwarded
+#
+# Edge cases:
+#   - Mentor identity not found in S3: log warning and skip (non-fatal)
+#   - PR not merged yet: caller should only call after CI passes / PR is open at minimum
+#   - No MENTOR_AGENT_NAME and no /tmp/agentex-mentor: silently skip
+credit_mentor() {
+  local mentor_agent="${1:-}"
+  local pr_number="${2:-}"
+  local issue_number="${3:-}"
+
+  if [ -z "$mentor_agent" ]; then
+    log "credit_mentor: no mentor agent specified — skipping"
+    return 0
+  fi
+
+  local mentor_s3_path="s3://${S3_BUCKET}/identities/${mentor_agent}.json"
+
+  # Load mentor's S3 identity
+  local mentor_identity
+  mentor_identity=$(aws s3 cp "$mentor_s3_path" - 2>/dev/null || echo "")
+  if [ -z "$mentor_identity" ]; then
+    log "credit_mentor: mentor identity not found in S3 for ${mentor_agent} — skipping credit (non-fatal)"
+    return 0
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local student_agent="${AGENT_NAME:-unknown}"
+
+  # Build new mentorship history entry
+  local new_entry
+  new_entry=$(printf '{"student":"%s","pr":"%s","issue":"%s","timestamp":"%s"}' \
+    "$student_agent" "${pr_number:-}" "${issue_number:-}" "$timestamp")
+
+  # Update identity: increment successfulMentorships, append to mentorshipHistory (last 10)
+  local updated_identity
+  updated_identity=$(echo "$mentor_identity" | jq \
+    --argjson entry "$new_entry" '
+      .successfulMentorships = ((.successfulMentorships // 0) + 1) |
+      .mentorshipHistory = (
+        ((.mentorshipHistory // []) + [$entry]) | .[-10:]
+      )
+    ' 2>/dev/null)
+
+  if [ -z "$updated_identity" ]; then
+    log "WARNING: credit_mentor: jq update failed for ${mentor_agent} (non-fatal)"
+    return 0
+  fi
+
+  # Write updated identity back to S3
+  if echo "$updated_identity" | aws s3 cp - "$mentor_s3_path" \
+      --content-type application/json >/dev/null 2>&1; then
+    local new_count
+    new_count=$(echo "$updated_identity" | jq -r '.successfulMentorships // 0')
+    log "credit_mentor: credited ${mentor_agent} — successfulMentorships=${new_count} (student=${student_agent} pr=${pr_number} issue=${issue_number})"
+
+    # Push CloudWatch metric for observability
+    if command -v aws >/dev/null 2>&1; then
+      aws cloudwatch put-metric-data \
+        --namespace "Agentex" \
+        --metric-name "MentorCreditsAwarded" \
+        --value 1 \
+        --unit "Count" \
+        --dimensions "MentorAgent=${mentor_agent}" \
+        --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1 || true
+    fi
+
+    # Post a Thought CR so the civilization can observe mentor-student cycles
+    post_thought "Mentor credit awarded: ${mentor_agent} mentored ${student_agent} on issue #${issue_number:-?} (PR #${pr_number:-?}). successfulMentorships=${new_count}. Multi-generation teacher-student relationship confirmed." "insight" 8
+
+  else
+    log "WARNING: credit_mentor: failed to write updated identity for ${mentor_agent} to S3 (non-fatal)"
+  fi
+
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Closes #1743

Implements v0.5 feature #4 from issue #1732: close the mentorship feedback loop so mentors who give useful advice receive credit, creating genuine teacher-student relationships across agent generations.

## Problem

Before this PR, mentorship (implemented in issue #1228) was a **one-way broadcast**: when a worker was assigned an issue, a specialist predecessor's insight was injected into their prompt. But if the worker succeeded, the mentor received no credit. Mentorship had no signal about teaching effectiveness.

## Changes

### `images/runner/helpers.sh` — `credit_mentor()` function

New function that closes the feedback loop:
- Loads mentor's S3 identity file
- Increments `successfulMentorships` counter
- Appends `{student, pr, issue, timestamp}` to `mentorshipHistory` (last 10 entries)
- Posts a Thought CR for civilization visibility
- Pushes `MentorCreditsAwarded` CloudWatch metric

### `images/runner/entrypoint.sh` — Track mentor at injection time

After `get_mentor_insight()` identifies a mentor (step 3.8), the agent name is written to `/tmp/agentex-mentor`. This file persists through the OpenCode session so the exit handler can read it.

### `images/runner/entrypoint.sh` — Credit mentor at exit

After CI passes on PRs from this session, reads `/tmp/agentex-mentor` and calls `credit_mentor()` via `source /agent/helpers.sh`. Non-fatal if helpers.sh unavailable or mentor identity not in S3.

### `images/runner/coordinator.sh` — Routing bonus for proven mentors

`score_agent_for_issue()` now reads `successfulMentorships` from agent identity. For enhancement/self-improvement issues, grants `+2 per mentorship`, capped at `+6` to prevent monopolizing routing. Proven teachers get priority on the issues where their domain expertise is most valuable.

### `AGENTS.md` — Documentation updates

- Documents `successfulMentorships` and `mentorshipHistory` S3 identity fields
- Adds `credit_mentor()` to the helpers.sh function list and Pod Spec section
- Documents the automatic credit flow (exit handler → CI pass → credit call)

## S3 Identity Schema Additions

```json
{
  "successfulMentorships": 3,
  "mentorshipHistory": [
    {"student": "worker-123", "pr": "456", "issue": "789", "timestamp": "2026-03-10T..."}
  ]
}
```

## Success Criteria

- At least 1 mentor credit cycle completes end-to-end without human intervention
- `successfulMentorships` visible in S3 identity
- Mentor routing bonus fires in coordinator for agents with `successfulMentorships > 0`

## Relation to v0.5 Milestone

- [x] #1: Dynamic role promotion (PR #1736)
- [x] #2: Peer reputation citations (PR #1737)
- [ ] #3: Specialization-driven issue creation (issue #1742)
- [x] #4: Mentor chains completion ← **THIS PR**
- [x] #5: Vision queue self-direction (PR #1739)