### PR TITLE
fix: add open-PR check and planner guard to entrypoint.sh claim_task()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1361,9 +1361,38 @@ append_to_chronicle() {
 # can claim a given issue even under concurrent access.
 # Usage: claim_task <issue_number>
 # Returns: 0 if claim succeeded, 1 if already claimed by another agent or on error
+#
+# Issue #1669: Planners should spawn workers for issues, not claim them directly.
+# Issue #1672: Also checks for existing open PRs before claiming to prevent duplicate work.
 claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
+
+  # Issue #1669: Planners should spawn workers for issues, not claim them directly.
+  # Planner assignments become ghost entries that block workers from claiming the same issues,
+  # because planners exit after spawning workers (not after implementing the issue).
+  local calling_role="${AGENT_ROLE:-}"
+  if [ "$calling_role" = "planner" ]; then
+    log "Coordinator: planners should not claim issues — spawn a worker for issue #$issue instead (role=$calling_role)"
+    return 1
+  fi
+
+  # Issue #1672: Check if an open PR already exists for this issue before claiming.
+  # The coordinator's task queue refresh (refresh_task_queue) already skips issues
+  # with open PRs, but agents that self-select via direct claim_task() bypass that check.
+  # This pre-claim PR check prevents duplicate PR implementations when multiple agents
+  # see the same open issue and race to claim it after a stale assignment is released.
+  local github_repo="${REPO:-pnz1990/agentex}"
+  local open_pr_url
+  open_pr_url=$(gh api "/repos/${github_repo}/pulls?state=open&per_page=100" 2>/dev/null | \
+    jq -r --arg n "$issue" \
+    '.[] | select(.body // "" | test("(C|c)loses? #\($n)\\b|(F|f)ixes? #\($n)\\b|(R|r)esolves? #\($n)\\b")) | .html_url' \
+    2>/dev/null | head -1)
+  if [ -n "$open_pr_url" ]; then
+    log "Coordinator: issue #$issue already has open PR — skipping to prevent duplicate implementation (PR: $open_pr_url)"
+    push_metric "TaskClaimBlockedByPR" 1
+    return 1
+  fi
 
   local max_attempts=5
   local attempt=0


### PR DESCRIPTION
## Summary

Ports the two safety checks from `helpers.sh` `claim_task()` to `entrypoint.sh` `claim_task()`, fixing the root cause of duplicate PR proliferation (6 duplicate PRs across 3 issues observed in session 2026-03-10T21:30-21:35Z).

## Problem

`entrypoint.sh` and `helpers.sh` each define their own `claim_task()` function. Issue #1672 added an open-PR check to `helpers.sh` only. The copy in `entrypoint.sh` (runner context — used when agents run in pods) was NOT updated.

This means when agents running in pods call `claim_task`, they skip both:
1. The **planner guard** — planners were claiming issues directly, leaving ghost assignments
2. The **open-PR check** — multiple workers could claim and implement the same issue

## Changes

In `images/runner/entrypoint.sh`, inside `claim_task()`, added immediately after the null guard:

1. **Planner role guard** (issue #1669): Returns 1 if `AGENT_ROLE=planner`, preventing planner ghost assignments that block workers.

2. **Open-PR check** (issue #1672): Calls GitHub API to check if an open PR already closes/fixes/resolves the issue before proceeding with the CAS claim. Returns 1 with `push_metric "TaskClaimBlockedByPR" 1` if a PR exists.

## Impact

- Eliminates ~50% wasted compute from duplicate PR workers
- `entrypoint.sh` and `helpers.sh` `claim_task()` are now functionally equivalent
- No behavior change for workers claiming unclaimed issues without open PRs

Closes #1783