### PR TITLE
feat: coordinator warns when multiple open PRs reference same issue (closes #1809)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -609,6 +609,24 @@ refresh_task_queue() {
         local covered_count
         covered_count=$(echo "$covered_issues" | wc -w | tr -d ' ')
         echo "[$(date -u +%H:%M:%S)] Issue #1384: Found $covered_count issues with open PRs (will skip from queue): ${covered_issues:-none}"
+
+        # Issue #1809: Detect issues with 2+ open PRs and warn via Thought CR.
+        # sort -u above deduplicates so we lose count info. Re-extract without -u to count.
+        local all_covered_raw
+        all_covered_raw=$(echo "$prs_json" | \
+            jq -r '.[].body // ""' 2>/dev/null | \
+            grep -oiE '(closes|fixes|resolves) #[0-9]+' | \
+            grep -oE '[0-9]+' | sort)
+        # Find issues appearing 2+ times (duplicate PRs)
+        local dup_issues
+        dup_issues=$(echo "$all_covered_raw" | uniq -d)
+        if [ -n "$dup_issues" ]; then
+            local dup_count
+            dup_count=$(echo "$dup_issues" | wc -w | tr -d ' ')
+            echo "[$(date -u +%H:%M:%S)] Issue #1809: WARNING — $dup_count issue(s) have 2+ open PRs: ${dup_issues//$'\n'/ }"
+            # Post a warning Thought CR so planners can identify duplicates to close
+            post_coordinator_thought "DUPLICATE PR WARNING (issue #1809): The following issue(s) each have 2+ open PRs, creating duplicate work. Consider closing the older PR for each: ${dup_issues//$'\n'/ }" "insight"
+        fi
     fi
 
     # Build scored list: "score:number"


### PR DESCRIPTION
## Summary

- Detects issues with 2+ open PRs during refresh_task_queue() and posts a warning Thought CR
- Helps planners identify duplicate PR situations that waste agent effort

## Problem

Issues 1764, 1772, 1787, 1799 currently each have 2+ open PRs. The coordinator was silently
skipping these issues (correctly) but gave no signal about the duplicate PR situation.

## Changes

In `refresh_task_queue()` in `coordinator.sh`:
- Re-extracts PR issue numbers WITHOUT `sort -u` to preserve count information
- Uses `uniq -d` to identify issues appearing 2+ times
- Posts a coordinator insight Thought CR when duplicates are found:
  `DUPLICATE PR WARNING (issue #1809): The following issue(s) each have 2+ open PRs: 1764 1772 ...`

Closes #1809

## Impact

Planners will see this warning in peer thoughts and can manually close older duplicate PRs,
reducing wasted agent effort and merge conflicts.

## Files Changed

- `images/runner/coordinator.sh` — not a protected file