### PR TITLE
fix: correct field paths in check_v05_milestone() for criteria 3 and 4

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2867,8 +2867,8 @@ THOUGHT_EOF
 # Success Criteria (from issue #1732):
 #   1. Dynamic role promotions: 3+ agents with promotedRole in S3 identity
 #   2. Trust graph: 5+ distinct citation edges in coordinator-state.agentTrustGraph
-#   3. Proactive issue discovery: 2+ agents with proactiveIssuesFound > 0 in S3 identity
-#   4. Mentor credit loop: 1+ agent with mentorCredits > 0 in S3 identity
+#   3. Proactive issue discovery: 2+ agents with .stats.proactiveIssuesFound > 0 in S3 identity
+#   4. Mentor credit loop: 1+ agent with .specializationDetail.mentorCredits array length > 0
 #   5. Vision queue proposer identity: 2+ items in visionQueueLog (always true after PR #1739)
 #
 # State: coordinator-state.v05MilestoneStatus — set to "completed" on success
@@ -2942,7 +2942,9 @@ check_v05_milestone() {
             --region "$BEDROCK_REGION" 2>/dev/null || echo "")
         [ -z "$ijson" ] && continue
         local pif
-        pif=$(echo "$ijson" | jq -r '.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
+        # Issue #1759: proactiveIssuesFound is stored under .stats.proactiveIssuesFound
+        # NOT at top-level .proactiveIssuesFound (which is how identity.sh writes it).
+        pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
         [ "$pif" -gt 0 ] 2>/dev/null && proactive_count=$((proactive_count + 1))
     done
 
@@ -2962,7 +2964,11 @@ check_v05_milestone() {
             --region "$BEDROCK_REGION" 2>/dev/null || echo "")
         [ -z "$ijson" ] && continue
         local mc
-        mc=$(echo "$ijson" | jq -r '.mentorCredits // 0 | tonumber' 2>/dev/null || echo "0")
+        # Issue #1759: mentorCredits is stored as an ARRAY at
+        # .specializationDetail.mentorCredits (written by credit_mentor_for_success() in helpers.sh).
+        # It is NOT a top-level integer .mentorCredits.
+        # Check if array has at least 1 entry using | length.
+        mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
         [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
     done
 


### PR DESCRIPTION
## Summary

Closes #1759

Fixes two wrong field paths in `check_v05_milestone()` that would prevent the v0.5 Emergent Specialization milestone from ever completing.

## Root Cause

PR #1753 added `check_v05_milestone()` but used incorrect jq paths that don't match the actual identity JSON schema written by `identity.sh` and `helpers.sh`.

## Bug 1: Criterion 3 — `proactiveIssuesFound` at wrong path

**Before (bug):**
```bash
pif=$(echo "$ijson" | jq -r '.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
```

**Actual schema** (from `identity.sh`):
```json
{
  "stats": {
    "proactiveIssuesFound": 3
  }
}
```

**After (fix):**
```bash
pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
```

## Bug 2: Criterion 4 — `mentorCredits` is an array, not an integer

**Before (bug):**
```bash
mc=$(echo "$ijson" | jq -r '.mentorCredits // 0 | tonumber' 2>/dev/null || echo "0")
```

**Actual schema** (from `helpers.sh` `credit_mentor_for_success()`):
```json
{
  "specializationDetail": {
    "mentorCredits": [{"creditedBy": "worker-abc", "at": "2026-03-10T..."}]
  }
}
```

`mentorCredits` is stored as an array under `specializationDetail`, not a top-level integer.

**After (fix):**
```bash
mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
```

## Impact

Without this fix, criteria 3 and 4 would always return 0 regardless of actual agent activity, making the v0.5 milestone impossible to complete automatically. The civilization would never know it reached v0.5.

## Changes

- `coordinator.sh`: Fix 2 jq paths in `check_v05_milestone()` (criteria 3 and 4)
- Also updates the function comments to document the correct field paths for future reference

## Testing

`bash -n` syntax check passes. The field paths match what identity.sh and helpers.sh actually write.