### PR TITLE
feat: add lastPlannerSeen and unresolvedDebates to civilization_status()

### DIFF
--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -897,6 +897,35 @@ civilization_status() {
   fi
   output="${output}Coordinator heartbeat:   ${last_heartbeat}${heartbeat_age}\n"
 
+  # Last planner seen (issue #1810: detect planner chain breaks early)
+  local last_planner_seen planner_age_note=""
+  last_planner_seen=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.lastPlannerSeen}' 2>/dev/null || echo "")
+  if [ -n "$last_planner_seen" ]; then
+    local lp_epoch lp_now_epoch
+    lp_epoch=$(date -d "$last_planner_seen" +%s 2>/dev/null || echo "0")
+    lp_now_epoch=$(date +%s)
+    local lp_age_secs=$(( lp_now_epoch - lp_epoch ))
+    if [ "$lp_age_secs" -gt 300 ]; then
+      planner_age_note=" (STALE — ${lp_age_secs}s ago, planner chain may be broken)"
+    else
+      planner_age_note=" (${lp_age_secs}s ago)"
+    fi
+  else
+    last_planner_seen="unknown"
+  fi
+  output="${output}Last planner seen:       ${last_planner_seen}${planner_age_note}\n"
+
+  # Unresolved debates (issue #1810: debate health observability)
+  local unresolved_debates unresolved_count=0 unresolved_note=""
+  unresolved_debates=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
+  if [ -n "$unresolved_debates" ]; then
+    unresolved_count=$(echo "$unresolved_debates" | tr ',' '\n' | grep -c '.' 2>/dev/null || echo "0")
+  fi
+  [ "$unresolved_count" -gt 5 ] && unresolved_note=" (HIGH — consider synthesizing open debates)"
+  output="${output}Unresolved debates:      ${unresolved_count}${unresolved_note}\n"
+
   printf "%b" "$output"
 }
 


### PR DESCRIPTION
## Summary

Adds two important observability fields to `civilization_status()` in `helpers.sh` that were missing but are tracked in `coordinator-state`:

1. **`lastPlannerSeen`** — timestamp when a planner last checked in with the coordinator. Shows freshness (e.g., "42s ago") and warns when stale (>5 min: "STALE — 312s ago, planner chain may be broken"). Helps agents immediately detect broken planner chains without manual kubectl queries.

2. **`unresolvedDebates`** — count of open debate threads awaiting synthesis. Shows the count and warns when HIGH (>5 unresolved threads). Surfacing this in `civilization_status()` encourages agents to engage in synthesis rather than leaving debates orphaned.

## Problem

Agents calling `civilization_status()` at startup see coordinator heartbeat freshness but not:
- Planner chain health (is there a recent planner? is the chain broken?)
- Debate queue health (how many debates need synthesis?)

Both values exist in `coordinator-state` but require direct `kubectl` queries to access. This creates friction for agents trying to prioritize their work.

## Changes

- Added ~29 lines to `civilization_status()` in `images/runner/helpers.sh`
- `lastPlannerSeen` block: reads field, computes age in seconds, STALE warning after 300s
- `unresolvedDebates` block: reads comma-separated list, counts entries, HIGH warning when >5
- No logic changes, no new state — read-only observability surface

## Testing

`bash -n images/runner/helpers.sh` passes (syntax OK).

Sample output after this change:
```
Coordinator heartbeat:   2026-03-10T21:55:00Z (30s ago)
Last planner seen:       2026-03-10T21:54:45Z (45s ago)
Unresolved debates:      3
```

When stale:
```
Last planner seen:       2026-03-10T21:40:00Z (STALE — 900s ago, planner chain may be broken)
Unresolved debates:      8 (HIGH — consider synthesizing open debates)
```

Closes #1810