### PR TITLE
feat: swarm memory persistence — write swarm summary to S3 on dissolution (v0.6 feature #1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,6 +704,8 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
+- `write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions>` — v0.6 swarm memory (issue #1773). Write a structured swarm dissolution record to `s3://<bucket>/swarm-memories/<swarm-name>.json`. Called automatically by `entrypoint.sh` on swarm dissolution, but agents can also call it manually for partial records.
+- `query_swarm_memories [topic_keyword]` — v0.6 swarm memory (issue #1773). Query past swarm memory records from S3. Planners should call this before forming a new swarm to check for prior experience with similar goals. Returns JSON records, one per line.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1265,10 +1267,11 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
     Source with: source /agent/helpers.sh
       Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-                query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
-                write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-                propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success()
+                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
+                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
+                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                 cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
+                 write_swarm_memory(), query_swarm_memories()
 ```
 
 Environment:

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -5378,11 +5378,21 @@ if [ -n "$SWARM_REF" ]; then
           kubectl_with_timeout 10 patch configmap "${SWARM_REF}-state" -n "$NAMESPACE" \
             --type=merge -p '{"data":{"phase":"Disbanded"}}' 2>/dev/null || true
           
+          # Issue #1773 v0.6: Persist swarm memory to S3 before dissolution
+          # Read the swarm goal from the state ConfigMap for the memory record
+          SWARM_GOAL=$(echo "$SWARM_STATE" | jq -r '.data.goal // "unknown goal"' 2>/dev/null || echo "unknown goal")
+          # Collect key decisions from recent swarm thoughts (best-effort)
+          SWARM_DECISIONS=$(kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l "agentex/thought,agentex/swarm=${SWARM_REF}" -o json 2>/dev/null | \
+            jq -r '[.items[] | select(.data.thoughtType=="decision" or .data.thoughtType=="insight") | .data.content] | join("; ")' 2>/dev/null | \
+            cut -c1-500 || echo "none recorded")
+          [ -z "$SWARM_DECISIONS" ] && SWARM_DECISIONS="none recorded"
+          write_swarm_memory "$SWARM_REF" "$SWARM_GOAL" "$NEW_MEMBERS" "$TOTAL_TASKS" "$SWARM_DECISIONS"
+          
           # Broadcast dissolution message
           post_message "broadcast" "Swarm $SWARM_REF has disbanded after completing all tasks. Members: $NEW_MEMBERS. Total tasks: $TOTAL_TASKS." "status"
           
           # Post thought about dissolution
-          post_thought "Swarm $SWARM_REF dissolved. Goal achieved. All $TOTAL_TASKS tasks completed." "insight" 9
+          post_thought "Swarm $SWARM_REF dissolved. Goal achieved. All $TOTAL_TASKS tasks completed. Swarm memory persisted to S3 (issue #1773)." "insight" 9
         else
           log "All tasks complete but only ${IDLE_SECONDS}s idle (need 300s for dissolution)"
         fi

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1509,5 +1509,125 @@ credit_mentor_for_success() {
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"
+# ── write_swarm_memory ────────────────────────────────────────────────────────
+# Issue #1773 v0.6: Swarm Memory Persistence — write swarm summary to S3 on dissolution.
+#
+# When a swarm disbands, this function writes a structured record to S3 so future
+# swarms with similar goals can learn from past experiences, key decisions, and
+# what was accomplished. This is the foundation of swarm institutional memory.
+#
+# Usage: write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions>
+#
+# Parameters:
+#   swarm_name      - Name of the swarm (e.g., "swarm-routing-fix")
+#   goal            - The swarm's stated goal
+#   members_csv     - Comma-separated list of member agent names
+#   tasks_completed - Number of tasks completed by this swarm
+#   key_decisions   - Free text summary of key decisions or findings (no quotes inside)
+#
+# S3 location: s3://<bucket>/swarm-memories/<swarm-name>.json
+#
+# Example:
+#   write_swarm_memory "swarm-routing-fix" "Fix coordinator routing regression" \
+#     "ada,turing,aristotle" 5 "Routing bug was in specialization score calculation"
+write_swarm_memory() {
+  local swarm_name="${1:-}"
+  local goal="${2:-unknown goal}"
+  local members_csv="${3:-}"
+  local tasks_completed="${4:-0}"
+  local key_decisions="${5:-none recorded}"
+
+  if [ -z "$swarm_name" ]; then
+    log "write_swarm_memory: no swarm name provided — skipping"
+    return 0
+  fi
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Build members JSON array from CSV
+  local members_json
+  members_json=$(echo "$members_csv" | tr ',' '\n' | jq -R . 2>/dev/null | jq -s . 2>/dev/null || echo "[]")
+
+  # Escape strings for JSON (replace " with \", replace newlines with space)
+  local safe_goal
+  safe_goal=$(echo "$goal" | sed 's/"/\\"/g' | tr '\n' ' ')
+  local safe_decisions
+  safe_decisions=$(echo "$key_decisions" | sed 's/"/\\"/g' | tr '\n' ' ')
+
+  local memory_json
+  memory_json=$(printf '{"swarmName":"%s","goal":"%s","members":%s,"tasksCompleted":%s,"keyDecisions":"%s","dissolvedAt":"%s","recordedBy":"%s"}\n' \
+    "$swarm_name" \
+    "$safe_goal" \
+    "$members_json" \
+    "$tasks_completed" \
+    "$safe_decisions" \
+    "$timestamp" \
+    "${AGENT_NAME:-unknown}")
+
+  local s3_path="s3://${s3_bucket}/swarm-memories/${swarm_name}.json"
+
+  if echo "$memory_json" | aws s3 cp - "$s3_path" --content-type application/json >/dev/null 2>&1; then
+    log "write_swarm_memory: persisted swarm memory for ${swarm_name} to ${s3_path}"
+    return 0
+  else
+    log "WARNING: write_swarm_memory: failed to write swarm memory for ${swarm_name} to S3 (non-fatal)"
+    return 0
+  fi
+}
+
+# ── query_swarm_memories ──────────────────────────────────────────────────────
+# Issue #1773 v0.6: Query past swarm memory records from S3.
+#
+# Before forming a new swarm, planners and coordinators can query past swarm
+# memories to find prior experience with similar goals, avoiding repeated mistakes
+# and building on past knowledge.
+#
+# Usage: query_swarm_memories [topic_keyword]
+#
+# Parameters:
+#   topic_keyword - Optional: filter results to swarms whose goal contains this term
+#                   If omitted, lists all swarm memories
+#
+# Output: JSON array of matching swarm memory records, one per line
+#
+# Example:
+#   query_swarm_memories "routing"
+#   # Returns all swarms whose goal mentioned "routing"
+#
+#   query_swarm_memories
+#   # Returns all swarm memories
+query_swarm_memories() {
+  local topic="${1:-}"
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+
+  local memories
+  memories=$(aws s3 ls "s3://${s3_bucket}/swarm-memories/" 2>/dev/null | awk '{print $4}' | while read -r f; do
+    [ -z "$f" ] && continue
+    local record
+    record=$(aws s3 cp "s3://${s3_bucket}/swarm-memories/$f" - 2>/dev/null || echo "")
+    [ -z "$record" ] && continue
+
+    if [ -z "$topic" ]; then
+      echo "$record"
+    else
+      # Filter by topic — check if goal contains the keyword (case-insensitive)
+      local goal_match
+      goal_match=$(echo "$record" | jq -r --arg t "$topic" \
+        'select(.goal | ascii_downcase | test($t | ascii_downcase)) | .swarmName' 2>/dev/null || echo "")
+      if [ -n "$goal_match" ]; then
+        echo "$record"
+      fi
+    fi
+  done)
+
+  if [ -n "$memories" ]; then
+    echo "$memories"
+  else
+    echo "[]"
+  fi
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the first feature of the v0.6 Collective Action milestone (#1771): **Swarm Memory Persistence**.

When a swarm disbands after completing all its tasks, it now writes a structured memory record to S3 so future swarms with similar goals can learn from past experience.

## Problem

Before this change, when a swarm dissolved, all its institutional knowledge was lost:
- What goal it pursued
- Who were the members
- How many tasks were completed
- Key decisions and lessons learned

Future swarms with identical goals had to rediscover the same lessons from scratch, wasting agent cycles and increasing error rates.

## Changes

### `images/runner/helpers.sh`
- **`write_swarm_memory(swarm_name, goal, members_csv, tasks_completed, key_decisions)`** — writes a structured JSON record to `s3://agentex-thoughts/swarm-memories/<swarm-name>.json`
- **`query_swarm_memories([topic_keyword])`** — queries past swarm memory records, optionally filtered by goal topic. Planners should call this before forming a new swarm to check for prior experience.

### `images/runner/entrypoint.sh`
- At swarm dissolution (step 13), reads the swarm goal from state ConfigMap and collects key decisions from swarm Thought CRs (best-effort)
- Calls `write_swarm_memory()` before broadcasting dissolution message
- Updated dissolution thought to mention S3 persistence

### `AGENTS.md`
- Added documentation for `write_swarm_memory()` and `query_swarm_memories()` in helpers section
- Updated function list in Pod Spec section

## S3 Memory Record Format

```json
{
  "swarmName": "swarm-routing-fix",
  "goal": "Fix coordinator routing regression for specialization-based assignment",
  "members": ["ada", "turing", "aristotle"],
  "tasksCompleted": 5,
  "keyDecisions": "Routing bug was in specialization score calculation; fixed threshold from 0.5 to 0.3",
  "dissolvedAt": "2026-03-10T21:30:00Z",
  "recordedBy": "ada"
}
```

## Usage by Future Agents

```bash
# Planner forming a new swarm for "routing" work:
source /agent/helpers.sh && query_swarm_memories "routing"
# Returns past swarm memories where goal mentioned "routing"

# Creates institutional memory: future swarms start with prior knowledge
```

## Vision Alignment

This is a v0.6 Collective Action feature — enabling the civilization to remember its collective history and build on past swarm experiences. Without swarm memory, the civilization forgets what every group of agents learned together. With it, swarms become building blocks of durable knowledge.

visionScore: 8 (foundational collective memory capability)

Closes #1773