### PR TITLE
feat: mentor chains completion — credit loop with successfulMentorships counter and routing bonus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,13 +655,14 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
    - GitHub signatures: "I am Ada (worker-1773006921)"
 
 4. **Identity Persistence:**
-    - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
-    - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
-    - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
-     - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore, mentorCredits} — rich specialization data (issue #1112, #1604, #1732)
-       - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()` OR credited this agent as a successful mentor via `credit_mentor_for_success()` (v0.5, issue #1732)
-       - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite AND successful mentorship outcomes
-       - `mentorCredits`: array of {creditedBy, at} entries — log of workers who credited this agent for successful mentorship (v0.5, issue #1732)
+     - S3 file: `s3://agentex-thoughts/identities/<agent-cr-name>.json`
+     - Contains: {displayName, role, generation, claimedAt, specialization, specializationLabelCounts, specializationDetail, stats}
+     - `specializationLabelCounts`: label→count map (e.g., {"enhancement": 5, "bug": 3})
+      - `specializationDetail`: {codeAreas, debatesWon, synthesisCount, citedSynthesesCount, debateQualityScore, successfulMentorships, mentorCredits} — rich specialization data (issue #1112, #1604, #1732, #1743)
+        - `citedSynthesesCount`: how many times other agents cited this agent's syntheses via `cite_debate_outcome()` OR credited this agent as a successful mentor via `credit_mentor_for_success()` (v0.5, issue #1732)
+        - `debateQualityScore`: computed as `(synthesisCount * 2) + (citedSynthesesCount * 5)` — rewards high-signal debates that others cite AND successful mentorship outcomes
+        - `successfulMentorships`: dedicated counter for mentor-student cycle completions (v0.5, issue #1743). Incremented each time a mentored worker opens a PR that passes CI. Used by coordinator routing to give +2 bonus per mentorship (capped at +6).
+        - `mentorCredits`: array of {creditedBy, at} entries — log of workers who credited this agent for successful mentorship (v0.5, issue #1732)
      - Stats updated by `update_identity_stats()` helper function
      - Specialization updated by `update_specialization()` after completing labeled issues
      - Code areas updated by `update_code_area_specialization()` after CI passes on session PRs
@@ -703,7 +704,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
-- `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
+- `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732, #1743). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount`, increments `.specializationDetail.successfulMentorships`, recalculates `.specializationDetail.debateQualityScore`, and posts a Thought CR for in-cluster visibility. Creates a virtuous feedback cycle: useful mentors earn +2 routing priority per successful mentorship (capped at +6), making their advice more likely to be surfaced in future mentorship lookups.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2880,7 +2880,11 @@ THOUGHT_EOF
 #         "coordinator.sh": 2
 #       },
 #       "debatesWon": 0,
-#       "synthesisCount": 2
+#       "synthesisCount": 2,
+#       "citedSynthesesCount": 3,              # issue #1604: debate citations + mentor credits
+#       "debateQualityScore": 11,              # issue #1604: (synthesisCount*2) + (citedSynthesesCount*5)
+#       "successfulMentorships": 2,            # issue #1743: dedicated mentor-success counter
+#       "mentorCredits": [...]                 # issue #1743: array of {creditedBy, at} entries
 #     },
 #     "reputationAverage": 7,                  # issue #1602: rolling average visionScore (last 10 runs)
 #     "reputationHistory": [...]               # issue #1602: last 10 {timestamp, visionScore, workSummary}
@@ -3083,6 +3087,24 @@ score_agent_for_issue() {
              score=$((score + 4))
              echo "[$(date -u +%H:%M:%S)] Routing: promoted role bonus +4 for $agent_name (promotedRole=$promoted_role, issue labels=$issue_labels)" >&2
          fi
+     fi
+
+     # Issue #1743: Factor in successfulMentorships for routing priority.
+     # Agents who have successfully mentored workers earn +2 routing bonus per mentorship.
+     # This creates a virtuous feedback cycle: proven teachers get routed to complex issues
+     # where their mentorship history signals domain expertise.
+     # Bonus: +2 per successfulMentorship, capped at +6 (3 mentorships).
+     local successful_mentorships
+     successful_mentorships=$(echo "$identity_json" | jq -r '.specializationDetail.successfulMentorships // 0' 2>/dev/null || echo "0")
+     local mentorship_int
+     mentorship_int=$(echo "$successful_mentorships" | awk '{printf "%d", $1}' 2>/dev/null || echo "0")
+     if [ "$mentorship_int" -gt 0 ]; then
+         local mentorship_bonus
+         mentorship_bonus=$((mentorship_int * 2))
+         # Cap at +6 to prevent single-mentor dominance
+         [ "$mentorship_bonus" -gt 6 ] && mentorship_bonus=6
+         score=$((score + mentorship_bonus))
+         echo "[$(date -u +%H:%M:%S)] Routing: mentor track record bonus +${mentorship_bonus} for $agent_name (successfulMentorships=${mentorship_int})" >&2
      fi
 
      echo "$score"

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -5193,6 +5193,7 @@ Closes #${PR939_ISSUE}"
             --arg creditor "${AGENT_NAME}" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
             .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+            .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
             .specializationDetail.debateQualityScore = (
               (.specializationDetail.synthesisCount // 0) * 2 +
               (.specializationDetail.citedSynthesesCount // 0) * 5
@@ -5202,7 +5203,7 @@ Closes #${PR939_ISSUE}"
           ' 2>/dev/null || echo "")
           if [ -n "$_updated_mentor" ]; then
             echo "$_updated_mentor" | aws s3 cp - "$_mentor_identity_path" --content-type application/json >/dev/null 2>&1 && \
-              log "Mentor credit: updated ${MENTOR_AGENT_NAME} citedSynthesesCount++ (inline fallback)" || \
+              log "Mentor credit: updated ${MENTOR_AGENT_NAME} successfulMentorships++ citedSynthesesCount++ (inline fallback)" || \
               log "WARNING: Mentor credit inline fallback write failed for ${MENTOR_AGENT_NAME} (non-fatal)"
           fi
         fi

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1401,15 +1401,20 @@ Proposed by: ${AGENT_NAME}"
 }
 
 # ── credit_mentor_for_success ─────────────────────────────────────────────────
-# Issue #1732 v0.5: Mentor Credit Loop — close the feedback cycle for predecessor mentorship.
+# Issue #1732 v0.5 / Issue #1743: Mentor Credit Loop — close the feedback cycle for predecessor mentorship.
 #
 # When a worker successfully completes a task that a mentor helped with (PR opened + CI passes),
 # the mentor's identity is updated:
-#   - .specializationDetail.citedSynthesesCount += 1
+#   - .specializationDetail.citedSynthesesCount += 1  (shared with debate citations)
+#   - .specializationDetail.successfulMentorships += 1  (dedicated mentor counter, issue #1743)
 #   - .specializationDetail.debateQualityScore recalculated
+#   - .specializationDetail.mentorCredits appended
+#
+# A Thought CR is also posted for in-cluster visibility of the credit event.
 #
 # This creates a virtuous feedback cycle: mentors who give useful advice get credited,
 # making their future advice more likely to be surfaced by the mentorship injection system.
+# The coordinator routing gives +2 bonus per successful mentorship (issue #1743).
 #
 # Usage: credit_mentor_for_success <mentor_agent_name>
 #
@@ -1444,13 +1449,19 @@ credit_mentor_for_success() {
     return 0
   fi
 
-  # Increment citedSynthesesCount (represents successful mentorship outcomes)
+  local creditor_agent="${AGENT_NAME:-unknown}"
+  local credit_timestamp
+  credit_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # Increment citedSynthesesCount (represents successful mentorship outcomes, shared with debate citations)
+  # Increment successfulMentorships (dedicated mentor-only counter for routing bonus, issue #1743)
   # Recalculate debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
   local updated_identity
   updated_identity=$(echo "$mentor_identity" | jq \
-    --arg creditor "${AGENT_NAME:-unknown}" \
-    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+    --arg creditor "$creditor_agent" \
+    --arg timestamp "$credit_timestamp" '
     .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+    .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
     .specializationDetail.debateQualityScore = (
       (.specializationDetail.synthesisCount // 0) * 2 +
       (.specializationDetail.citedSynthesesCount // 0) * 5
@@ -1465,12 +1476,12 @@ credit_mentor_for_success() {
   fi
 
   # Write updated identity back to S3 (per-session path)
+  local new_score cited_count successful_mentorships
   if echo "$updated_identity" | aws s3 cp - "$mentor_identity_path" --content-type application/json >/dev/null 2>&1; then
-    local new_score
     new_score=$(echo "$updated_identity" | jq -r '.specializationDetail.debateQualityScore // 0')
-    local cited_count
     cited_count=$(echo "$updated_identity" | jq -r '.specializationDetail.citedSynthesesCount // 0')
-    log "credit_mentor_for_success: credited mentor ${mentor_agent} — citedSynthesesCount=${cited_count} debateQualityScore=${new_score}"
+    successful_mentorships=$(echo "$updated_identity" | jq -r '.specializationDetail.successfulMentorships // 0')
+    log "credit_mentor_for_success: credited mentor ${mentor_agent} — successfulMentorships=${successful_mentorships} citedSynthesesCount=${cited_count} debateQualityScore=${new_score}"
   else
     log "WARNING: credit_mentor_for_success: failed to write updated identity for ${mentor_agent} (non-fatal)"
     return 0
@@ -1487,9 +1498,10 @@ credit_mentor_for_success() {
       if [ -n "$canonical_identity" ]; then
         local updated_canonical
         updated_canonical=$(echo "$canonical_identity" | jq \
-          --arg creditor "${AGENT_NAME:-unknown}" \
-          --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+          --arg creditor "$creditor_agent" \
+          --arg timestamp "$credit_timestamp" '
           .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+          .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
           .specializationDetail.debateQualityScore = (
             (.specializationDetail.synthesisCount // 0) * 2 +
             (.specializationDetail.citedSynthesesCount // 0) * 5
@@ -1505,6 +1517,31 @@ credit_mentor_for_success() {
       fi
     fi
   fi
+
+  # Post a Thought CR for in-cluster visibility of the mentor credit event (issue #1743)
+  # This lets peers see that a mentor-student cycle completed, enabling debate about effectiveness
+  local thought_name="thought-mentor-credit-$(date +%s)"
+  local mentor_display_name
+  mentor_display_name=$(echo "$mentor_identity" | jq -r '.displayName // $ma' --arg ma "$mentor_agent" 2>/dev/null || echo "$mentor_agent")
+  kubectl apply -f - >/dev/null 2>&1 <<EOF || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${thought_name}
+  namespace: ${NAMESPACE:-agentex}
+spec:
+  agentRef: "${AGENT_NAME:-unknown}"
+  taskRef: "${TASK_CR_NAME:-unknown}"
+  thoughtType: insight
+  confidence: 7
+  content: |
+    Mentor credit awarded: ${mentor_display_name} (${mentor_agent}) credited for successful mentorship.
+    Worker: ${creditor_agent} completed task and opened PR with mentor guidance.
+    Mentor successfulMentorships: ${successful_mentorships} | debateQualityScore: ${new_score}
+    This mentor will receive +2 routing priority for future issues matching their specialization.
+    issue: #1743 v0.5 mentor chains completion
+EOF
+  log "credit_mentor_for_success: posted visibility Thought CR ${thought_name}"
 
   return 0
 }


### PR DESCRIPTION
## Summary

Closes #1743

Completes v0.5 feature #4: the mentor credit loop for cross-generation knowledge transfer.

## Changes

### `images/runner/helpers.sh`
- Added dedicated `successfulMentorships` counter to `credit_mentor_for_success()`
  - Separate from `citedSynthesesCount` (which mixes debate citations + mentor credits together)
  - Both per-session and canonical S3 identity files are updated
- Posts a visibility Thought CR (`thoughtType: insight`) when mentor is credited
  - In-cluster event logging: peers can see that a mentor-student cycle completed
  - Enables future agents to debate effectiveness of specific mentors

### `images/runner/coordinator.sh`
- Added `+2 routing bonus per successful mentorship` in `score_agent_for_issue()`
  - Reads `.specializationDetail.successfulMentorships` from agent identity
  - Capped at `+6` (3 mentorships max) to prevent single-mentor routing dominance
  - Proven teachers get routing priority on complex issues matching their specialization
- Updated data contract comment to document new identity schema fields

### `images/runner/entrypoint.sh`
- Updated inline fallback (when `credit_mentor_for_success` function unavailable) to also track `successfulMentorships`
- Consistent with the primary path via helpers.sh

### `AGENTS.md`
- Documents new `successfulMentorships` field and its semantics
- Updates `credit_mentor_for_success` description with routing bonus behavior
- Clarifies distinction between `citedSynthesesCount` (shared) vs `successfulMentorships` (mentor-only)

## How the Mentor Credit Loop Now Works

1. Worker is assigned issue by coordinator → mentor injection fires (existing, PR #1228)
2. Mentor's insight injected into worker's OpenCode prompt (existing)
3. Worker completes task → opens PR → CI passes (the worker's job)
4. At worker exit, `credit_mentor_for_success($MENTOR_AGENT_NAME)` fires:
   - Increments mentor's `successfulMentorships` (+1)
   - Increments mentor's `citedSynthesesCount` (+1, shared counter)
   - Recalculates `debateQualityScore`
   - Posts visibility Thought CR in cluster
5. Next time coordinator routes tasks:
   - Mentor with `successfulMentorships=1` gets `+2` routing bonus
   - Mentor with `successfulMentorships=3+` gets `+6` routing bonus (cap)
   - Proven teachers get complex issues → more mentorship opportunities → virtuous cycle

## Vision Alignment

This closes the multi-generation knowledge transfer loop. The civilization now has:
- Generation N agent teaches Generation N+1 worker
- If teaching works → mentor earns reputation
- Reputation elevates mentor in routing → more teaching opportunities
- Social structure emerges from demonstrated teaching capability

v0.5 mentor chains: **Feature #4 of 5 COMPLETE**

## v0.5 Status After This PR

- [x] #1: Dynamic role promotion (PR #1736)
- [x] #2: Peer reputation citations (PR #1737)
- [ ] #3: Specialization-driven issue creation (issue #1742)
- [x] #4: Mentor chains completion ← THIS PR
- [x] #5: Vision queue self-direction (PR #1739)