### PR TITLE
perf: fix tally_votes early skip to use tight window after coordinator restart (closes #1798)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1605,6 +1605,21 @@ tally_and_enact_votes() {
         tally_cutoff_ts="$cutoff_24h"
       fi
 
+     # Issue #1798: Tight window for "no new votes" early skip check (separate from tally_cutoff_ts).
+     # tally_cutoff_ts can be up to 24h (needed to rebuild vote counts on restart), but
+     # the early skip check only needs votes since the LAST TALLY RUN to determine if a topic
+     # needs re-processing. Using the full 24h window causes all enacted topics to be re-processed
+     # (because old votes exist in the 24h window), preventing the early skip from firing.
+     # Fix: compute a tight cutoff based on last_tally_ts (or 10min ago as fallback).
+     local recent_tally_cutoff_ts
+     if [ -n "$last_tally_ts" ]; then
+       # Use last_tally_ts with 2-min buffer for clock skew — any vote after last tally is "new"
+       recent_tally_cutoff_ts=$(date -u -d "${last_tally_ts} -2 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "$last_tally_ts")
+     else
+       # On first run after restart, use 10-min window to catch genuine recent activity
+       recent_tally_cutoff_ts=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+     fi
+
      kubectl_with_timeout 10 get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null \
          | jq --arg cutoff "$tally_cutoff_ts" '[.items[] |
              select(.data.thoughtType == "proposal" or .data.thoughtType == "vote" or .data.thoughtType == "debate") |
@@ -1674,14 +1689,23 @@ tally_and_enact_votes() {
             is_vision_topic=true
         fi
         if [ "$is_vision_topic" = false ] && echo "$loop_enacted" | grep -qF "enacted_topic_${topic}"; then
-            # Topic has prior enactments. Check if there are ANY new proposal/vote thoughts for it.
-            # (If no new thoughts exist for this topic in the time window, the tally outcome
-            # cannot change — skip the full tally to save time.)
+            # Topic has prior enactments. Check if there are ANY new votes since the LAST TALLY RUN.
+            # Issue #1798: Use recent_tally_cutoff_ts (tight window since last tally) instead of
+            # the full thoughts_file window (up to 24h). The 24h window contains old votes for
+            # enacted topics, causing the early skip to never fire and processing 125+ topics × 5s
+            # per tally cycle (10+ min/cycle). The tight window ensures only genuinely new activity
+            # triggers re-processing.
             local new_votes_for_topic
-            new_votes_for_topic=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | .ts" \
-                "$thoughts_file" 2>/dev/null | wc -l | tr -d ' ')
+            if [ -n "$recent_tally_cutoff_ts" ]; then
+                new_votes_for_topic=$(jq -r --arg cutoff "$recent_tally_cutoff_ts" \
+                    ".[] | select(.type == \"vote\" and .ts >= \$cutoff and (.content | contains(\"#vote-$topic\"))) | .ts" \
+                    "$thoughts_file" 2>/dev/null | wc -l | tr -d ' ')
+            else
+                new_votes_for_topic=$(jq -r ".[] | select(.type == \"vote\" and (.content | contains(\"#vote-$topic\"))) | .ts" \
+                    "$thoughts_file" 2>/dev/null | wc -l | tr -d ' ')
+            fi
             if [ "$new_votes_for_topic" -eq 0 ]; then
-                echo "[$(date -u +%H:%M:%S)] $topic already enacted and no new votes — skipping"
+                echo "[$(date -u +%H:%M:%S)] $topic already enacted and no new votes since last tally — skipping"
                 continue
             fi
         fi


### PR DESCRIPTION
## Summary

Fixes a critical coordinator performance regression that causes `tally_votes()` to run for 10+ minutes per cycle after coordinator restart, effectively freezing milestone tracking.

## Problem

After coordinator restart, `tally_cutoff_ts` uses a 24h floor to rebuild vote counts from history. This causes `thoughts_file` to contain thousands of old votes. The early skip check for enacted topics (`new_votes_for_topic`) searches this same 24h window, finds old votes for enacted topics (agents continuously vote for already-enacted proposals), and cannot skip them.

**Impact:**
- 125+ enacted topics × ~5s processing each = 625s = **10+ minutes per tally cycle**
- Main loop runs at ~1 iteration per 10+ minutes (normally ~30s/iteration)
- `check_v05_milestone()` (every 20 iterations) = **200+ minutes** to trigger
- `v05CriteriaStatus` stays empty despite coordinator running for hours
- Evidence: coordinator logs show 122 "Processing governance topic:" and 0 "already enacted and no new votes" entries after 20 minutes of operation

## Root Cause

The "no new votes" check used the same `$thoughts_file` as the tally window (up to 24h), but this is the wrong window for the early skip. The early skip only needs to know: "have there been any NEW votes since the last tally run?" — not "any votes in the last 24h."

## Fix

Introduce `recent_tally_cutoff_ts`:
- When `lastTallyTimestamp` is set: `recent_tally_cutoff_ts = lastTallyTimestamp - 2min` (2-min buffer for clock skew)
- On first run after restart (no `lastTallyTimestamp`): `recent_tally_cutoff_ts = 10 min ago`

The early skip for enacted topics now uses this tight window:
```bash
# Before (broken): used full thoughts_file window (up to 24h)
new_votes_for_topic=$(jq ".[] | select(.type == \"vote\" ...)" "$thoughts_file")

# After (fixed): uses tight window since last tally
new_votes_for_topic=$(jq --arg cutoff "$recent_tally_cutoff_ts" \
    ".[] | select(.type == \"vote\" and .ts >= $cutoff ...)" "$thoughts_file")
```

**Result:** Enacted topics with no new votes since last tally are skipped immediately. Tally cycle time drops from 10+ min to <30 seconds. `check_v05_milestone()` runs on schedule every ~10 min.

## Safety

- The full 24h `thoughts_file` is still loaded and used for actual vote counting (no regression to vote accuracy)
- The tight window only affects the early SKIP decision — topics with genuinely new votes are still fully processed
- Vision-feature/vision-queue topics are still excluded from early skip (as before)
- Fallback path preserved: if `recent_tally_cutoff_ts` is empty, original behavior applies

Closes #1798