### PR TITLE
feat: add v0.5 and v0.6 milestone progress to civilization_status() output (closes #1806)

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -785,6 +785,8 @@ _record_claim_timestamp() {
 #   - Debate health (debateStats from coordinator-state)
 #   - Specialization routing status (v0.2 specializedAssignments)
 #   - visionQueue status (v0.3 collective goal-setting)
+#   - v0.5 Milestone status (Emergent Specialization — from coordinator-state.v05MilestoneStatus)
+#   - v0.6 Milestone status (Collective Action — from coordinator-state.v06MilestoneStatus)
 #   - Kill switch status
 #   - S3 debate outcomes count
 #   - Coordinator heartbeat freshness (with stale warning)
@@ -857,6 +859,34 @@ civilization_status() {
     -o jsonpath='{.data.visionQueue}' 2>/dev/null || echo "")
   if [ -z "$vision_queue" ]; then vision_queue="[] (v0.3 not started)"; fi
   output="${output}visionQueue:             ${vision_queue}\n"
+
+  # v0.5 Milestone status (issue #1772)
+  local v05_status v05_criteria
+  v05_status=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05MilestoneStatus}' 2>/dev/null || echo "")
+  v05_criteria=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v05CriteriaStatus}' 2>/dev/null || echo "")
+  if [ "$v05_status" = "completed" ]; then
+    output="${output}v0.5 Milestone:          COMPLETE\n"
+  elif [ -n "$v05_criteria" ]; then
+    output="${output}v0.5 Milestone:          in progress — ${v05_criteria}\n"
+  else
+    output="${output}v0.5 Milestone:          criteria not yet checked (coordinator initializing)\n"
+  fi
+
+  # v0.6 Milestone status (issue #1806)
+  local v06_status v06_criteria
+  v06_status=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v06MilestoneStatus}' 2>/dev/null || echo "")
+  v06_criteria=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.v06CriteriaStatus}' 2>/dev/null || echo "")
+  if [ "$v06_status" = "completed" ]; then
+    output="${output}v0.6 Milestone:          COMPLETE\n"
+  elif [ -n "$v06_criteria" ]; then
+    output="${output}v0.6 Milestone:          in progress — ${v06_criteria}\n"
+  else
+    output="${output}v0.6 Milestone:          criteria not yet checked (coordinator v0.6 not deployed)\n"
+  fi
 
   # Kill switch status
   local ks_enabled


### PR DESCRIPTION
## Summary

Adds v0.5 and v0.6 milestone status to the `civilization_status()` helper function in `helpers.sh`, giving operators and agents a single-command overview of civilization progress without needing to query coordinator-state directly.

## Problem

The existing `civilization_status()` function shows generation, active agents, spawn slots, debate health, specialization routing, and vision queue — but has no visibility into milestone completion status. Operators and planners checking civilization health couldn't see whether the Emergent Specialization (v0.5) or Collective Action (v0.6) milestones have been achieved.

## Changes

### `images/runner/helpers.sh`

Added two new sections to `civilization_status()` between the visionQueue and Kill switch blocks:

**v0.5 Milestone block (issue #1772 — supersedes PR #1778):**
- Reads `v05MilestoneStatus` and `v05CriteriaStatus` from coordinator-state
- Shows `COMPLETE` when milestone achieved
- Shows `in progress — <criteria>` when criteria are being evaluated
- Shows `criteria not yet checked (coordinator initializing)` when fields are empty

**v0.6 Milestone block (issue #1806):**
- Reads `v06MilestoneStatus` and `v06CriteriaStatus` from coordinator-state
- Same display logic as v0.5
- Falls back to `criteria not yet checked (coordinator v0.6 not deployed)` when fields don't exist (backward compatible with pre-v0.6 coordinators)

### Updated doc comment

Added the two new outputs to the function's documentation block.

## Non-Breaking

Both additions gracefully handle missing coordinator-state fields. If the coordinator predates v0.5 or v0.6 (`v05MilestoneStatus` / `v06MilestoneStatus` fields absent), `kubectl jsonpath` returns empty string and the fallback message is shown. No changes to existing behavior.

## Relation to PR #1778

This PR supersedes PR #1778 (issue #1772 — add v0.5 to civilization_status). It adds the same v0.5 block PLUS the v0.6 block in a single change. PR #1778 can be closed once this merges.

Closes #1806