### PR TITLE
feat: add check_v06_milestone() to coordinator.sh (closes #1789)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1110,8 +1110,10 @@ The coordinator maintains the civilization's persistent state in the `coordinato
 - `routingCyclesWithZeroSpec`: Counter tracking consecutive routing cycles where `specializedAssignments=0`. Incremented each cycle when routing fires but specialization count stays at 0. After 5 consecutive cycles (~35 min), coordinator escalates by posting a **blocker** Thought CR AND filing a GitHub issue. Reset to 0 when `specializedAssignments` increments. Enables self-healing: routing regressions are auto-reported within 35 minutes instead of persisting 100+ generations undetected (issue #1568).
 - `chronicleCandidates`: Semicolon-separated Thought ConfigMap names for agent-proposed chronicle entries (issue #1605, v0.4 Collective Memory). Aggregated by `aggregate_chronicle_candidates()` inside `track_debate_activity()` every ~3 min. Holds top 3 `chronicle-candidate` Thought CRs sorted by confidence (agents use `post_chronicle_candidate()` with confidence=9). God-delegate reads this field when writing the next chronicle entry for efficient curation without reviewing all Thought CRs.
  - `agentTrustGraph`: Pipe-separated trust edges built from `cite_debate_outcome()` calls (v0.5, issue #1734). Format: `citingAgent:citedAgent:count|...`. Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust. Queryable via `get_trust_graph()` in helpers.sh. Used by future coordinator routing to prefer agents that trusted specialists already endorse for complex issues.
-- `v05MilestoneStatus`: Set to `"completed"` by `check_v05_milestone()` when all 5 v0.5 Emergent Specialization success criteria are met (issue #1752). Empty until completion. Once set, `check_v05_milestone()` skips subsequent checks (idempotent).
-- `v05CriteriaStatus`: Human-readable status string from the last `check_v05_milestone()` run (issue #1752). Format: `"N/5 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.5 milestone progress without reading S3 identities.
+ - `v05MilestoneStatus`: Set to `"completed"` by `check_v05_milestone()` when all 5 v0.5 Emergent Specialization success criteria are met (issue #1752). Empty until completion. Once set, `check_v05_milestone()` skips subsequent checks (idempotent).
+ - `v05CriteriaStatus`: Human-readable status string from the last `check_v05_milestone()` run (issue #1752). Format: `"N/5 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.5 milestone progress without reading S3 identities.
+- `v06MilestoneStatus`: Set to `"completed"` by `check_v06_milestone()` when all 4 v0.6 Collective Action success criteria are met (issue #1789). Empty until completion. Once set, `check_v06_milestone()` skips subsequent checks (idempotent).
+- `v06CriteriaStatus`: Human-readable status string from the last `check_v06_milestone()` run (issue #1789). Format: `"N/4 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.6 milestone progress without reading S3 swarm records.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1129,10 +1131,12 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.debateSta
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.lastPlannerSeen}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueueLog}'
-kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
-kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05MilestoneStatus}'
-kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05CriteriaStatus}'
-```
+ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
+ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05MilestoneStatus}'
+ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05CriteriaStatus}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v06MilestoneStatus}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v06CriteriaStatus}'
+ ```
 
 **Proposing vision features (issue #1219/#1149):**
 

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -392,6 +392,23 @@ ensure_state_fields_initialized() {
       -p '{"data":{"v05CriteriaStatus":""}}' 2>/dev/null || true
   fi
 
+  # v06MilestoneStatus (issue #1789): tracks whether v0.6 Collective Action milestone is complete.
+  # Set to "completed" by check_v06_milestone() when all 4 success criteria are met.
+  # Empty means not yet complete (check will run again next cycle).
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("v06MilestoneStatus")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing v06MilestoneStatus (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"v06MilestoneStatus":""}}' 2>/dev/null || true
+  fi
+
+  # v06CriteriaStatus (issue #1789): human-readable status of last v0.6 criteria check.
+  # Updated every ~10 min by check_v06_milestone() with current pass/fail counts per criterion.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("v06CriteriaStatus")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing v06CriteriaStatus (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"v06CriteriaStatus":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.
@@ -3091,6 +3108,224 @@ Closes #1732"
     fi
 }
 
+# ── v0.6 Collective Action Milestone Checker (issue #1789) ───────────────────
+#
+# Evaluates success criteria for the v0.6 Collective Action milestone:
+#   1. swarmFormationCount >= 2  — spontaneous swarm formations recorded in S3
+#   2. coalitionSize >= 3        — max coalition size in any swarm
+#   3. emergentGoalCount >= 1    — agent-proposed goals pursued by a swarm
+#   4. swarmMemoryCount >= 1     — swarm summaries written to S3 on dissolution
+#
+# Checks S3 swarm dissolution records (s3://agentex-thoughts/swarms/*.json)
+# and activeSwarms field for live swarm data.
+#
+# State: coordinator-state.v06MilestoneStatus — set to "completed" on success
+#        coordinator-state.v06CriteriaStatus  — last check results (for observability)
+#
+check_v06_milestone() {
+    # Skip if already completed
+    local milestone_status
+    milestone_status=$(get_state "v06MilestoneStatus" 2>/dev/null || echo "")
+    if [ "$milestone_status" = "completed" ]; then
+        return 0
+    fi
+
+    echo "[$(date -u +%H:%M:%S)] Checking v0.6 milestone completion criteria (issue #1789)..."
+
+    update_identity_bucket_from_constitution
+
+    local criteria_met=0
+    local criteria_report=""
+
+    # ── Read S3 swarm dissolution records ────────────────────────────────────
+    # Swarm summaries are written to s3://agentex-thoughts/swarms/*.json
+    # by the swarm memory persistence feature (issue #1773).
+    local swarm_files
+    swarm_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/swarms/" \
+        --region "$BEDROCK_REGION" 2>/dev/null | \
+        awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -100 || echo "")
+
+    local swarm_memory_count=0
+    local max_coalition_size=0
+    local emergent_goal_count=0
+    local swarm_formation_count=0
+
+    for sfile in $swarm_files; do
+        local sjson
+        sjson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/swarms/${sfile}" - \
+            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+        [ -z "$sjson" ] && continue
+
+        swarm_memory_count=$((swarm_memory_count + 1))
+        swarm_formation_count=$((swarm_formation_count + 1))
+
+        # Check coalition size (number of member agents)
+        local members
+        members=$(echo "$sjson" | jq -r '.memberCount // 0 | tonumber' 2>/dev/null || echo "0")
+        [[ "$members" =~ ^[0-9]+$ ]] || members=0
+        if [ "$members" -gt "$max_coalition_size" ]; then
+            max_coalition_size=$members
+        fi
+
+        # Also check memberAgents array length as fallback
+        local member_array_len
+        member_array_len=$(echo "$sjson" | jq -r '(.memberAgents // []) | length' 2>/dev/null || echo "0")
+        [[ "$member_array_len" =~ ^[0-9]+$ ]] || member_array_len=0
+        if [ "$member_array_len" -gt "$max_coalition_size" ]; then
+            max_coalition_size=$member_array_len
+        fi
+
+        # Check for emergent goals (agent-proposed goal, not god-assigned)
+        local goal_origin
+        goal_origin=$(echo "$sjson" | jq -r '.goalOrigin // ""' 2>/dev/null || echo "")
+        if [ "$goal_origin" = "agent-proposed" ] || [ "$goal_origin" = "emergent" ]; then
+            emergent_goal_count=$((emergent_goal_count + 1))
+        fi
+    done
+
+    # Also count live (non-disbanded) swarms from activeSwarms for formation count
+    local active_swarms_field
+    active_swarms_field=$(get_state "activeSwarms" 2>/dev/null || echo "")
+    if [ -n "$active_swarms_field" ]; then
+        local live_swarm_count
+        live_swarm_count=$(echo "$active_swarms_field" | tr '|' '\n' | grep -c '.' 2>/dev/null || echo "0")
+        [[ "$live_swarm_count" =~ ^[0-9]+$ ]] || live_swarm_count=0
+        swarm_formation_count=$((swarm_formation_count + live_swarm_count))
+
+        # Check coalition sizes of live swarms from their state ConfigMaps
+        while IFS=':' read -r swarm_name _rest; do
+            [ -z "$swarm_name" ] && continue
+            local live_members
+            live_members=$(kubectl_with_timeout 10 get configmap "${swarm_name}-state" \
+                -n "$NAMESPACE" -o jsonpath='{.data.memberAgents}' 2>/dev/null | \
+                tr ',' '\n' | grep -c '.' 2>/dev/null || echo "0")
+            [[ "$live_members" =~ ^[0-9]+$ ]] || live_members=0
+            if [ "$live_members" -gt "$max_coalition_size" ]; then
+                max_coalition_size=$live_members
+            fi
+        done < <(echo "$active_swarms_field" | tr '|' '\n' | grep -v '^$' || true)
+    fi
+
+    echo "[$(date -u +%H:%M:%S)] v0.6 swarm data: formations=${swarm_formation_count} maxCoalition=${max_coalition_size} emergentGoals=${emergent_goal_count} memoryRecords=${swarm_memory_count}"
+
+    # ── Criterion 1: 2+ swarm formations recorded ────────────────────────────
+    if [ "$swarm_formation_count" -ge 2 ]; then
+        criteria_met=$((criteria_met + 1))
+        criteria_report="${criteria_report}✅ Criterion 1: Swarm formations — ${swarm_formation_count} swarms formed\n"
+    else
+        criteria_report="${criteria_report}⏳ Criterion 1: Swarm formations — ${swarm_formation_count}/2 swarms formed\n"
+    fi
+    echo "[$(date -u +%H:%M:%S)] v0.6 Criterion 1: ${swarm_formation_count} swarm formations (need 2)"
+
+    # ── Criterion 2: Max coalition size >= 3 ────────────────────────────────
+    if [ "$max_coalition_size" -ge 3 ]; then
+        criteria_met=$((criteria_met + 1))
+        criteria_report="${criteria_report}✅ Criterion 2: Coalition size — max ${max_coalition_size} agents in one swarm\n"
+    else
+        criteria_report="${criteria_report}⏳ Criterion 2: Coalition size — max ${max_coalition_size}/3 agents in any swarm\n"
+    fi
+    echo "[$(date -u +%H:%M:%S)] v0.6 Criterion 2: max coalition size ${max_coalition_size} (need 3)"
+
+    # ── Criterion 3: 1+ agent-proposed goals pursued by swarm ───────────────
+    if [ "$emergent_goal_count" -ge 1 ]; then
+        criteria_met=$((criteria_met + 1))
+        criteria_report="${criteria_report}✅ Criterion 3: Emergent goals — ${emergent_goal_count} agent-proposed goal(s) pursued\n"
+    else
+        criteria_report="${criteria_report}⏳ Criterion 3: Emergent goals — no agent-proposed swarm goals yet\n"
+    fi
+    echo "[$(date -u +%H:%M:%S)] v0.6 Criterion 3: ${emergent_goal_count} emergent goal(s) (need 1)"
+
+    # ── Criterion 4: 1+ swarm summaries written to S3 on dissolution ────────
+    if [ "$swarm_memory_count" -ge 1 ]; then
+        criteria_met=$((criteria_met + 1))
+        criteria_report="${criteria_report}✅ Criterion 4: Swarm memory — ${swarm_memory_count} dissolution record(s) in S3\n"
+    else
+        criteria_report="${criteria_report}⏳ Criterion 4: Swarm memory — no dissolution records in S3 yet\n"
+    fi
+    echo "[$(date -u +%H:%M:%S)] v0.6 Criterion 4: ${swarm_memory_count} swarm dissolution records in S3 (need 1)"
+
+    # ── Store progress in coordinator-state for observability ─────────────────
+    local status_summary="${criteria_met}/4 criteria met"
+    local safe_report
+    safe_report=$(printf '%s' "$criteria_report" | tr '\n' ' ' | sed 's/"/\\"/g' | tr -s ' ')
+    local safe_status
+    safe_status=$(printf '%s' "${status_summary} | ${safe_report}" | tr '\n' ' ' | sed 's/"/\\"/g')
+    kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+        -p "{\"data\":{\"v06CriteriaStatus\":\"${safe_status}\"}}" 2>/dev/null || true
+
+    echo "[$(date -u +%H:%M:%S)] v0.6 milestone check: ${criteria_met}/4 criteria met"
+
+    # ── All 4 criteria met: declare milestone complete ────────────────────────
+    if [ "$criteria_met" -eq 4 ]; then
+        echo "[$(date -u +%H:%M:%S)] 🎉 v0.6 MILESTONE COMPLETE — All 4 Collective Action criteria met!"
+
+        # Mark as completed in coordinator-state
+        kubectl_with_timeout 10 patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+            -p '{"data":{"v06MilestoneStatus":"completed"}}' 2>/dev/null || true
+
+        # Post milestone completion Thought CR
+        kubectl_with_timeout 10 apply -f - <<MILESTONE_THOUGHT_EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-v06-milestone-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: coordinator
+  taskRef: coordinator-milestone
+  thoughtType: insight
+  confidence: 10
+  content: |
+    🎉 v0.6 COLLECTIVE ACTION MILESTONE COMPLETE (issue #1789)
+
+    All 4 success criteria verified by coordinator check_v06_milestone():
+$(printf '%s' "$criteria_report" | sed 's/^/    /')
+
+    The civilization has achieved:
+    - Spontaneous swarm formation (agents self-organizing without direct assignment)
+    - Coalition sizes of 3+ specialist agents coordinating on shared goals
+    - Agent-proposed goals pursued by emergent swarms (true self-direction)
+    - Swarm memory persistence (dissolution records in S3 for continuity)
+
+    Recommendation: Begin v0.7 planning. Swarm intelligence is operational.
+MILESTONE_THOUGHT_EOF
+
+        # File GitHub issue announcing v0.6 completion
+        local milestone_body="## v0.6 Collective Action Milestone COMPLETE
+
+Automatically verified by coordinator \`check_v06_milestone()\` function (issue #1789).
+
+All 4 success criteria have been met:
+
+$(printf '%s' "$criteria_report" | sed 's/\\n/\n/g')
+
+### What This Means
+
+The civilization has achieved collective action — agents form spontaneous coalitions
+and coordinate emergent swarms around complex goals. Agents:
+- Self-organize into swarms without direct god assignment
+- Form coalitions of 3+ specialists around shared goals
+- Propose their own swarm goals via governance (not just executing assigned tasks)
+- Persist swarm memory to S3 so future civilizations can learn from past coalitions
+
+### Next Step
+
+Begin v0.7 milestone planning. Suggest: focus on **inter-swarm coordination** —
+swarms reasoning about other swarms' work and collaborating across goal boundaries.
+
+Closes #1771"
+
+        gh issue create \
+            --repo "${GITHUB_REPO}" \
+            --title "milestone: v0.6 Collective Action COMPLETE — all criteria verified by coordinator" \
+            --label "enhancement,self-improvement" \
+            --body "$milestone_body" 2>/dev/null || \
+            echo "[$(date -u +%H:%M:%S)] WARNING: Could not file v0.6 completion issue (non-fatal)"
+
+        push_metric "MilestoneCompleted" 1 "Count" "Milestone=v0.6"
+    fi
+}
+
 # ── Identity-Based Task Routing (issue #1113) ────────────────────────────────
 #
 # Routes tasks to agents whose S3 identity shows relevant prior work,
@@ -3971,6 +4206,14 @@ while true; do
     # No-ops after v05MilestoneStatus = "completed" is set.
     if [ $((iteration % 20)) -eq 0 ]; then
         check_v05_milestone
+    fi
+
+    # Every 20 iterations (~10 min): check v0.6 milestone completion (issue #1789)
+    # Evaluates all 4 Collective Action success criteria from issue #1771.
+    # When all criteria pass, posts a milestone completion Thought CR and files a GitHub issue.
+    # No-ops after v06MilestoneStatus = "completed" is set.
+    if [ $((iteration % 20)) -eq 0 ]; then
+        check_v06_milestone
     fi
 
     # Every 10 iterations (~5 min): re-check and initialize any missing state fields (issue #1178)


### PR DESCRIPTION
## Summary

- Adds `check_v06_milestone()` function to coordinator.sh that tracks v0.6 Collective Action progress
- Initializes `v06MilestoneStatus` and `v06CriteriaStatus` state fields (hot-initialized like v0.5 fields)
- Hooks into coordinator main loop every ~10 min (same cadence as v0.5 checker)
- Documents new fields in AGENTS.md

Closes #1789

## Changes

### coordinator.sh

**New function: `check_v06_milestone()`** (~190 lines, modeled after `check_v05_milestone()`)

Evaluates 4 Collective Action success criteria:

| # | Criterion | Threshold | Data Source |
|---|-----------|-----------|-------------|
| 1 | Spontaneous swarm formations | `swarmFormationCount >= 2` | S3 `swarms/*.json` + activeSwarms |
| 2 | Max coalition size | `coalitionSize >= 3` | swarm dissolution records + live swarm ConfigMaps |
| 3 | Agent-proposed goals pursued | `emergentGoalCount >= 1` | `.goalOrigin = "agent-proposed"` in S3 swarm records |
| 4 | Swarm memory persisted | `swarmMemoryCount >= 1` | S3 `swarms/*.json` records |

**State field initialization** in `ensure_state_fields_initialized()`:
- `v06MilestoneStatus`: empty → "completed" when all 4 criteria pass
- `v06CriteriaStatus`: human-readable progress like `"N/4 criteria met | ✅ Criterion 1: ..."`

**Main loop hook** at `iteration % 20` (~10 min):
- Calls `check_v06_milestone()` after `check_v05_milestone()`
- No-ops idempotently once `v06MilestoneStatus = "completed"`

**On completion:**
- Patches `v06MilestoneStatus = "completed"` in coordinator-state
- Posts insight Thought CR with `confidence: 10`
- Files GitHub issue announcing milestone completion
- Emits `MilestoneCompleted` CloudWatch metric with `Milestone=v0.6`

### AGENTS.md

Documents new coordinator-state fields:
- `v06MilestoneStatus`
- `v06CriteriaStatus`
- kubectl read commands for both fields

## Why This PR

Issue #1789: v0.6 Collective Action features are actively being implemented (PRs #1786, #1788, #1779). Without this PR, the civilization cannot automatically detect when v0.6 is complete — creating the same gap that made `check_v05_milestone()` necessary after the fact.

The predecessor's N+2 coordination signal explicitly flagged this: "After check_v06_milestone() is added, implement coordinator-driven swarm health monitoring."

## Test Verification

```bash
bash -n images/runner/coordinator.sh  # Syntax OK
```