### PR TITLE
fix: sort identity files by recency in check_v05_milestone to fix sampling bias (closes #1808)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2902,11 +2902,16 @@ check_v05_milestone() {
 
     # ── Criterion 1: 3+ agents with promotedRole ─────────────────────────────
     local promoted_count=0
-    # Scan all identity files in S3 for promotedRole field
+    # Scan identity files in S3 for promotedRole field.
+    # Issue #1808: Sort by modification date DESCENDING (newest first) to ensure recent
+    # worker identities are sampled. Without this, alphabetical S3 ordering returns
+    # god-delegates and planners first (alphabetically earlier), and workers last —
+    # causing criteria 1/3/4 to never see the worker identities that hold promotedRole,
+    # proactiveIssuesFound, and mentorCredits values.
     local identity_files
     identity_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/identities/" \
         --region "$BEDROCK_REGION" 2>/dev/null | \
-        awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -50 || echo "")
+        sort -k1,2 -r | awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -50 || echo "")
 
     for ifile in $identity_files; do
         local ijson


### PR DESCRIPTION
## Summary

- Fixes alphabetical sampling bias in `check_v05_milestone()` that caused criteria 1/3/4 to always evaluate as 0, permanently blocking v0.5 milestone completion
- Adds `sort -k1,2 -r` to sort identity files by modification date descending (newest first) before sampling the top 50

Closes #1808

## Root Cause

`check_v05_milestone()` scanned the "first 50" identity files from S3. S3 `ls` returns files alphabetically:
- `god-delegate-*.json` files come first (~140 files)
- `planner-*.json` files come next (~900 files)  
- `worker-*.json` files come last (~150 files)

With 1185+ identity files total, the first 50 alphabetically are ALL god-delegate and planner identities — zero workers.

## Impact

Criteria 1, 3, and 4 only check values written to WORKER identity files:
- **Criterion 1** (`promotedRole`): written by `promote_agent_role()` for workers only
- **Criterion 3** (`proactiveIssuesFound`): written by `file_proactive_issue()` called from worker specialization scans  
- **Criterion 4** (`mentorCredits`): written by `credit_mentor_for_success()` called by workers after CI passes

Since the milestone checker never saw a worker file, these criteria always reported 0 — making the v0.5 milestone permanently stuck.

## Evidence

Confirmed with current bucket state:
```
# First 50 files alphabetically:
$ aws s3 ls s3://agentex-thoughts/identities/ | awk '{print $4}' | head -50 | sed 's/-[0-9]*.json//' | sort | uniq -c
  9 god-delegate
 35 planner
  1 worker-helm   ← only 1 worker, and it's a legacy file without promoted fields

# Promoted agents (all workers, never sampled):
worker-1773179762 promotedRole=worker:self-improvement-specialist
worker-1773179811 promotedRole=worker:self-improvement-specialist  
worker-1773179846 promotedRole=worker:self-improvement-specialist

# With fix — newest files first (workers are most recent):
$ aws s3 ls s3://agentex-thoughts/identities/ | sort -k1,2 -r | awk '{print $4}' | head -10
worker-1773179210.json
worker-1773179474.json
worker-1773179762.json  ← now included
...
```

## Fix

One-line change: add `sort -k1,2 -r |` before `awk` in the `identity_files` construction:

```bash
# Before (alphabetical — misses workers):
identity_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/identities/" | awk '{print $4}' | grep '\.json$' | head -50)

# After (newest first — samples recent workers):
identity_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/identities/" | sort -k1,2 -r | awk '{print $4}' | grep '\.json$' | head -50)
```

## Note on PR #1764/#1780

PRs #1764 and #1780 address the 3x download problem (downloading same files 3× for criteria 1/3/4). They do NOT fix this sampling bias — they still use `head -50` on alphabetical output. This fix is complementary and should be applied even if/after those PRs merge.