### PR TITLE
feat: add v0.5/v0.6 milestone progress to system-status.sh (closes #1829)

### DIFF
--- a/manifests/system/system-status.sh
+++ b/manifests/system/system-status.sh
@@ -150,7 +150,40 @@ echo "   Vision: ${VISION}..."
 echo "   Generation: $GENERATION"
 echo ""
 
-# 8. HEALTH SUMMARY
+# 8. MILESTONE PROGRESS (v0.5 Emergent Specialization / v0.6 Collective Action)
+echo -e "${BLUE}🏆 Civilization Milestones${NC}"
+
+# v0.5 Emergent Specialization
+V05_STATUS=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+  -o jsonpath='{.data.v05MilestoneStatus}' 2>/dev/null || echo "")
+V05_CRITERIA=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+  -o jsonpath='{.data.v05CriteriaStatus}' 2>/dev/null || echo "")
+if [ "$V05_STATUS" = "completed" ]; then
+  echo -e "   v0.5 Emergent Specialization: ${GREEN}COMPLETE${NC}"
+elif [ -n "$V05_CRITERIA" ]; then
+  # Show first 100 chars of criteria to avoid excessive scrolling
+  SHORT_CRITERIA=$(echo "$V05_CRITERIA" | cut -c1-100)
+  echo -e "   v0.5 Emergent Specialization: ${YELLOW}in progress${NC} — ${SHORT_CRITERIA}..."
+else
+  echo -e "   v0.5 Emergent Specialization: ${YELLOW}not yet checked${NC} (coordinator initializing)"
+fi
+
+# v0.6 Collective Action
+V06_STATUS=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+  -o jsonpath='{.data.v06MilestoneStatus}' 2>/dev/null || echo "")
+V06_CRITERIA=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+  -o jsonpath='{.data.v06CriteriaStatus}' 2>/dev/null || echo "")
+if [ "$V06_STATUS" = "completed" ]; then
+  echo -e "   v0.6 Collective Action:       ${GREEN}COMPLETE${NC}"
+elif [ -n "$V06_CRITERIA" ]; then
+  SHORT_V06_CRITERIA=$(echo "$V06_CRITERIA" | cut -c1-100)
+  echo -e "   v0.6 Collective Action:       ${YELLOW}in progress${NC} — ${SHORT_V06_CRITERIA}..."
+else
+  echo -e "   v0.6 Collective Action:       ${YELLOW}not yet initialized${NC} (coordinator v0.6 not deployed)"
+fi
+echo ""
+
+# 9. HEALTH SUMMARY
 echo -e "${BLUE}📊 Health Summary${NC}"
 HEALTH_OK=0
 HEALTH_WARN=0


### PR DESCRIPTION
## Summary

- Adds a new **Section 8: Civilization Milestones** to `manifests/system/system-status.sh`
- Shows v0.5 Emergent Specialization and v0.6 Collective Action milestone progress
- Green COMPLETE / Yellow in-progress (with criteria summary) / Yellow not-yet-initialized
- Reads from `coordinator-state.v05MilestoneStatus`, `v05CriteriaStatus`, `v06MilestoneStatus`, `v06CriteriaStatus`

## Problem

The operator-facing `system-status.sh` dashboard was completely blind to civilization milestone progress. A god operator running `./system-status.sh` could see circuit breaker, kill switch, agents, roles, thoughts, GitHub status, and constitution — but had NO visibility into whether v0.5 (Emergent Specialization) and v0.6 (Collective Action) milestones were progressing.

This is distinct from issues #1772 and #1806, which add milestone to `civilization_status()` in `helpers.sh`. This change targets the separate operator dashboard script.

## Changes

- **`manifests/system/system-status.sh`**: Added Section 8 (Civilization Milestones) before the Health Summary section, renumbering Health Summary from 8 to 9. Shows criteria progress truncated to 100 chars to avoid dashboard clutter.

## DATA CONTRACT

N/A — reads existing `coordinator-state` fields only, no new schema.

## Testing

- `bash -n manifests/system/system-status.sh` passes syntax check
- Logic follows same pattern as v05/v06 checks in coordinator.sh's `check_v05_milestone()`

Closes #1829