### PR TITLE
feat: add successfulMentorships counter and routing bonus (closes #1743)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3130,7 +3130,11 @@ Closes #1732"
 #         "coordinator.sh": 2
 #       },
 #       "debatesWon": 0,
-#       "synthesisCount": 2
+#       "synthesisCount": 2,
+#       "citedSynthesesCount": 3,              # shared counter: debate citations + mentor credits
+#       "successfulMentorships": 2,            # issue #1743: mentor-only counter for routing bonus
+#       "debateQualityScore": 21,              # computed: (synthesisCount*2) + (citedSynthesesCount*5)
+#       "mentorCredits": [...]                 # array: [{creditedBy, at}] — log of workers who credited
 #     },
 #     "reputationAverage": 7,                  # issue #1602: rolling average visionScore (last 10 runs)
 #     "reputationHistory": [...]               # issue #1602: last 10 {timestamp, visionScore, workSummary}
@@ -3355,6 +3359,26 @@ score_agent_for_issue() {
              score=$((score + 2))
              echo "[$(date -u +%H:%M:%S)] Routing: trust graph bonus +2 for $agent_name (cited by $distinct_citers distinct peers)" >&2
          fi
+     fi
+
+     # Issue #1743: v0.5 Feature #4 — Successful mentorships routing bonus.
+     # Agents with a track record of successful mentorships earn a routing bonus,
+     # prioritizing proven teachers for complex issues matching their specialization.
+     # Bonus: +2 per successfulMentorship, capped at +6 (3 mentorships max).
+     # Uses the dedicated .specializationDetail.successfulMentorships counter written by
+     # credit_mentor_for_success() in helpers.sh — separate from citedSynthesesCount.
+     local successful_mentorships
+     successful_mentorships=$(echo "$identity_json" | jq -r \
+         '.specializationDetail.successfulMentorships // 0 | tonumber' 2>/dev/null || echo "0")
+     if [ "$successful_mentorships" -gt 0 ]; then
+         local mentorship_bonus
+         mentorship_bonus=$(( successful_mentorships * 2 ))
+         # Cap at +6 to prevent single-mentor routing dominance
+         if [ "$mentorship_bonus" -gt 6 ]; then
+             mentorship_bonus=6
+         fi
+         score=$((score + mentorship_bonus))
+         echo "[$(date -u +%H:%M:%S)] Routing: mentorship bonus +${mentorship_bonus} for $agent_name (successfulMentorships=${successful_mentorships})" >&2
      fi
 
      echo "$score"

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4992,6 +4992,7 @@ Closes #${PR939_ISSUE}"
       credit_mentor_for_success "$MENTOR_AGENT_NAME" 2>/dev/null || true
     else
       # Inline fallback: directly update mentor identity S3 file
+      # Issue #1743: also increment successfulMentorships (separate from citedSynthesesCount)
       _mentor_identity_path="s3://${S3_BUCKET}/identities/${MENTOR_AGENT_NAME}.json"
       if aws s3 ls "$_mentor_identity_path" >/dev/null 2>&1; then
         _mentor_identity=$(aws s3 cp "$_mentor_identity_path" - 2>/dev/null || echo "")
@@ -5000,6 +5001,7 @@ Closes #${PR939_ISSUE}"
             --arg creditor "${AGENT_NAME}" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
             .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+            .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
             .specializationDetail.debateQualityScore = (
               (.specializationDetail.synthesisCount // 0) * 2 +
               (.specializationDetail.citedSynthesesCount // 0) * 5
@@ -5009,7 +5011,7 @@ Closes #${PR939_ISSUE}"
           ' 2>/dev/null || echo "")
           if [ -n "$_updated_mentor" ]; then
             echo "$_updated_mentor" | aws s3 cp - "$_mentor_identity_path" --content-type application/json >/dev/null 2>&1 && \
-              log "Mentor credit: updated ${MENTOR_AGENT_NAME} citedSynthesesCount++ (inline fallback)" || \
+              log "Mentor credit: updated ${MENTOR_AGENT_NAME} citedSynthesesCount++ successfulMentorships++ (inline fallback)" || \
               log "WARNING: Mentor credit inline fallback write failed for ${MENTOR_AGENT_NAME} (non-fatal)"
           fi
         fi

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1400,25 +1400,31 @@ Proposed by: ${AGENT_NAME}"
   return 0
 }
 
-# ── credit_mentor_for_success ─────────────────────────────────────────────────
-# Issue #1732 v0.5: Mentor Credit Loop — close the feedback cycle for predecessor mentorship.
-#
-# When a worker successfully completes a task that a mentor helped with (PR opened + CI passes),
-# the mentor's identity is updated:
-#   - .specializationDetail.citedSynthesesCount += 1
-#   - .specializationDetail.debateQualityScore recalculated
-#
-# This creates a virtuous feedback cycle: mentors who give useful advice get credited,
-# making their future advice more likely to be surfaced by the mentorship injection system.
-#
-# Usage: credit_mentor_for_success <mentor_agent_name>
-#
-# This is called by entrypoint.sh after CI passes on a session PR when MENTOR_AGENT_NAME is set.
-#
-# Example:
-#   if [ -n "${MENTOR_AGENT_NAME:-}" ] && [ "$PRS_OPENED" -gt 0 ]; then
-#     credit_mentor_for_success "$MENTOR_AGENT_NAME"
-#   fi
+ # ── credit_mentor_for_success ─────────────────────────────────────────────────
+ # Issue #1732/#1743 v0.5: Mentor Credit Loop — close the feedback cycle for predecessor mentorship.
+ #
+ # When a worker successfully completes a task that a mentor helped with (PR opened + CI passes),
+ # the mentor's identity is updated:
+ #   - .specializationDetail.citedSynthesesCount += 1  (shared: debate citations + mentor credits)
+ #   - .specializationDetail.successfulMentorships += 1  (mentor-only counter, issue #1743)
+ #   - .specializationDetail.debateQualityScore recalculated
+ #   - .specializationDetail.mentorCredits[] appended with {creditedBy, at}
+ #
+ # The successfulMentorships counter is kept separate from citedSynthesesCount so the
+ # coordinator can apply a distinct routing bonus (+2 per mentorship, capped at +6) for
+ # proven teachers without conflating it with debate synthesis quality.
+ #
+ # This creates a virtuous feedback cycle: mentors who give useful advice get credited,
+ # making their future advice more likely to be surfaced by the mentorship injection system.
+ #
+ # Usage: credit_mentor_for_success <mentor_agent_name>
+ #
+ # This is called by entrypoint.sh after CI passes on a session PR when MENTOR_AGENT_NAME is set.
+ #
+ # Example:
+ #   if [ -n "${MENTOR_AGENT_NAME:-}" ] && [ "$PRS_OPENED" -gt 0 ]; then
+ #     credit_mentor_for_success "$MENTOR_AGENT_NAME"
+ #   fi
 credit_mentor_for_success() {
   local mentor_agent="${1:-}"
 
@@ -1444,69 +1450,77 @@ credit_mentor_for_success() {
     return 0
   fi
 
-  # Increment citedSynthesesCount (represents successful mentorship outcomes)
-  # Recalculate debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
-  local updated_identity
-  updated_identity=$(echo "$mentor_identity" | jq \
-    --arg creditor "${AGENT_NAME:-unknown}" \
-    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
-    .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
-    .specializationDetail.debateQualityScore = (
-      (.specializationDetail.synthesisCount // 0) * 2 +
-      (.specializationDetail.citedSynthesesCount // 0) * 5
-    ) |
-    .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
-      [{"creditedBy": $creditor, "at": $timestamp}]
-  ' 2>/dev/null || echo "")
+   # Increment citedSynthesesCount (shared: debate citations + mentor credits) AND
+   # successfulMentorships (mentor-only counter, issue #1743) for clean separation.
+   # Recalculate debateQualityScore = (synthesisCount * 2) + (citedSynthesesCount * 5)
+   local updated_identity
+   updated_identity=$(echo "$mentor_identity" | jq \
+     --arg creditor "${AGENT_NAME:-unknown}" \
+     --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+     .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+     .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
+     .specializationDetail.debateQualityScore = (
+       (.specializationDetail.synthesisCount // 0) * 2 +
+       (.specializationDetail.citedSynthesesCount // 0) * 5
+     ) |
+     .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
+       [{"creditedBy": $creditor, "at": $timestamp}]
+   ' 2>/dev/null || echo "")
 
-  if [ -z "$updated_identity" ]; then
-    log "credit_mentor_for_success: jq transform failed for ${mentor_agent} — skipping"
-    return 0
-  fi
+   if [ -z "$updated_identity" ]; then
+     log "credit_mentor_for_success: jq transform failed for ${mentor_agent} — skipping"
+     return 0
+   fi
 
-  # Write updated identity back to S3 (per-session path)
-  if echo "$updated_identity" | aws s3 cp - "$mentor_identity_path" --content-type application/json >/dev/null 2>&1; then
-    local new_score
-    new_score=$(echo "$updated_identity" | jq -r '.specializationDetail.debateQualityScore // 0')
-    local cited_count
-    cited_count=$(echo "$updated_identity" | jq -r '.specializationDetail.citedSynthesesCount // 0')
-    log "credit_mentor_for_success: credited mentor ${mentor_agent} — citedSynthesesCount=${cited_count} debateQualityScore=${new_score}"
-  else
-    log "WARNING: credit_mentor_for_success: failed to write updated identity for ${mentor_agent} (non-fatal)"
-    return 0
-  fi
+   # Write updated identity back to S3 (per-session path)
+   if echo "$updated_identity" | aws s3 cp - "$mentor_identity_path" --content-type application/json >/dev/null 2>&1; then
+     local new_score
+     new_score=$(echo "$updated_identity" | jq -r '.specializationDetail.debateQualityScore // 0')
+     local cited_count
+     cited_count=$(echo "$updated_identity" | jq -r '.specializationDetail.citedSynthesesCount // 0')
+     local successful_mentorships
+     successful_mentorships=$(echo "$updated_identity" | jq -r '.specializationDetail.successfulMentorships // 0')
+     log "credit_mentor_for_success: credited mentor ${mentor_agent} — citedSynthesesCount=${cited_count} successfulMentorships=${successful_mentorships} debateQualityScore=${new_score}"
+   else
+     log "WARNING: credit_mentor_for_success: failed to write updated identity for ${mentor_agent} (non-fatal)"
+     return 0
+   fi
 
-  # Also update canonical identity if it exists (displayName-based path)
-  local display_name
-  display_name=$(echo "$mentor_identity" | jq -r '.displayName // ""' 2>/dev/null || echo "")
-  if [ -n "$display_name" ] && [ "$display_name" != "null" ]; then
-    local canonical_path="s3://${S3_BUCKET}/identities/canonical/${display_name}.json"
-    if aws s3 ls "$canonical_path" >/dev/null 2>&1; then
-      local canonical_identity
-      canonical_identity=$(aws s3 cp "$canonical_path" - 2>/dev/null || echo "")
-      if [ -n "$canonical_identity" ]; then
-        local updated_canonical
-        updated_canonical=$(echo "$canonical_identity" | jq \
-          --arg creditor "${AGENT_NAME:-unknown}" \
-          --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
-          .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
-          .specializationDetail.debateQualityScore = (
-            (.specializationDetail.synthesisCount // 0) * 2 +
-            (.specializationDetail.citedSynthesesCount // 0) * 5
-          ) |
-          .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
-            [{"creditedBy": $creditor, "at": $timestamp}]
-        ' 2>/dev/null || echo "")
-        if [ -n "$updated_canonical" ]; then
-          echo "$updated_canonical" | aws s3 cp - "$canonical_path" --content-type application/json >/dev/null 2>&1 && \
-            log "credit_mentor_for_success: updated canonical identity for ${display_name}" || \
-            log "WARNING: credit_mentor_for_success: failed to update canonical identity for ${display_name} (non-fatal)"
-        fi
-      fi
-    fi
-  fi
+   # Post a visibility Thought CR so peers can see the mentor-student cycle completed
+   post_thought "Mentor credit: ${mentor_agent} credited by ${AGENT_NAME:-unknown} for successful mentorship (successfulMentorships=$(echo "$updated_identity" | jq -r '.specializationDetail.successfulMentorships // 0'))" "insight" 7 2>/dev/null || true
 
-  return 0
+   # Also update canonical identity if it exists (displayName-based path)
+   local display_name
+   display_name=$(echo "$mentor_identity" | jq -r '.displayName // ""' 2>/dev/null || echo "")
+   if [ -n "$display_name" ] && [ "$display_name" != "null" ]; then
+     local canonical_path="s3://${S3_BUCKET}/identities/canonical/${display_name}.json"
+     if aws s3 ls "$canonical_path" >/dev/null 2>&1; then
+       local canonical_identity
+       canonical_identity=$(aws s3 cp "$canonical_path" - 2>/dev/null || echo "")
+       if [ -n "$canonical_identity" ]; then
+         local updated_canonical
+         updated_canonical=$(echo "$canonical_identity" | jq \
+           --arg creditor "${AGENT_NAME:-unknown}" \
+           --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+           .specializationDetail.citedSynthesesCount = (.specializationDetail.citedSynthesesCount // 0) + 1 |
+           .specializationDetail.successfulMentorships = (.specializationDetail.successfulMentorships // 0) + 1 |
+           .specializationDetail.debateQualityScore = (
+             (.specializationDetail.synthesisCount // 0) * 2 +
+             (.specializationDetail.citedSynthesesCount // 0) * 5
+           ) |
+           .specializationDetail.mentorCredits = (.specializationDetail.mentorCredits // []) +
+             [{"creditedBy": $creditor, "at": $timestamp}]
+         ' 2>/dev/null || echo "")
+         if [ -n "$updated_canonical" ]; then
+           echo "$updated_canonical" | aws s3 cp - "$canonical_path" --content-type application/json >/dev/null 2>&1 && \
+             log "credit_mentor_for_success: updated canonical identity for ${display_name} (successfulMentorships incremented)" || \
+             log "WARNING: credit_mentor_for_success: failed to update canonical identity for ${display_name} (non-fatal)"
+         fi
+       fi
+     fi
+   fi
+
+   return 0
 }
 
 log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"


### PR DESCRIPTION
## Summary

Closes #1743

Completes v0.5 feature #4: the mentor credit loop for cross-generation knowledge transfer.

This is a minimal implementation addressing the feedback from closed PR #1761: branch from current main and keep the change minimal.

## Changes

### `images/runner/helpers.sh`
- Added `.specializationDetail.successfulMentorships` counter in `credit_mentor_for_success()`
  - Dedicated **mentor-only** counter, separate from `citedSynthesesCount` (which mixes debate citations + mentor credits together, making specialization reasoning opaque)
  - Both per-session and canonical S3 identity files are updated
- Updated comment to document the new field and the separation rationale
- Added `post_thought()` call for in-cluster visibility when a mentor is credited (peers can see mentor-student cycles complete)

### `images/runner/coordinator.sh`
- Added `+2 routing bonus per successfulMentorship` in `score_agent_for_issue()`
  - Capped at `+6` (3 mentorships max) to prevent single-mentor routing dominance
  - Reads `.specializationDetail.successfulMentorships` from agent S3 identity
  - Proven teachers get routing priority on issues matching their specialization
- Updated data contract comment to document all `specializationDetail` fields including `successfulMentorships`, `citedSynthesesCount`, `debateQualityScore`, and `mentorCredits`

### `images/runner/entrypoint.sh`
- Updated inline fallback (when `credit_mentor_for_success` is unavailable) to also increment `successfulMentorships` for consistency with the primary path via helpers.sh

## Why successfulMentorships is separate from citedSynthesesCount

`citedSynthesesCount` serves double duty: it's incremented by both `cite_debate_outcome()` (debate synthesis citations) and `credit_mentor_for_success()` (mentor credits). This makes it impossible to distinguish debate quality from teaching quality. The new `successfulMentorships` counter provides a clean signal: "how many times have workers I mentored successfully completed their PR?"

The coordinator can now apply distinct bonuses:
- Trust graph (+2) for widely-cited debate synthesizers
- Debate quality (+3) for high-quality debaters (debateQualityScore > 10)
- **Mentorship (+2×N, capped at +6) for proven teachers** ← NEW

## How the Mentor Credit Loop Works

1. Worker is assigned issue by coordinator → mentor injection fires (existing, PR #1228)
2. Mentor's insight injected into worker's OpenCode prompt (existing)
3. Worker completes task → opens PR → CI passes
4. Worker exit handler calls `credit_mentor_for_success($MENTOR_AGENT_NAME)` (existing, PR #1749)
5. **NEW**: Mentor's `successfulMentorships` incremented in S3 identity
6. **NEW**: Next routing cycle gives the mentor +2 per successful mentorship
7. Coordinator routes harder issues preferentially to proven teachers