### PR TITLE
fix: add planner guard and open-PR check to entrypoint.sh claim_task()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1365,6 +1365,32 @@ claim_task() {
   local issue="$1"
   [ -z "$issue" ] || [ "$issue" = "0" ] && return 1
 
+  # Issue #1669: Planners should spawn workers for issues, not claim them directly.
+  # Planner assignments become ghost entries that block workers from claiming the same issues,
+  # because planners exit after spawning workers (not after implementing the issue).
+  local calling_role="${AGENT_ROLE:-}"
+  if [ "$calling_role" = "planner" ]; then
+    log "Coordinator: planners should not claim issues — spawn a worker for issue #$issue instead (role=$calling_role)"
+    return 1
+  fi
+
+  # Issue #1672: Check if an open PR already exists for this issue before claiming.
+  # The coordinator's task queue refresh (refresh_task_queue) already skips issues
+  # with open PRs, but workers that self-select via direct claim_task() bypass that check.
+  # This pre-claim PR check prevents duplicate PR implementations when multiple agents
+  # see the same open issue and race to claim it after a stale assignment is released.
+  local github_repo="${REPO:-pnz1990/agentex}"
+  local open_pr_url
+  open_pr_url=$(gh api "/repos/${github_repo}/pulls?state=open&per_page=100" 2>/dev/null | \
+    jq -r --arg n "$issue" \
+    '.[] | select(.body // "" | test("(C|c)loses? #\($n)\\b|(F|f)ixes? #\($n)\\b|(R|r)esolves? #\($n)\\b")) | .html_url' \
+    2>/dev/null | head -1)
+  if [ -n "$open_pr_url" ]; then
+    log "Coordinator: issue #$issue already has open PR — skipping to prevent duplicate implementation (PR: $open_pr_url)"
+    push_metric "TaskClaimBlockedByPR" 1
+    return 1
+  fi
+
   local max_attempts=5
   local attempt=0
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where `entrypoint.sh`'s `claim_task()` was missing two safety guards that `helpers.sh` already had, causing duplicate PR proliferation.

Closes #1783

## Root Cause

`helpers.sh` (OpenCode context) had two guards added in issue #1669 and #1672:
1. **Planner role guard**: prevents planners from claiming issues (they should spawn workers)
2. **Open-PR pre-check**: prevents claiming issues that already have an open PR

`entrypoint.sh` (runner/bash context) `claim_task()` was NOT updated with either guard — creating a second, diverged implementation that allowed both failure modes.

## Evidence of Impact

Observed 2026-03-10: 6 duplicate PRs across 3 issues in a single session:
- Issue #1764 → PRs #1768 AND #1780 (both open)
- Issue #1772 → PRs #1774 AND #1778 (both open)
- Issue #1773 → PRs #1777 AND #1779 (both open)

## Changes

Added to `entrypoint.sh` `claim_task()` at the function top, before the CAS loop:
1. **Planner role guard** — returns 1 if `AGENT_ROLE=planner` with informative log message
2. **Open-PR pre-check** — queries GitHub `/repos/{repo}/pulls?state=open` and matches against `Closes/Fixes/Resolves #N` in PR bodies (identical jq filter to `helpers.sh`)

## Testing

`bash -n images/runner/entrypoint.sh` — syntax clean. Logic is identical to the proven `helpers.sh` implementation.