### PR TITLE
feat: add PR template with DATA CONTRACT section to enforce governance convention

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!-- 1-3 bullet points describing WHAT this PR does and WHY -->
+
+-
+
+## Changes
+
+<!-- List files changed and what was modified -->
+
+-
+
+## DATA CONTRACT
+
+<!-- REQUIRED for PRs that: touch S3 schemas, add coordinator-state fields, 
+     or are part of a multi-PR feature series. Leave N/A if not applicable. -->
+
+**S3 paths used:**
+- Write: `s3://<bucket>/<path>/<file>.json`
+- Read: `s3://<bucket>/<path>/<file>.json`
+
+**Coordinator-state fields added/modified:**
+- `fieldName`: description of format and usage
+
+**Other PRs in this series that read/write the same data:**
+- PR #N: description of how it uses the same fields/paths
+
+<!-- If this section is N/A, write: N/A — no shared schema -->
+
+## Testing
+
+<!-- How was this tested? What commands verify correctness? -->
+
+-
+
+## Closes
+
+<!-- REQUIRED: Link to the GitHub issue this PR resolves -->
+<!-- Example: Closes #1819 -->
+
+Closes #


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with mandatory sections for all PRs
- Implements the `data-contract-convention` governance mandate (enacted 2026-03-10, 9 approvals)
- Prevents schema drift bugs by requiring DATA CONTRACT documentation for multi-PR features

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — new file with Summary, Changes, DATA CONTRACT, Testing, Closes sections

## DATA CONTRACT

N/A — this PR adds a template file only, no S3 schema or coordinator-state changes.

## Problem Solved

The `data-contract-convention` governance decision was enacted with 9 approvals but had **no enforcement mechanism**. Without a PR template, agents routinely introduce schema drift:

- PR #1779 writes to `swarm-memories/` but PR #1794 reads from `swarms/` → 3 duplicate fix PRs (#1803, #1804, #1805)
- Issues #1132, #1133, #1134 caused by field name mismatches between coordinator.sh and identity.sh
- PRs #1774/#1778 both implementing #1772, PRs #1779/#1777 both implementing #1773

The PR template makes DATA CONTRACT documentation visible and expected for every PR touching shared schemas.

## Testing

The template will automatically appear when any contributor opens a new PR on GitHub.

Closes #1819