### PR TITLE
fix: sync entrypoint.sh claim_task with helpers.sh — add PR check and planner guard (closes #1783)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1365,6 +1365,34 @@ claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
 
+  # Issue #1669: Planners should spawn workers for issues, not claim them directly.
+  # Planner assignments become ghost entries that block workers from claiming the same issues,
+  # because planners exit after spawning workers (not after implementing the issue).
+  local calling_role="${AGENT_ROLE:-}"
+  if [ "$calling_role" = "planner" ]; then
+    log "Coordinator: planners should not claim issues — spawn a worker for issue #$issue instead (role=$calling_role)"
+    return 1
+  fi
+
+  # Issue #1672 / #1783: Check if an open PR already exists for this issue before claiming.
+  # The coordinator's task queue refresh (refresh_task_queue) already skips issues
+  # with open PRs, but agents that self-select via direct claim_task() bypass that check.
+  # This pre-claim PR check prevents duplicate PR implementations when multiple agents
+  # see the same open issue and race to claim it after a stale assignment is released.
+  # NOTE: This check was originally added to helpers.sh only (issue #1672), leaving the
+  # entrypoint.sh copy unprotected — causing the duplicate PRs observed in issue #1783.
+  local github_repo="${REPO:-pnz1990/agentex}"
+  local open_pr_url
+  open_pr_url=$(gh api "/repos/${github_repo}/pulls?state=open&per_page=100" 2>/dev/null | \
+    jq -r --arg n "$issue" \
+    '.[] | select(.body // "" | test("(C|c)loses? #\($n)\\b|(F|f)ixes? #\($n)\\b|(R|r)esolves? #\($n)\\b")) | .html_url' \
+    2>/dev/null | head -1)
+  if [ -n "$open_pr_url" ]; then
+    log "Coordinator: issue #$issue already has open PR — skipping to prevent duplicate implementation (PR: $open_pr_url)"
+    push_metric "TaskClaimBlockedByPR" 1
+    return 1
+  fi
+
   local max_attempts=5
   local attempt=0
 


### PR DESCRIPTION
## Summary

Fixes issue #1783: `entrypoint.sh`'s `claim_task()` was missing two safety checks that were added to `helpers.sh` in issue #1672 but never backported to the entrypoint copy.

## Changes

- **Planner role guard**: Planners calling `claim_task()` now get an explicit rejection with log message (issue #1669 pattern)
- **Open PR check**: Before claiming, the function now checks if an open PR already covers the issue via `Closes #N` / `Fixes #N` in PR bodies (issue #1672 pattern, backported from helpers.sh)

## Root Cause

`entrypoint.sh` and `helpers.sh` each define their own `claim_task()`. When issue #1672 added the open-PR check to `helpers.sh`, it was NOT added to `entrypoint.sh`. Workers running in the runner context call the entrypoint.sh version, bypassing the PR guard.

**Evidence**: In session 2026-03-10T21:30Z, three issues (#1764, #1772, #1773) each accumulated two open PRs despite claim_task being called.

## Constitution Alignment

This file is protected and requires `god-approved`. This change:
- ✅ Fixes a bug without changing intended behavior  
- ✅ Enforces existing constitution rules (issue #1672 open-PR guard, issue #1669 planner guard)
- ✅ Does not expand agent autonomy
- ✅ No new behavior added — backports existing checks to consistent state

Closes #1783

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior — backports existing checks from helpers.sh
- [x] Cites relevant constitution/vision sections: issue #1672 (PR dedup), issue #1669 (planner claim guard)
- [x] Linked to GitHub issue #1783
- [x] Does not expand agent autonomy or bypass safety mechanisms