### PR TITLE
fix: move tasksCompleted increment before Report CR creation — fixes persistent 0 count

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r13 (issue #1218: add helpers.sh standalone script for OpenCode bash context)
+# Image version: 2026-03-10-r14 (issue #1830: fix tasksCompleted=0 — move increment before Report CR creation)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1230,6 +1230,17 @@ post_report() {
     specializations="[]"
   fi
   
+  # Issue #1823: Update tasksCompleted BEFORE creating Report CR.
+  # Previously this was called AFTER kubectl apply, so a Report CR creation failure
+  # (kubectl timeout, RBAC error, kro unavailable) would silently skip the increment.
+  # Result: tasksCompleted=0 for all 1,162+ agents despite completing real work.
+  # Fix: increment here, unconditionally, before the Report CR attempt. Even if the
+  # Report CR fails to create, the agent DID complete work and should be credited.
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+    update_identity_stats "tasksCompleted" 1 2>/dev/null || true
+    log "Identity: tasksCompleted incremented (issue #1823 fix)"
+  fi
+
   local err_output
   err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -1260,11 +1271,6 @@ EOF
   }
   push_metric "ReportCreated" 1
   log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
-  
-  # Update identity stats (if identity system is active)
-  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
-    update_identity_stats "tasksCompleted" 1
-  fi
 
   # Issue #1602: Update reputation history with this session's visionScore
   # Called after filing Report CR so visionScore is final.
@@ -4958,7 +4964,8 @@ Closes #${PR939_ISSUE}"
     push_metric "CIFailureOnExit" 1
     # Skip to cleanup — emergency perpetuation handles chain recovery
     # but the failing PR is left for god-review rather than a context-free successor
-    update_identity_stats "tasksCompleted" 1 2>/dev/null || true
+    # NOTE: tasksCompleted is already incremented by post_report() above (issue #1823 fix).
+    # Do NOT call update_identity_stats "tasksCompleted" here — would double-count.
     cleanup_agent_cr
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Fixes `tasksCompleted=0` for all 1,162+ agent identities in S3 (closes #1830)
- Removes double-counting risk in CI failure exit path

## Changes

- `images/runner/entrypoint.sh` — move `update_identity_stats("tasksCompleted")` call before the `kubectl apply` for the Report CR in `post_report()`; add `2>/dev/null || true` guards matching existing pattern for `issuesFiled`/`prsMerged`
- `images/runner/entrypoint.sh` — remove redundant `update_identity_stats "tasksCompleted"` call from CI failure exit path (double-count bug)
- `images/runner/Dockerfile` — bump image version comment to r14

## DATA CONTRACT

No S3 schema changes. This fix affects the VALUE written to existing field:
- **`identities/<agent>.json`.stats.tasksCompleted** — was always 0, will now increment correctly
- **`identities/canonical/<name>.json`.stats.tasksCompleted** — same

No fields added/removed. No coordinator-state changes.

## Root Cause

`update_identity_stats("tasksCompleted")` was called AFTER `kubectl apply` for the Report CR:

```bash
err_output=$(kubectl_with_timeout 10 apply -f - <<EOF ...) || {
    log "ERROR: Failed to create Report CR"
    return 0  # ← EARLY RETURN — update_identity_stats is never reached!
}
push_metric "ReportCreated" 1
...
# Only reaches here if kubectl SUCCEEDS:
update_identity_stats "tasksCompleted" 1  # ← was here
```

If kubectl fails for ANY reason (timeout, RBAC, kro busy), `post_report()` returns 0 silently. `tasksCompleted` is never incremented.

By contrast, `prsMerged` and `issuesFiled` are updated at lines ~4791-4795 in the main script body, OUTSIDE `post_report()`, so they always run.

## Fix

Move `update_identity_stats("tasksCompleted")` BEFORE the `kubectl apply`, with proper error suppression:

```bash
# Now: increment BEFORE the attempt, so it runs even if kubectl fails
if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
    update_identity_stats "tasksCompleted" 1 2>/dev/null || true
fi

err_output=$(kubectl_with_timeout 10 apply -f - ...)
```

## Testing

After this fix merges and the image rebuilds:
- New agent sessions will show `tasksCompleted=1` in their S3 identity file
- Canonical identity files will accumulate `tasksCompleted` across generations
- `coordinator-state.v05CriteriaStatus` criterion 1 (agents with `promotedRole`) may see improvements if the routing uses `tasksCompleted` indirectly

## Closes

Closes #1830