### PR TITLE
feat: add activeSwarms tracking for v0.6 Swarm Intelligence observability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1112,6 +1112,7 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `agentTrustGraph`: Pipe-separated trust edges built from `cite_debate_outcome()` calls (v0.5, issue #1734). Format: `citingAgent:citedAgent:count|...`. Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust. Queryable via `get_trust_graph()` in helpers.sh. Used by future coordinator routing to prefer agents that trusted specialists already endorse for complex issues.
 - `v05MilestoneStatus`: Set to `"completed"` by `check_v05_milestone()` when all 5 v0.5 Emergent Specialization success criteria are met (issue #1752). Empty until completion. Once set, `check_v05_milestone()` skips subsequent checks (idempotent).
 - `v05CriteriaStatus`: Human-readable status string from the last `check_v05_milestone()` run (issue #1752). Format: `"N/5 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.5 milestone progress without reading S3 identities.
+- `activeSwarms`: Pipe-separated active swarm entries (v0.6, issue #1775). Format: `"swarm-name:goal-summary|swarm-name2:goal-summary2|..."`. Updated by `track_active_swarms()` every ~2.5 min. Empty when no swarms are active. Read by `civilization_status()` for swarm health observability. Foundation for coordinator-driven swarm automation.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1132,6 +1133,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQue
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05MilestoneStatus}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05CriteriaStatus}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.activeSwarms}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -392,6 +392,17 @@ ensure_state_fields_initialized() {
       -p '{"data":{"v05CriteriaStatus":""}}' 2>/dev/null || true
   fi
 
+  # activeSwarms (issue #1775, v0.6 Swarm Intelligence): comma-separated list of active swarm names
+  # with their goals. Format: "swarm-name:goal-summary|swarm-name2:goal-summary2|..."
+  # Updated by track_active_swarms() every 5 iterations (~2.5 min) in the main loop.
+  # civilization_status() reads this field for swarm health observability.
+  # Empty string means no active swarms (normal state before v0.6 swarm automation).
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("activeSwarms")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing activeSwarms (was absent, issue #1775)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"activeSwarms":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.
@@ -1113,6 +1124,48 @@ cleanup_orphaned_pods() {
 
     echo "[$(date -u +%H:%M:%S)] Deleted $deleted_count orphaned pods"
     push_metric "OrphanedPodsDeleted" "$deleted_count" "Count" "Component=Coordinator"
+}
+
+# track_active_swarms — Count and summarize non-Disbanded swarms (issue #1775, v0.6)
+# Scans ConfigMaps with label agentex/swarm that are in Forming or Active phase.
+# Writes activeSwarms field to coordinator-state as pipe-separated "name:goal" entries.
+# Called every 5 iterations (~2.5 min) in the main loop.
+# This establishes observability (Success Criterion 4) before automation features are added.
+track_active_swarms() {
+    # Find swarm state ConfigMaps: they have the agentex/swarm label and a phase field
+    # that is either "Forming" or "Active" (not "Disbanded")
+    local swarm_summary=""
+    local active_count=0
+
+    # Get all ConfigMaps with a goal field (swarm state CMs have goal + phase)
+    while IFS=$'\t' read -r name phase goal; do
+        [ -z "$name" ] && continue
+        [ -z "$phase" ] && continue
+        # Only include non-disbanded swarms
+        if [ "$phase" != "Disbanded" ]; then
+            active_count=$((active_count + 1))
+            # Truncate goal to 60 chars for readability
+            local short_goal
+            short_goal=$(printf '%s' "${goal:-unknown}" | cut -c1-60)
+            if [ -z "$swarm_summary" ]; then
+                swarm_summary="${name}:${short_goal}"
+            else
+                swarm_summary="${swarm_summary}|${name}:${short_goal}"
+            fi
+        fi
+    done < <(kubectl_with_timeout 15 get configmaps -n "$NAMESPACE" \
+        -l "agentex/swarm" -o json 2>/dev/null | \
+        jq -r '.items[] | select(.data.goal != null) | [.metadata.name, (.data.phase // ""), (.data.goal // "")] | @tsv' \
+        2>/dev/null || true)
+
+    update_state "activeSwarms" "$swarm_summary"
+
+    if [ "$active_count" -gt 0 ]; then
+        echo "[$(date -u +%H:%M:%S)] track_active_swarms: $active_count active swarm(s): $swarm_summary"
+        push_metric "ActiveSwarms" "$active_count" "Count" "Component=Coordinator"
+    else
+        push_metric "ActiveSwarms" 0 "Count" "Component=Coordinator"
+    fi
 }
 
 # cleanup_old_cluster_resources — Periodically delete stale Thought and Message CRs (issue #1617)
@@ -3987,6 +4040,13 @@ while true; do
     # are deleted without cascade-deleting their pods (historical behavior pre-TTL governance).
     if [ $((iteration % 10)) -eq 0 ]; then
         cleanup_orphaned_pods
+    fi
+
+    # Every 5 iterations (~2.5 min): update activeSwarms in coordinator-state (issue #1775, v0.6)
+    # Tracks non-Disbanded Swarm state ConfigMaps for swarm health observability.
+    # This is the foundational observability step before coordinator-driven swarm automation.
+    if [ $((iteration % 5)) -eq 0 ]; then
+        track_active_swarms
     fi
 
     # NOTE (issue #867): Planner-chain liveness check removed.

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -897,6 +897,19 @@ civilization_status() {
   fi
   output="${output}Coordinator heartbeat:   ${last_heartbeat}${heartbeat_age}\n"
 
+  # Active swarms (v0.6, issue #1775 — Swarm Intelligence observability)
+  local active_swarms
+  active_swarms=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.activeSwarms}' 2>/dev/null || echo "")
+  if [ -z "$active_swarms" ]; then
+    output="${output}Active swarms:           none (v0.6 swarm automation not yet triggered)\n"
+  else
+    # Count swarms: pipe-separated entries
+    local swarm_count
+    swarm_count=$(printf '%s' "$active_swarms" | tr '|' '\n' | grep -c . 2>/dev/null || echo "0")
+    output="${output}Active swarms:           ${swarm_count} active — ${active_swarms}\n"
+  fi
+
   printf "%b" "$output"
 }
 


### PR DESCRIPTION
## Summary

- Adds `activeSwarms` field to `coordinator-state` ConfigMap that tracks non-Disbanded swarm state ConfigMaps
- Coordinator scans every 2.5 min (`track_active_swarms()`) and writes swarm names + goal summaries
- `civilization_status()` in helpers.sh now shows swarm health (count + goal summaries)
- Documents `activeSwarms` field in AGENTS.md coordinator state reference

Closes #1775

## Changes

### coordinator.sh
- Add `activeSwarms` initialization in `ensure_state_fields_initialized()` (hot-initialized like other state fields)
- Add `track_active_swarms()` function that scans ConfigMaps with `agentex/swarm` label for non-Disbanded phases
- Call `track_active_swarms()` in the main loop every 5 iterations (~2.5 min)
- Emit `ActiveSwarms` CloudWatch metric for operational visibility

### helpers.sh
- Add "Active swarms" section to `civilization_status()` output
- Shows swarm count and name:goal summary when swarms are active
- Shows informational message when no swarms are active (expected until v0.6 automation)

### AGENTS.md
- Document `activeSwarms` field in the Coordinator State section
- Add kubectl read command for the new field

## Why This PR

Issue #1775 is the v0.6 Swarm Intelligence milestone. The issue explicitly identifies the "Proposed First Step (XS effort)" as:
> Add `activeSwarms` field to coordinator-state initialization. Begin tracking active Swarm CRs in coordinator main loop.

This PR implements exactly that first step: establishing observability before the full automation features (coordinator-driven swarm spawning, specialist recruitment) are added in subsequent PRs.

## Test Verification

- `bash -n coordinator.sh` passes (syntax check clean)
- `bash -n helpers.sh` passes (syntax check clean)
- No behavior change when no swarms exist (empty field + informational status message)
- When swarms exist with `agentex/swarm` label and `phase != Disbanded`, they are counted and summarized