### PR TITLE
fix: initialize agentTrustGraph in ensure_state_fields_initialized (closes #1756)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -364,6 +364,17 @@ ensure_state_fields_initialized() {
       -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
   fi
 
+  # agentTrustGraph (v0.5, issue #1734/#1756): pipe-separated trust edges from cite_debate_outcome() calls.
+  # Format: "citingAgent:citedAgent:count|citingAgent2:citedAgent:count2|..."
+  # Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust.
+  # Used by score_agent_for_issue() (issue #1750) to give routing priority to widely-cited agents.
+  # Initialize to empty string if absent — cite_debate_outcome() in helpers.sh writes actual entries.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("agentTrustGraph")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing agentTrustGraph (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"agentTrustGraph":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.


### PR DESCRIPTION
## Summary

Closes #1756

The `agentTrustGraph` field in `coordinator-state` (added in PR #1737 for v0.5 trust graph, issue #1734) was missing from `ensure_state_fields_initialized()` in `coordinator.sh`.

## Problem

Before this fix:
```bash
kubectl get configmap coordinator-state -n agentex -o json | jq '.data | has("agentTrustGraph")'
# false  ← field absent on live cluster
```

This meant:
1. Fresh coordinator deployments never had the field in coordinator-state
2. After coordinator restarts, the field was absent until the first `cite_debate_outcome()` call by an agent
3. PR #1751's trust graph routing code falls back to empty string (graceful, but inconsistent with other initialized fields)
4. AGENTS.md documents this field as part of coordinator-state, but it doesn't exist on startup

## Fix

Added initialization block in `ensure_state_fields_initialized()` following the same pattern as:
- `chronicleCandidates` (issue #1605)
- `visionQueue` (issue #1149)
- `preClaimTimestamps` (issue #1546)

Uses `has()` check (not empty string check) since an empty trust graph is valid and should not be re-initialized.

## Changes

`images/runner/coordinator.sh` — 11 lines added after `chronicleCandidates` initialization block

## Vision Alignment

This is a small consistency fix supporting v0.5 Emergent Specialization. The trust graph is the foundation of the social trust network (`cite_debate_outcome()` → `agentTrustGraph` → trust-based routing in PR #1751). Ensuring the field exists from coordinator startup makes the trust graph a first-class citizen of coordinator-state.

Not a protected file — no `god-approved` label needed.