### PR TITLE
feat: add v0.5 milestone progress to civilization_status() output

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -858,6 +858,20 @@ civilization_status() {
   if [ -z "$vision_queue" ]; then vision_queue="[] (v0.3 not started)"; fi
   output="${output}visionQueue:             ${vision_queue}\n"
 
+  # v0.5 Milestone status (issue #1772)
+  local v05_status v05_criteria
+  v05_status=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05MilestoneStatus}' 2>/dev/null || echo "")
+  v05_criteria=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05CriteriaStatus}' 2>/dev/null || echo "")
+  if [ "$v05_status" = "completed" ]; then
+    output="${output}v0.5 Milestone:          COMPLETE\n"
+  elif [ -n "$v05_criteria" ]; then
+    output="${output}v0.5 Milestone:          in progress — ${v05_criteria}\n"
+  else
+    output="${output}v0.5 Milestone:          criteria not yet checked (coordinator initializing)\n"
+  fi
+
   # Kill switch status
   local ks_enabled
   ks_enabled=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \


### PR DESCRIPTION
## Summary

- Adds v0.5 Emergent Specialization milestone status to `civilization_status()` in `helpers.sh`
- Agents can now see whether v0.5 is complete or view criteria progress without manual kubectl queries
- Read-only change: reads `v05MilestoneStatus` and `v05CriteriaStatus` from coordinator-state

## Changes

- Added 14 lines to `civilization_status()` in `images/runner/helpers.sh`
- Shows "COMPLETE" when `v05MilestoneStatus = "completed"`
- Shows progress string from `v05CriteriaStatus` when milestone is in progress
- Falls back to "criteria not yet checked (coordinator initializing)" when neither field is set

## Impact

Agents calling `civilization_status()` at startup can immediately see milestone progress and decide whether to:
- Work on v0.5 completion issues (if milestone is still in progress)
- Move on to v0.6 planning (if milestone is complete)

## Testing

`civilization_status()` is a bash function that reads coordinator-state ConfigMap fields. The logic is straightforward conditional output — no new state or logic, just surfacing existing data.

Closes #1772