### PR TITLE
feat: v0.5 mentor credit loop — credit mentors when worker PR passes CI (closes #1732)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -658,9 +658,10 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
     - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
-     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore} — rich specialization data (issue #1112, #1604)
-       - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()`
-       - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite
+     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore, mentorCredits} — rich specialization data (issue #1112, #1604, #1732)
+       - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()` OR credited this agent as a successful mentor via `credit_mentor_for_success()` (v0.5, issue #1732)
+       - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite AND successful mentorship outcomes
+       - `mentorCredits`: array of {creditedBy, at} entries — log of workers who credited this agent for successful mentorship (v0.5, issue #1732)
      - Stats updated by `update_identity_stats()` helper function
      - Specialization updated by `update_specialization()` after completing labeled issues
      - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
@@ -700,8 +701,9 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `query_thoughts [--topic X] [--file X] [--type X] [--min-confidence N] [--limit N]` — query Thought CRs by topic, file, type, or confidence
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
-- `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
+ - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
+- `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1262,7 +1264,7 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph()
+                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success()
 ```
 
 Environment:

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4641,6 +4641,46 @@ Closes #${PR939_ISSUE}"
       done <<< "$SESSION_PR_NUMBERS"
     fi
   fi
+
+  # Issue #1732 v0.5: Mentor Credit Loop — credit mentor when worker PR passes CI.
+  # When a mentor helped this worker (via step 3.8 mentorship injection) and the worker
+  # successfully opened a PR that passed CI, update the mentor's identity to credit them.
+  # This closes the feedback cycle: useful mentors earn quality score boosts, making
+  # their advice more likely to be surfaced in future mentorship lookups.
+  if [ -n "${MENTOR_AGENT_NAME:-}" ]; then
+    log "Mentor credit: crediting mentor ${MENTOR_AGENT_NAME} for worker PR success (issue #1732 v0.5)"
+    if type credit_mentor_for_success &>/dev/null; then
+      credit_mentor_for_success "$MENTOR_AGENT_NAME" 2>/dev/null || true
+    else
+      # Inline fallback: directly update mentor identity S3 file
+      _mentor_identity_path="s3://${S3_BUCKET}/identities/${MENTOR_AGENT_NAME}.json"
+      if aws s3 ls "$_mentor_identity_path" >/dev/null 2>&1; then
+        _mentor_identity=$(aws s3 cp "$_mentor_identity_path" - 2>/dev/null || echo "")
+        if [ -n "$_mentor_identity" ]; then
+          _updated_mentor=$(echo "$_mentor_identity" | jq \
+            --arg creditor "${AGENT_NAME}" \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+            .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+            .specializationDetail.debateQualityScore = (
+              (.specializationDetail.synthesisCount // 0) * 2 +
+              (.specializationDetail.citedSynthesesCount // 0) * 5
+            ) |
+            .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
+              [{"creditedBy": $creditor, "at": $ts}]
+          ' 2>/dev/null || echo "")
+          if [ -n "$_updated_mentor" ]; then
+            echo "$_updated_mentor" | aws s3 cp - "$_mentor_identity_path" --content-type application/json >/dev/null 2>&1 && \
+              log "Mentor credit: updated ${MENTOR_AGENT_NAME} citedSynthesesCount++ (inline fallback)" || \
+              log "WARNING: Mentor credit inline fallback write failed for ${MENTOR_AGENT_NAME} (non-fatal)"
+          fi
+        fi
+      else
+        log "Mentor credit: identity not found for ${MENTOR_AGENT_NAME} — skipping (non-fatal)"
+      fi
+    fi
+    push_metric "MentorCreditGranted" 1 "Count" "MentorAgent=${MENTOR_AGENT_NAME}"
+    log "Mentor credit complete for ${MENTOR_AGENT_NAME}"
+  fi
 fi
 
 # Update specialization based on issue labels worked on this session (issue #1098, #1347)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1400,5 +1400,114 @@ Proposed by: ${AGENT_NAME}"
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate available"
+# ── credit_mentor_for_success ─────────────────────────────────────────────────
+# Issue #1732 v0.5: Mentor Credit Loop — close the feedback cycle for predecessor mentorship.
+#
+# When a worker successfully completes a task that a mentor helped with (PR opened + CI passes),
+# the mentor's identity is updated:
+#   - .specializationDetail.citedSynthesesCount += 1
+#   - .specializationDetail.debateQualityScore recalculated
+#
+# This creates a virtuous feedback cycle: mentors who give useful advice get credited,
+# making their future advice more likely to be surfaced by the mentorship injection system.
+#
+# Usage: credit_mentor_for_success <mentor_agent_name>
+#
+# This is called by entrypoint.sh after CI passes on a session PR when MENTOR_AGENT_NAME is set.
+#
+# Example:
+#   if [ -n "${MENTOR_AGENT_NAME:-}" ] && [ "$PRS_OPENED" -gt 0 ]; then
+#     credit_mentor_for_success "$MENTOR_AGENT_NAME"
+#   fi
+credit_mentor_for_success() {
+  local mentor_agent="${1:-}"
+
+  if [ -z "$mentor_agent" ]; then
+    log "credit_mentor_for_success: no mentor agent name provided — skipping"
+    return 0
+  fi
+
+  local mentor_identity_path="s3://${S3_BUCKET}/identities/${mentor_agent}.json"
+
+  # Check if mentor identity exists
+  if ! aws s3 ls "$mentor_identity_path" >/dev/null 2>&1; then
+    log "credit_mentor_for_success: per-session identity not found for ${mentor_agent} — checking canonical path"
+    log "credit_mentor_for_success: mentor identity not found at ${mentor_identity_path} — skipping credit (non-fatal)"
+    return 0
+  fi
+
+  # Read mentor identity
+  local mentor_identity
+  mentor_identity=$(aws s3 cp "$mentor_identity_path" - 2>/dev/null || echo "")
+  if [ -z "$mentor_identity" ]; then
+    log "credit_mentor_for_success: failed to read mentor identity for ${mentor_agent} — skipping"
+    return 0
+  fi
+
+  # Increment citedSynthesesCount (represents successful mentorship outcomes)
+  # Recalculate debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
+  local updated_identity
+  updated_identity=$(echo "$mentor_identity" | jq \
+    --arg creditor "${AGENT_NAME:-unknown}" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+    .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+    .specializationDetail.debateQualityScore = (
+      (.specializationDetail.synthesisCount // 0) * 2 +
+      (.specializationDetail.citedSynthesesCount // 0) * 5
+    ) |
+    .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
+      [{"creditedBy": $creditor, "at": $timestamp}]
+  ' 2>/dev/null || echo "")
+
+  if [ -z "$updated_identity" ]; then
+    log "credit_mentor_for_success: jq transform failed for ${mentor_agent} — skipping"
+    return 0
+  fi
+
+  # Write updated identity back to S3 (per-session path)
+  if echo "$updated_identity" | aws s3 cp - "$mentor_identity_path" --content-type application/json >/dev/null 2>&1; then
+    local new_score
+    new_score=$(echo "$updated_identity" | jq -r '.specializationDetail.debateQualityScore // 0')
+    local cited_count
+    cited_count=$(echo "$updated_identity" | jq -r '.specializationDetail.citedSynthesesCount // 0')
+    log "credit_mentor_for_success: credited mentor ${mentor_agent} — citedSynthesesCount=${cited_count} debateQualityScore=${new_score}"
+  else
+    log "WARNING: credit_mentor_for_success: failed to write updated identity for ${mentor_agent} (non-fatal)"
+    return 0
+  fi
+
+  # Also update canonical identity if it exists (displayName-based path)
+  local display_name
+  display_name=$(echo "$mentor_identity" | jq -r '.displayName // ""' 2>/dev/null || echo "")
+  if [ -n "$display_name" ] && [ "$display_name" != "null" ]; then
+    local canonical_path="s3://${S3_BUCKET}/identities/canonical/${display_name}.json"
+    if aws s3 ls "$canonical_path" >/dev/null 2>&1; then
+      local canonical_identity
+      canonical_identity=$(aws s3 cp "$canonical_path" - 2>/dev/null || echo "")
+      if [ -n "$canonical_identity" ]; then
+        local updated_canonical
+        updated_canonical=$(echo "$canonical_identity" | jq \
+          --arg creditor "${AGENT_NAME:-unknown}" \
+          --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+          .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+          .specializationDetail.debateQualityScore = (
+            (.specializationDetail.synthesisCount // 0) * 2 +
+            (.specializationDetail.citedSynthesesCount // 0) * 5
+          ) |
+          .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
+            [{"creditedBy": $creditor, "at": $timestamp}]
+        ' 2>/dev/null || echo "")
+        if [ -n "$updated_canonical" ]; then
+          echo "$updated_canonical" | aws s3 cp - "$canonical_path" --content-type application/json >/dev/null 2>&1 && \
+            log "credit_mentor_for_success: updated canonical identity for ${display_name}" || \
+            log "WARNING: credit_mentor_for_success: failed to update canonical identity for ${display_name} (non-fatal)"
+        fi
+      fi
+    fi
+  fi
+
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Rebased version of #1740 (which had unresolvable merge conflicts from divergent base).
All changes applied cleanly on current main.

- Adds `credit_mentor_for_success()` to `helpers.sh` — credits a mentor's S3 identity when a worker PR passes CI
- Adds mentor credit call in `entrypoint.sh` CI pass block — triggered when `MENTOR_AGENT_NAME` is set
- Updates `AGENTS.md` to document the new function and `mentorCredits` identity field

## How It Works

1. Worker is assigned an issue; step 3.8 injects a mentor's insight via `MENTORSHIP_BLOCK` and sets `MENTOR_AGENT_NAME`
2. Worker implements and opens a PR
3. On CI pass exit path, `credit_mentor_for_success($MENTOR_AGENT_NAME)` is called
4. Mentor's S3 identity gets `citedSynthesesCount++` and `debateQualityScore` recalculated
5. Future mentorship lookups rank this mentor higher — creating a feedback loop

## Constitution Alignment

- Enforces existing vision: "roles formed by capability, not assignment"
- Does not expand agent autonomy
- Non-fatal: all S3 writes are `|| true` — no crash risk

Closes #1732