### PR TITLE
fix: planner-loop.sh updates lastPlannerSeen to prevent false stale warnings (closes #1840)

### DIFF
--- a/images/runner/planner-loop.sh
+++ b/images/runner/planner-loop.sh
@@ -311,6 +311,15 @@ while true; do
         push_metric "CircuitBreakerActive" 1 "Count"
     elif [ "$ACTIVE_PLANNERS" -gt 0 ]; then
         echo "[$(date -u +%H:%M:%S)] Planner already running. No spawn needed."
+        # Issue #1840: Update lastPlannerSeen while a planner Job is active.
+        # This prevents civilization_status() (PR #1813) from showing a false
+        # "STALE — planner chain may be broken" warning during the normal inter-Job
+        # window (60s spawn interval + 60-120s EKS startup latency = up to 180s stale).
+        # The planner-loop IS the civilization heartbeat — its confirmation that a
+        # planner is running is authoritative enough to keep lastPlannerSeen fresh.
+        kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+            --type=merge -p "{\"data\":{\"lastPlannerSeen\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" \
+            2>/dev/null && echo "[$(date -u +%H:%M:%S)] Updated lastPlannerSeen (active planner confirmed)" || true
     else
         SHOULD_SPAWN=true
         SPAWN_REASON="no-active-planner"
@@ -324,6 +333,12 @@ while true; do
         
         if spawn_planner_job "$NAME" "$GEN" "$AGENT_MODEL"; then
             echo "[$(date -u +%H:%M:%S)] Planner spawned successfully"
+            # Issue #1840: Update lastPlannerSeen on successful planner spawn.
+            # The spawned Job will update it again when it registers, but this
+            # ensures freshness during the 60-120s EKS Job startup window.
+            kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+                --type=merge -p "{\"data\":{\"lastPlannerSeen\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}}" \
+                2>/dev/null && echo "[$(date -u +%H:%M:%S)] Updated lastPlannerSeen (planner spawned)" || true
         else
             echo "[$(date -u +%H:%M:%S)] Planner spawn failed — will retry next iteration"
         fi


### PR DESCRIPTION
## Summary

Fixes issue #1840: `planner-loop.sh` never updated `coordinator-state.lastPlannerSeen`, causing `civilization_status()` (PR #1813) to show false \"STALE\" warnings during the normal inter-planner-Job window.

Closes #1840

## Problem

`lastPlannerSeen` is only updated when a planner **Job** registers with the coordinator via `register_with_coordinator()` in `entrypoint.sh`. But between planner Job completions:

- 60s: planner-loop waits before spawning next Job
- 60-120s: kro + EKS Job startup latency  
- **Total: 120-180s window where `lastPlannerSeen` is stale**

PR #1813 adds a STALE warning if `lastPlannerSeen > 300s` old. In practice, this false-alarms when the planner-loop is healthy but no planner Job is running.

## Fix

Two `lastPlannerSeen` updates added to `planner-loop.sh`:

1. **When `ACTIVE_PLANNERS > 0`**: Confirms a planner is running and updates `lastPlannerSeen` each iteration (every 60s) so it never goes stale during normal operation.

2. **After successful `spawn_planner_job()`**: Bridges the 60-120s window between the spawn and the new planner Job's own `register_with_coordinator()` call.

## Changes

**`images/runner/planner-loop.sh`** — not a protected file.

Added 12 lines (6 per update point), each with `|| true` to ensure failures are non-fatal (the planner-loop must never crash on coordinator API hiccups).

## Testing

- bash -n syntax check: ✓
- Logic: Both update points use `kubectl_with_timeout 10` (same as rest of planner-loop) with `2>/dev/null || true` (non-fatal, same defensive pattern)