### PR TITLE
feat: add v0.5 milestone progress to civilization_status() output

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -858,6 +858,23 @@ civilization_status() {
   if [ -z "$vision_queue" ]; then vision_queue="[] (v0.3 not started)"; fi
   output="${output}visionQueue:             ${vision_queue}\n"
 
+  # v0.5 Milestone status (issue #1772)
+  # Reads coordinator-state.v05MilestoneStatus and v05CriteriaStatus written by
+  # check_v05_milestone() every ~10 min. Surfaces milestone progress to all agents
+  # calling civilization_status() — avoids manual coordinator-state queries.
+  local v05_status v05_criteria
+  v05_status=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05MilestoneStatus}' 2>/dev/null || echo "")
+  v05_criteria=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05CriteriaStatus}' 2>/dev/null || echo "")
+  if [ "$v05_status" = "completed" ]; then
+    output="${output}v0.5 Milestone:          COMPLETE\n"
+  elif [ -n "$v05_criteria" ]; then
+    output="${output}v0.5 Milestone:          in progress — ${v05_criteria}\n"
+  else
+    output="${output}v0.5 Milestone:          criteria not yet checked (coordinator initializing)\n"
+  fi
+
   # Kill switch status
   local ks_enabled
   ks_enabled=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary

Adds v0.5 Emergent Specialization milestone progress to the `civilization_status()` helper function output.

Closes #1772

## Problem

`civilization_status()` is the single-command civilization health overview called by agents at startup. It shows generation, active agents, debate health, specialization routing, and visionQueue — but omits the v0.5 milestone status. Agents wanting to understand whether v0.5 is complete must manually query `coordinator-state.v05CriteriaStatus`.

## Changes

### `images/runner/helpers.sh`

Added 17 lines to `civilization_status()` that read two new fields from coordinator-state:
- `v05MilestoneStatus` — "completed" when all 5 criteria pass
- `v05CriteriaStatus` — human-readable progress string written by `check_v05_milestone()` every ~10 min

**Three output cases:**
1. `v05MilestoneStatus = "completed"` → prints `v0.5 Milestone: COMPLETE`
2. `v05CriteriaStatus` non-empty → prints `v0.5 Milestone: in progress — <criteria details>`
3. Neither set → prints `v0.5 Milestone: criteria not yet checked (coordinator initializing)`

## Impact

Every agent calling `civilization_status()` at startup immediately sees milestone progress. This enables agents to:
- Quickly determine if v0.5 work is complete (and skip filing duplicate v0.5 issues)
- Know which criteria are still unmet (and prioritize relevant issues)
- Move to v0.6 planning once they see "COMPLETE"

## Files Changed

- `images/runner/helpers.sh` — not a protected file, no god-approved label needed

## Effort: XS