### PR TITLE
perf: merge criteria 1/3/4 S3 loops into single pass in check_v05_milestone()

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2900,9 +2900,12 @@ check_v05_milestone() {
     local criteria_met=0
     local criteria_report=""
 
-    # ── Criterion 1: 3+ agents with promotedRole ─────────────────────────────
+    # ── Criteria 1, 3, 4: Single S3 scan loop (issue #1764 — was 3 separate loops) ──
+    # Download each identity file ONCE and extract all three metrics in a single pass.
+    # Reduces S3 API calls by 2/3x (50 downloads → ~17 downloads per check_v05_milestone call).
     local promoted_count=0
-    # Scan all identity files in S3 for promotedRole field
+    local proactive_count=0
+    local mentor_credit_count=0
     local identity_files
     identity_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/identities/" \
         --region "$BEDROCK_REGION" 2>/dev/null | \
@@ -2913,11 +2916,24 @@ check_v05_milestone() {
         ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
             --region "$BEDROCK_REGION" 2>/dev/null || echo "")
         [ -z "$ijson" ] && continue
+
+        # Criterion 1: promotedRole
         local prole
         prole=$(echo "$ijson" | jq -r '.promotedRole // ""' 2>/dev/null || echo "")
         [ -n "$prole" ] && promoted_count=$((promoted_count + 1))
+
+        # Criterion 3: proactiveIssuesFound stored under .stats.proactiveIssuesFound
+        local pif
+        pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
+        [ "$pif" -gt 0 ] 2>/dev/null && proactive_count=$((proactive_count + 1))
+
+        # Criterion 4: mentorCredits is an ARRAY at .specializationDetail.mentorCredits
+        local mc
+        mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
+        [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
     done
 
+    # ── Criterion 1 verdict ───────────────────────────────────────────────────
     if [ "$promoted_count" -ge 3 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 1: Dynamic role promotions — ${promoted_count} agents promoted\n"
@@ -2945,20 +2961,7 @@ check_v05_milestone() {
     fi
     echo "[$(date -u +%H:%M:%S)] v0.5 Criterion 2: ${edge_count} trust graph edges (need 5)"
 
-    # ── Criterion 3: 2+ agents with proactiveIssuesFound > 0 ─────────────────
-    local proactive_count=0
-    for ifile in $identity_files; do
-        local ijson
-        ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
-            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
-        [ -z "$ijson" ] && continue
-        local pif
-        # Issue #1759: proactiveIssuesFound is stored under .stats.proactiveIssuesFound
-        # NOT at top-level .proactiveIssuesFound (which is how identity.sh writes it).
-        pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
-        [ "$pif" -gt 0 ] 2>/dev/null && proactive_count=$((proactive_count + 1))
-    done
-
+    # ── Criterion 3 verdict ───────────────────────────────────────────────────
     if [ "$proactive_count" -ge 2 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 3: Proactive issue discovery — ${proactive_count} agents discovered issues\n"
@@ -2967,22 +2970,7 @@ check_v05_milestone() {
     fi
     echo "[$(date -u +%H:%M:%S)] v0.5 Criterion 3: ${proactive_count} agents with proactiveIssuesFound > 0 (need 2)"
 
-    # ── Criterion 4: 1+ agent with mentorCredits > 0 ─────────────────────────
-    local mentor_credit_count=0
-    for ifile in $identity_files; do
-        local ijson
-        ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
-            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
-        [ -z "$ijson" ] && continue
-        local mc
-        # Issue #1759: mentorCredits is stored as an ARRAY at
-        # .specializationDetail.mentorCredits (written by credit_mentor_for_success() in helpers.sh).
-        # It is NOT a top-level integer .mentorCredits.
-        # Check if array has at least 1 entry using | length.
-        mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
-        [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
-    done
-
+    # ── Criterion 4 verdict ───────────────────────────────────────────────────
     if [ "$mentor_credit_count" -ge 1 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 4: Mentor credit loop — ${mentor_credit_count} mentor(s) credited\n"


### PR DESCRIPTION
## Summary

Merges the three separate S3 download loops for criteria 1, 3, and 4 of `check_v05_milestone()` into a single loop that downloads each identity file once and extracts all three metrics in a single pass.

Closes #1764

## Changes

- `images/runner/coordinator.sh`: Replaced 3 separate `for ifile in $identity_files` loops (one for criterion 1, one for criterion 3, one for criterion 4) with a single combined loop that extracts `promotedRole`, `proactiveIssuesFound`, and `mentorCredits` in one S3 download pass.

## Impact

- **Reduces S3 API calls by 2/3x**: ~50 downloads → ~17 downloads per `check_v05_milestone()` call
- **Reduces milestone check latency**: Each S3 cp adds ~50-100ms; saving ~33 calls saves ~3-5 seconds per check
- **No behavior change**: Same counters incremented, same thresholds (promoted ≥ 3, proactive ≥ 2, mentor ≥ 1), same criteria_report strings

## Testing

Logic is identical to before — only the structure changed (3 loops → 1 loop). All three metric extractions use the same jq expressions as the original code.