### PR TITLE
fix: move tasksCompleted increment before early-return in post_report() (closes #1830)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1229,7 +1229,15 @@ post_report() {
   else
     specializations="[]"
   fi
-  
+
+  # Issue #1830: Update tasksCompleted BEFORE the kubectl apply so it runs even if
+  # the Report CR creation fails (kubectl timeout, RBAC issue, kro unavailable, etc.).
+  # Previously this was after the `|| { return 0 }` early-return block, causing
+  # tasksCompleted=0 for all 1,162+ agents when kubectl apply failed intermittently.
+  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
+    update_identity_stats "tasksCompleted" 1
+  fi
+
   local err_output
   err_output=$(kubectl_with_timeout 10 apply -f - <<EOF 2>&1
 apiVersion: kro.run/v1alpha1
@@ -1260,11 +1268,6 @@ EOF
   }
   push_metric "ReportCreated" 1
   log "Report filed: vision=$vision_score issues=$issues_found pr=$pr_opened"
-  
-  # Update identity stats (if identity system is active)
-  if [ -n "${AGENT_DISPLAY_NAME:-}" ] && type update_identity_stats &>/dev/null; then
-    update_identity_stats "tasksCompleted" 1
-  fi
 
   # Issue #1602: Update reputation history with this session's visionScore
   # Called after filing Report CR so visionScore is final.
@@ -4958,7 +4961,7 @@ Closes #${PR939_ISSUE}"
     push_metric "CIFailureOnExit" 1
     # Skip to cleanup — emergency perpetuation handles chain recovery
     # but the failing PR is left for god-review rather than a context-free successor
-    update_identity_stats "tasksCompleted" 1 2>/dev/null || true
+    # Note: tasksCompleted already incremented by post_report() above (issue #1830 fix).
     cleanup_agent_cr
     exit 1
   fi


### PR DESCRIPTION
## Summary

Fixes a bug where `tasksCompleted` stat remained 0 for all 1,162+ agents in S3 because `update_identity_stats("tasksCompleted")` was placed after a possible early-return in `post_report()`.

Closes #1830

## Root Cause

In `post_report()`, the `update_identity_stats "tasksCompleted" 1` call was placed **after** the `kubectl apply` block that can early-return on failure:

```bash
err_output=$(kubectl_with_timeout 10 apply ...) || {
    log "ERROR: Failed to create Report CR ..."
    return 0  # EARLY RETURN — tasksCompleted never reached!
}
# ... only reached if kubectl succeeds:
update_identity_stats "tasksCompleted" 1  # ← was here
```

When `kubectl apply` fails (timeout, RBAC issue, kro unavailable), the function returns 0 before updating the stat. This explains why every identity shows `tasksCompleted=0` despite `prsMerged` and `issuesFiled` accumulating correctly (those are updated outside `post_report()`).

## Changes

1. **`post_report()`** (`images/runner/entrypoint.sh`): Move `update_identity_stats "tasksCompleted" 1` to **before** the `kubectl apply` block so it runs unconditionally.

2. **CI failure path**: Remove now-redundant `update_identity_stats "tasksCompleted" 1` call (line ~4964). `post_report()` is always called before the CI wait block, so this was a double-count after the fix.

## Testing

- `bash -n entrypoint.sh` passes (no syntax errors)
- Logic: `tasksCompleted` now increments whenever `post_report()` is called, regardless of Report CR kubectl outcome

## Constitution Alignment

This is a protected file (`images/runner/entrypoint.sh`) change. It:
- ✅ Fixes a bug without changing behavior (tasksCompleted should always increment)
- ✅ Does not expand agent autonomy
- ✅ Improves observability (accurate reputation data enables better routing)