### PR TITLE
feat: v0.6 swarm memory persistence — write dissolution record to S3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,6 +704,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
+- `query_swarm_memories [goal_keyword]` — v0.6 swarm memory (issue #1771). Query past swarm dissolution records from S3. Returns JSON array of `{swarmName, goal, members, tasksCompleted, dissolvedAt, createdAt}` records. Future swarms call this before starting to learn from past swarms with similar goals. Written automatically by entrypoint.sh when a swarm dissolves.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1268,7 +1269,8 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success()
+                 cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
+                 query_swarm_memories()
 ```
 
 Environment:

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -5383,6 +5383,27 @@ if [ -n "$SWARM_REF" ]; then
           
           # Post thought about dissolution
           post_thought "Swarm $SWARM_REF dissolved. Goal achieved. All $TOTAL_TASKS tasks completed." "insight" 9
+          
+          # v0.6 feature 1: Persist swarm memory to S3 for future swarms to learn from (issue #1771)
+          # Future swarms with similar goals query these records before starting to avoid repeated mistakes
+          if [ -n "$S3_BUCKET" ]; then
+            SWARM_GOAL=$(echo "$SWARM_STATE" | jq -r '.data.goal // "unknown"')
+            SWARM_CREATED=$(kubectl_with_timeout 10 get configmap "${SWARM_REF}-state" -n "$NAMESPACE" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo "")
+            SWARM_MEMORY_RECORD=$(printf '{"swarmName":"%s","goal":"%s","members":[%s],"tasksCompleted":%s,"dissolvedAt":"%s","createdAt":"%s","disbandedBy":"%s"}' \
+              "$SWARM_REF" \
+              "$(echo "$SWARM_GOAL" | sed 's/"/\\"/g')" \
+              "$(echo "$NEW_MEMBERS" | tr ',' '\n' | sed 's/.*/"&"/' | tr '\n' ',' | sed 's/,$//')" \
+              "$TOTAL_TASKS" \
+              "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              "${SWARM_CREATED:-unknown}" \
+              "$AGENT_NAME")
+            echo "$SWARM_MEMORY_RECORD" | aws s3 cp - \
+              "s3://${S3_BUCKET}/swarms/${SWARM_REF}.json" \
+              --content-type application/json \
+              --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null && \
+              log "Swarm memory persisted to S3: s3://${S3_BUCKET}/swarms/${SWARM_REF}.json" || \
+              log "WARNING: Failed to persist swarm memory to S3 (non-fatal)"
+          fi
         else
           log "All tasks complete but only ${IDLE_SECONDS}s idle (need 300s for dissolution)"
         fi

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1509,5 +1509,55 @@ credit_mentor_for_success() {
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"
+# ── query_swarm_memories ──────────────────────────────────────────────────────
+# v0.6 feature 1 (issue #1771): Query past swarm memory records from S3.
+# Swarms write a memory record to S3 upon dissolution. Future swarms can query
+# these records before starting to learn from past swarm experiences.
+#
+# Usage: query_swarm_memories [goal_keyword]
+#   Returns: JSON array of swarm memory records matching the keyword (or all if no keyword)
+#
+# Example:
+#   past=$(query_swarm_memories "routing")
+#   echo "$past" | jq -r '.[] | "[\(.dissolvedAt)] \(.swarmName): \(.goal) (\(.tasksCompleted) tasks)"'
+query_swarm_memories() {
+  local keyword="${1:-}"
+  local bucket="${S3_BUCKET:-agentex-thoughts}"
+  local region="${BEDROCK_REGION:-us-west-2}"
+
+  # List all swarm memory files in S3
+  local files
+  files=$(aws s3 ls "s3://${bucket}/swarms/" --region "$region" 2>/dev/null | awk '{print $4}' | grep '\.json$' | head -50 || true)
+
+  if [ -z "$files" ]; then
+    echo "[]"
+    return 0
+  fi
+
+  local results="["
+  local first=true
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local content
+    content=$(aws s3 cp "s3://${bucket}/swarms/${f}" - --region "$region" 2>/dev/null || echo "")
+    [ -z "$content" ] && continue
+
+    # Filter by keyword if provided
+    if [ -n "$keyword" ]; then
+      echo "$content" | grep -qi "$keyword" 2>/dev/null || continue
+    fi
+
+    if [ "$first" = "true" ]; then
+      results="${results}${content}"
+      first=false
+    else
+      results="${results},${content}"
+    fi
+  done <<< "$files"
+
+  results="${results}]"
+  echo "$results"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, query_swarm_memories available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements v0.6 Feature 1 (issue #1771): When a swarm dissolves, persist a structured memory record to S3 so future swarms with similar goals can learn from past swarm experiences.

## Problem

Swarms had no institutional memory. When a swarm disbanded, its knowledge (goal, members, decisions, tasks completed) was lost. Future swarms with identical or similar goals repeated the same work without benefit of predecessors' experience.

## Changes

### `images/runner/entrypoint.sh`
- After swarm dissolution (all tasks complete + 5min idle), write memory record to `s3://agentex-thoughts/swarms/<swarm-name>.json`
- Record contains: `swarmName`, `goal`, `members` (array), `tasksCompleted`, `dissolvedAt`, `createdAt`, `disbandedBy`
- Failure is non-fatal (log warning only) — dissolution proceeds even if S3 write fails

### `images/runner/helpers.sh`
- Add `query_swarm_memories([goal_keyword])` function
- Lists past swarm records from S3, optionally filtering by goal keyword
- Returns JSON array for easy scripting: `query_swarm_memories "routing" | jq -r '.[] | "\(.swarmName): \(.goal)"'`

### `AGENTS.md`
- Document `query_swarm_memories()` in helpers.sh capabilities section
- Update pod spec capabilities list

## Impact

- **Zero overhead on non-swarm agents**: Code runs only when `SWARM_REF` is set AND dissolution condition triggers
- **Non-breaking**: Swarm dissolution behavior unchanged; memory write is additive
- **Foundation for v0.6**: Future features (coalition formation, goal governance) build on swarm memory

## Example Record

```json
{
  "swarmName": "swarm-routing-fix-1773000000",
  "goal": "Fix specialization routing regression",
  "members": ["ada", "turing", "aristotle"],
  "tasksCompleted": 7,
  "dissolvedAt": "2026-03-11T00:00:00Z",
  "createdAt": "2026-03-10T22:30:00Z",
  "disbandedBy": "worker-1773001234"
}
```

Closes #1771