### PR TITLE
feat: implement structured escalation protocol (issue #1839)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,6 +704,13 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
+- `ax_escalate [--severity LOW|MEDIUM|HIGH|CRITICAL] [--type retry|blocked|conflict|decision|failed|security|proliferation] [--issue N] [--options "opt1,opt2"] <description>` — issue #1839 structured escalation protocol. When an agent is stuck and cannot self-resolve, call this instead of crashing. The escalation is persisted to S3, recorded in `coordinator-state.escalationQueue`, and a blocker Thought CR is posted. The coordinator auto-resolves by tier: retry re-queues, blocked/conflict post a directive, decision routes to god-delegate, critical files a GitHub issue for human attention. Example:
+  ```bash
+  source /agent/helpers.sh && ax_escalate --severity medium --type blocked --issue 789 "Merge conflict in coordinator.go"
+  ax_escalate --severity high --type decision --issue 789 --options "SQLite,PostgreSQL" "Which database?"
+  ax_escalate --severity critical --type security "Found exposed AWS credentials in PR #1830"
+  ```
+- `get_escalation_status [escalation_id]` — query escalation status from S3. No args returns all open escalations as JSON array; with ID returns the specific escalation object.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1112,6 +1119,10 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `agentTrustGraph`: Pipe-separated trust edges built from `cite_debate_outcome()` calls (v0.5, issue #1734). Format: `citingAgent:citedAgent:count|...`. Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust. Queryable via `get_trust_graph()` in helpers.sh. Used by future coordinator routing to prefer agents that trusted specialists already endorse for complex issues.
 - `v05MilestoneStatus`: Set to `"completed"` by `check_v05_milestone()` when all 5 v0.5 Emergent Specialization success criteria are met (issue #1752). Empty until completion. Once set, `check_v05_milestone()` skips subsequent checks (idempotent).
 - `v05CriteriaStatus`: Human-readable status string from the last `check_v05_milestone()` run (issue #1752). Format: `"N/5 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.5 milestone progress without reading S3 identities.
+- `escalationQueue`: Comma-separated escalation IDs written by `ax_escalate()` (issue #1839). Coordinator processes these every ~2.5 min via `handle_escalations()`, applying tier-based auto-resolution: Tier 0 (retry) re-queues the task, Tier 1 (blocked/conflict) posts a directive or spawns a fresh worker, Tier 2 (decision) routes to the god-delegate, Tier 3 (security/critical) posts a CRITICAL directive for immediate human attention. Read with:
+  ```bash
+  kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.escalationQueue}'
+  ```
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1132,6 +1143,7 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQue
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.chronicleCandidates}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05MilestoneStatus}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05CriteriaStatus}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.escalationQueue}'
 ```
 
 **Proposing vision features (issue #1219/#1149):**
@@ -1268,7 +1280,8 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success()
+                cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
+                ax_escalate(), get_escalation_status()
 ```
 
 Environment:

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -364,16 +364,25 @@ ensure_state_fields_initialized() {
        -p '{"data":{"chronicleCandidates":""}}' 2>/dev/null || true
    fi
 
-  # agentTrustGraph (v0.5, issue #1734/#1756): pipe-separated trust edges from cite_debate_outcome() calls.
-  # Format: "citingAgent:citedAgent:count|citingAgent2:citedAgent:count2|..."
-  # Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust.
-  # Used by score_agent_for_issue() (issue #1750) to give routing priority to widely-cited agents.
-  # Initialize to empty string if absent — cite_debate_outcome() in helpers.sh writes actual entries.
-  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("agentTrustGraph")' >/dev/null 2>&1; then
-    [ "$silent" = "false" ] && echo "  Initializing agentTrustGraph (was absent)"
-    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
-      -p '{"data":{"agentTrustGraph":""}}' 2>/dev/null || true
-  fi
+   # agentTrustGraph (v0.5, issue #1734/#1756): pipe-separated trust edges from cite_debate_outcome() calls.
+   # Format: "citingAgent:citedAgent:count|citingAgent2:citedAgent:count2|..."
+   # Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust.
+   # Used by score_agent_for_issue() (issue #1750) to give routing priority to widely-cited agents.
+   # Initialize to empty string if absent — cite_debate_outcome() in helpers.sh writes actual entries.
+   if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("agentTrustGraph")' >/dev/null 2>&1; then
+     [ "$silent" = "false" ] && echo "  Initializing agentTrustGraph (was absent)"
+     kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+       -p '{"data":{"agentTrustGraph":""}}' 2>/dev/null || true
+   fi
+
+   # escalationQueue (issue #1839): comma-separated escalation IDs for the coordinator
+   # to process. Written by ax_escalate() in helpers.sh. Coordinator processes and resolves
+   # escalations every 5 iterations (~2.5 min) via handle_escalations().
+   if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("escalationQueue")' >/dev/null 2>&1; then
+     [ "$silent" = "false" ] && echo "  Initializing escalationQueue (was absent)"
+     kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+       -p '{"data":{"escalationQueue":""}}' 2>/dev/null || true
+   fi
 
    # v05MilestoneStatus (issue #1752): tracks whether v0.5 Emergent Specialization milestone is complete.
   # Set to "completed" by check_v05_milestone() when all 5 success criteria are met.
@@ -2470,6 +2479,258 @@ aggregate_chronicle_candidates() {
     update_state "chronicleCandidates" "$top_candidates"
 }
 
+# handle_escalations() — Process agent escalation queue (issue #1839)
+# ─────────────────────────────────────────────────────────────────────────────
+# Tiered escalation protocol: agents call ax_escalate() to signal problems.
+# This function reads the escalation queue from coordinator-state, fetches each
+# escalation from S3, and applies auto-resolution rules by tier:
+#
+#   Tier 0 (retry)     — mark resolved, re-queue task after 5-min delay
+#   Tier 1 (blocked/conflict/failed)
+#                      — if conflict: spawn fresh worker on current main
+#                      — if blocked: check dependency resolution, re-queue
+#                      — if failed: route to god-delegate via directive
+#   Tier 2 (decision)  — post god-delegate-visible directive Thought CR
+#   Tier 3 (security/proliferation/critical) — verify GitHub issue filed,
+#                        post CRITICAL directive visible to all agents
+#
+# Called every 5 iterations (~2.5 min) from the coordinator main loop.
+handle_escalations() {
+    local queue
+    queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+        -o jsonpath='{.data.escalationQueue}' 2>/dev/null || echo "")
+
+    [ -z "$queue" ] && return 0
+
+    # Split queue into array
+    local escalation_ids
+    IFS=',' read -ra escalation_ids <<< "$queue"
+    local remaining_ids=()
+    local processed=0
+    local skipped=0
+
+    for esc_id in "${escalation_ids[@]}"; do
+        esc_id="${esc_id// /}"  # strip spaces
+        [ -z "$esc_id" ] && continue
+
+        # Fetch escalation from S3
+        local esc_json
+        esc_json=$(aws s3 cp "s3://${IDENTITY_BUCKET}/escalations/${esc_id}.json" - 2>/dev/null || echo "")
+        if [ -z "$esc_json" ] || [ "$esc_json" = "{}" ]; then
+            echo "[$(date -u +%H:%M:%S)] handle_escalations: ${esc_id} not found in S3 — skipping"
+            continue  # Drop from queue (already processed or never written)
+        fi
+
+        local status
+        status=$(echo "$esc_json" | jq -r '.status // "open"' 2>/dev/null)
+        if [ "$status" != "open" ]; then
+            # Already resolved — drop from queue
+            echo "[$(date -u +%H:%M:%S)] handle_escalations: ${esc_id} already ${status} — dropping from queue"
+            continue
+        fi
+
+        local severity category tier agent issue_num description options
+        severity=$(echo "$esc_json" | jq -r '.severity // "MEDIUM"' 2>/dev/null)
+        category=$(echo "$esc_json" | jq -r '.category // "blocked"' 2>/dev/null)
+        tier=$(echo "$esc_json" | jq -r '.tier // 1' 2>/dev/null)
+        agent=$(echo "$esc_json" | jq -r '.agent // "unknown"' 2>/dev/null)
+        issue_num=$(echo "$esc_json" | jq -r '.issue // ""' 2>/dev/null)
+        description=$(echo "$esc_json" | jq -r '.description // ""' 2>/dev/null)
+        options=$(echo "$esc_json" | jq -r '.options // ""' 2>/dev/null)
+
+        echo "[$(date -u +%H:%M:%S)] handle_escalations: processing ${esc_id} severity=${severity} category=${category} tier=${tier} agent=${agent}"
+
+        local resolution_action="none"
+        local auto_resolved=false
+
+        case "$tier" in
+            0)
+                # Tier 0 (retry): auto-resolve, re-queue task after delay
+                resolution_action="auto-retry"
+                if [ -n "$issue_num" ] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+                    # Re-add issue to task queue after short delay by adding back to GitHub queue
+                    echo "[$(date -u +%H:%M:%S)] handle_escalations: Tier 0 retry — re-queuing issue #${issue_num} for ${agent}"
+                    # Add a small delay entry to task queue
+                    local cur_queue
+                    cur_queue=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+                        -o jsonpath='{.data.taskQueue}' 2>/dev/null || echo "")
+                    if [ -z "$cur_queue" ]; then
+                        update_state "taskQueue" "$issue_num"
+                    else
+                        # Only add back if not already in queue
+                        if ! echo "$cur_queue" | grep -q "$issue_num"; then
+                            update_state "taskQueue" "${cur_queue},${issue_num}"
+                        fi
+                    fi
+                    auto_resolved=true
+                fi
+                ;;
+            1)
+                # Tier 1 (blocked/conflict/failed): reassign or post directive
+                case "$category" in
+                    conflict)
+                        # Conflict: spawn fresh worker on current main via directive thought
+                        resolution_action="spawn-fresh-worker"
+                        echo "[$(date -u +%H:%M:%S)] handle_escalations: Tier 1 conflict — posting directive to spawn fresh worker for issue #${issue_num}"
+                        kubectl_with_timeout 10 apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-esc-directive-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-state"
+  thoughtType: directive
+  confidence: 9
+  content: |
+    COORDINATOR DIRECTIVE [escalation-response]: Merge conflict detected by ${agent}
+    Issue: ${issue_num:-(none)}
+    Action: Spawn a fresh worker on current main branch to re-implement issue #${issue_num}.
+    The previous worker (${agent}) encountered: ${description}
+    EscalationID: ${esc_id}
+EOF
+                        auto_resolved=true
+                        ;;
+                    blocked)
+                        # Blocked: post directive for coordinator/god-delegate to address
+                        resolution_action="directive-posted"
+                        kubectl_with_timeout 10 apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-esc-directive-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-state"
+  thoughtType: directive
+  confidence: 9
+  content: |
+    COORDINATOR DIRECTIVE [escalation-response]: Agent blocked on dependency
+    Agent: ${agent}
+    Issue: ${issue_num:-(none)}
+    Blocked on: ${description}
+    Action: Resolve blocking dependency, then re-queue issue #${issue_num} for work.
+    EscalationID: ${esc_id}
+EOF
+                        auto_resolved=true
+                        ;;
+                    failed)
+                        # Failed: route to god-delegate
+                        resolution_action="routed-to-god-delegate"
+                        kubectl_with_timeout 10 apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-esc-directive-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-state"
+  thoughtType: directive
+  confidence: 9
+  content: |
+    COORDINATOR DIRECTIVE [escalation-response]: Agent task failed unrecoverably
+    Agent: ${agent}
+    Issue: ${issue_num:-(none)}
+    Failure: ${description}
+    Action: God-delegate — evaluate issue #${issue_num} and either close as won't-fix,
+    adjust requirements, or spawn architect for structural review.
+    EscalationID: ${esc_id}
+EOF
+                        auto_resolved=true
+                        ;;
+                esac
+                ;;
+            2)
+                # Tier 2 (decision): route to god-delegate
+                resolution_action="routed-to-god-delegate"
+                echo "[$(date -u +%H:%M:%S)] handle_escalations: Tier 2 decision — posting directive for god-delegate"
+                local options_block=""
+                [ -n "$options" ] && options_block="Options for god-delegate to choose: ${options}"
+                kubectl_with_timeout 10 apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-esc-directive-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-state"
+  thoughtType: directive
+  confidence: 9
+  content: |
+    COORDINATOR DIRECTIVE [escalation-response]: Decision required from god-delegate
+    Agent: ${agent}
+    Issue: ${issue_num:-(none)}
+    Decision needed: ${description}
+    ${options_block}
+    Action: God-delegate — make the decision and post a directive with the chosen option.
+    If an architecture decision, consider spawning an architect agent.
+    EscalationID: ${esc_id}
+EOF
+                auto_resolved=true
+                ;;
+            3)
+                # Tier 3 (security/proliferation/critical): post CRITICAL directive
+                resolution_action="critical-escalated"
+                echo "[$(date -u +%H:%M:%S)] CRITICAL ESCALATION: ${esc_id} severity=${severity} category=${category} agent=${agent}"
+                kubectl_with_timeout 10 apply -f - <<EOF >/dev/null 2>&1 || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-esc-critical-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-state"
+  thoughtType: directive
+  confidence: 9
+  content: |
+    🚨 CRITICAL ESCALATION [${category}/${severity}]: Immediate human attention required
+    Agent: ${agent}
+    Issue: ${issue_num:-(none)}
+    Description: ${description}
+    Action: Human/god-delegate must review immediately.
+    $([ "$category" = "security" ] && echo "SECURITY: Review for credentials, injection vulnerabilities, data exposure.")
+    $([ "$category" = "proliferation" ] && echo "PROLIFERATION: Consider activating kill switch if agent count is growing uncontrolled.")
+    EscalationID: ${esc_id}
+EOF
+                auto_resolved=true
+                ;;
+        esac
+
+        # Update escalation status in S3
+        if "$auto_resolved"; then
+            local resolved_json
+            resolved_json=$(echo "$esc_json" | jq \
+                --arg resolved_by "coordinator" \
+                --arg resolution "$resolution_action" \
+                --arg resolved_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                '.status = "resolved" | .resolvedBy = $resolved_by | .resolution = $resolution | .resolvedAt = $resolved_at')
+            echo "$resolved_json" | aws s3 cp - \
+                "s3://${IDENTITY_BUCKET}/escalations/${esc_id}.json" \
+                --content-type application/json >/dev/null 2>&1 || true
+            processed=$((processed + 1))
+            echo "[$(date -u +%H:%M:%S)] handle_escalations: ${esc_id} resolved via ${resolution_action}"
+        else
+            # Not yet resolvable — keep in queue
+            remaining_ids+=("$esc_id")
+            skipped=$((skipped + 1))
+        fi
+    done
+
+    # Update escalation queue with only remaining (unresolved) IDs
+    local new_queue_str
+    new_queue_str=$(IFS=','; echo "${remaining_ids[*]}")
+    update_state "escalationQueue" "${new_queue_str:-}"
+
+    if [ $processed -gt 0 ] || [ $skipped -gt 0 ]; then
+        echo "[$(date -u +%H:%M:%S)] handle_escalations: processed=${processed} skipped=${skipped} remaining_in_queue=${#remaining_ids[@]}"
+    fi
+}
+
 # Track debate activity — count debate threads, surface unresolved disagreements
 track_debate_activity() {
     local all_cm
@@ -3890,6 +4151,14 @@ while true; do
     # Every 5 iterations (~2.5 min): refresh task queue from GitHub
     if [ $((iteration % 5)) -eq 0 ]; then
         refresh_task_queue
+    fi
+
+    # Every 5 iterations (~2.5 min): process agent escalation queue (issue #1839)
+    # Agents call ax_escalate() in helpers.sh to signal problems needing coordinator help.
+    # This reads the escalationQueue field, applies tier-based auto-resolution, and
+    # routes decisions to god-delegate as needed.
+    if [ $((iteration % 5)) -eq 0 ]; then
+        handle_escalations
     fi
 
     # Every iteration: cleanup stale assignments

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -4658,6 +4658,27 @@ fi
 # Uses --watch with timeout for push notifications instead of polling.
 check_new_messages
 
+# ── 10.6. DETECT AGENT ESCALATION (issue #1839) ─────────────────────────────
+# Check if the agent called ax_escalate() and wrote an escalation state file.
+# If so, read the structured exit state and log it for visibility.
+# The escalation was already submitted to S3 + coordinator-state by ax_escalate().
+# Here we just log it and ensure the coordinator knows about it before we exit.
+if [ -f /tmp/agentex-escalation-state.json ]; then
+  ESCALATION_STATE=$(cat /tmp/agentex-escalation-state.json 2>/dev/null || echo "")
+  if [ -n "$ESCALATION_STATE" ]; then
+    ESC_SEVERITY=$(echo "$ESCALATION_STATE" | jq -r '.severity // "MEDIUM"' 2>/dev/null)
+    ESC_CATEGORY=$(echo "$ESCALATION_STATE" | jq -r '.category // "blocked"' 2>/dev/null)
+    ESC_TIER=$(echo "$ESCALATION_STATE" | jq -r '.tier // 1' 2>/dev/null)
+    ESC_ID=$(echo "$ESCALATION_STATE" | jq -r '.escalationId // ""' 2>/dev/null)
+    ESC_ISSUE=$(echo "$ESCALATION_STATE" | jq -r '.issue // ""' 2>/dev/null)
+    log "ESCALATION DETECTED: severity=${ESC_SEVERITY} category=${ESC_CATEGORY} tier=${ESC_TIER} id=${ESC_ID}"
+    push_metric "AgentEscalation" 1 "None"
+    push_metric "AgentEscalationTier${ESC_TIER}" 1 "None"
+    post_thought "Agent escalated: severity=${ESC_SEVERITY} category=${ESC_CATEGORY} tier=${ESC_TIER} issue=${ESC_ISSUE:-none}. Coordinator will process escalation ${ESC_ID} on next cycle." "observation" 7
+  fi
+  rm -f /tmp/agentex-escalation-state.json 2>/dev/null || true
+fi
+
 # ── 11.1. COST TRACKING (issue #607) ────────────────────────────────────────
 # Emit estimated Bedrock cost for this agent run to enable budget monitoring.
 # Sonnet 4.5 pricing: ~$3/M input tokens, ~$15/M output tokens.

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1509,5 +1509,317 @@ credit_mentor_for_success() {
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"
+# ── ax_escalate ───────────────────────────────────────────────────────────────
+# Issue #1839: Structured escalation protocol — tiered recovery paths.
+#
+# Agents call ax_escalate() when they need help they cannot self-resolve.
+# This is the primary "I need help" mechanism — structured, tiered, and
+# recoverable instead of a binary crash.
+#
+# Tiers:
+#   Tier 0 (retry)     — self-healing, no coordinator involvement
+#   Tier 1 (blocked/conflict) — coordinator reassigns or spawns fresh worker
+#   Tier 2 (decision)  — routed to god-delegate for resolution
+#   Tier 3 (security/proliferation/critical) — immediate human notification
+#
+# Severity levels: LOW | MEDIUM | HIGH | CRITICAL
+# Categories: retry | blocked | conflict | decision | failed | security | proliferation
+#
+# Usage:
+#   ax_escalate --severity medium --type blocked \
+#     --issue 789 \
+#     "Merge conflict in coordinator.go — 3 files conflict with main"
+#
+#   ax_escalate --severity high --type decision \
+#     --issue 789 \
+#     --options "SQLite,PostgreSQL,DynamoDB" \
+#     "Which database for the work ledger?"
+#
+#   ax_escalate --severity critical --type security \
+#     "Found exposed AWS credentials in PR #1830"
+#
+# Returns: 0 on success (escalation recorded), 1 on invalid arguments
+ax_escalate() {
+  local severity="MEDIUM"
+  local category="blocked"
+  local issue_num=""
+  local options=""
+  local description=""
+
+  # Parse arguments
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --severity|-s)
+        severity="${2^^}"  # uppercase
+        shift 2
+        ;;
+      --type|-t)
+        category="${2,,}"  # lowercase
+        shift 2
+        ;;
+      --issue|-i)
+        issue_num="$2"
+        shift 2
+        ;;
+      --options|-o)
+        options="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        description="$*"
+        break
+        ;;
+      -*)
+        log "ax_escalate: unknown flag $1 — ignoring"
+        shift
+        ;;
+      *)
+        description="$*"
+        break
+        ;;
+    esac
+  done
+
+  if [ -z "$description" ]; then
+    log "ERROR: ax_escalate requires a description"
+    echo "Usage: ax_escalate --severity MEDIUM --type blocked --issue N \"description\""
+    return 1
+  fi
+
+  # Validate severity
+  case "$severity" in
+    LOW|MEDIUM|HIGH|CRITICAL) ;;
+    *)
+      log "WARNING: ax_escalate: unknown severity '$severity' — defaulting to MEDIUM"
+      severity="MEDIUM"
+      ;;
+  esac
+
+  # Validate category
+  case "$category" in
+    retry|blocked|conflict|decision|failed|security|proliferation) ;;
+    *)
+      log "WARNING: ax_escalate: unknown category '$category' — defaulting to blocked"
+      category="blocked"
+      ;;
+  esac
+
+  # Determine tier based on category/severity
+  local tier
+  case "$category" in
+    retry)
+      tier=0
+      ;;
+    blocked|conflict|failed)
+      tier=1
+      ;;
+    decision)
+      tier=2
+      ;;
+    security|proliferation)
+      tier=3
+      ;;
+    *)
+      tier=1
+      ;;
+  esac
+  # CRITICAL severity always goes to Tier 3 regardless of category
+  if [ "$severity" = "CRITICAL" ]; then
+    tier=3
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local escalation_id
+  escalation_id="esc-${AGENT_NAME}-$(date +%s)"
+
+  # Build escalation JSON
+  local escaped_description
+  escaped_description=$(echo "$description" | jq -Rs '.')
+  local escaped_options
+  escaped_options=$(echo "${options:-}" | jq -Rs '.')
+
+  local escalation_json
+  escalation_json=$(jq -n \
+    --arg id "$escalation_id" \
+    --arg severity "$severity" \
+    --arg category "$category" \
+    --argjson tier "$tier" \
+    --arg agent "${AGENT_NAME:-unknown}" \
+    --arg issue "${issue_num:-}" \
+    --arg description "$description" \
+    --arg options "${options:-}" \
+    --arg status "open" \
+    --arg timestamp "$timestamp" \
+    --arg task_cr "${TASK_CR_NAME:-}" \
+    '{
+      id: $id,
+      severity: $severity,
+      category: $category,
+      tier: $tier,
+      agent: $agent,
+      issue: $issue,
+      taskCR: $task_cr,
+      description: $description,
+      options: $options,
+      status: $status,
+      createdAt: $timestamp
+    }')
+
+  log "ax_escalate: recording escalation id=${escalation_id} severity=${severity} category=${category} tier=${tier}"
+
+  # Persist escalation to S3 for coordinator to process
+  local s3_path="s3://${S3_BUCKET}/escalations/${escalation_id}.json"
+  local s3_output
+  if ! s3_output=$(echo "$escalation_json" | aws s3 cp - "$s3_path" --content-type application/json 2>&1); then
+    log "WARNING: ax_escalate: failed to write escalation to S3: $s3_output (continuing with coordinator-state update)"
+  else
+    log "ax_escalate: escalation persisted to S3: $s3_path"
+  fi
+
+  # Record escalation ID in coordinator-state.escalationQueue for coordinator to process
+  local current_queue
+  current_queue=$(kubectl_with_timeout 10 get configmap coordinator-state \
+    -n "$NAMESPACE" -o jsonpath='{.data.escalationQueue}' 2>/dev/null || echo "")
+  local new_queue
+  if [ -z "$current_queue" ]; then
+    new_queue="$escalation_id"
+  else
+    new_queue="${current_queue},${escalation_id}"
+  fi
+  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"escalationQueue\":\"${new_queue}\"}}" \
+    2>/dev/null && log "ax_escalate: escalation recorded in coordinator-state.escalationQueue" || \
+    log "WARNING: ax_escalate: failed to update coordinator-state (non-fatal — escalation is in S3)"
+
+  # Post a Thought CR so peers see the escalation immediately
+  local thought_type="blocker"
+  local thought_content="ESCALATION [${severity}/${category}/tier${tier}]:
+${description}"
+  if [ -n "$issue_num" ]; then
+    thought_content="${thought_content}
+Issue: #${issue_num}"
+  fi
+  if [ -n "$options" ]; then
+    thought_content="${thought_content}
+Options: ${options}"
+  fi
+  thought_content="${thought_content}
+EscalationID: ${escalation_id}
+Agent: ${AGENT_NAME:-unknown}"
+
+  post_thought "$thought_content" "$thought_type" 9 "escalation" "" "" 2>/dev/null || true
+
+  # For CRITICAL/Tier 3: also file a GitHub issue for human visibility
+  if [ "$tier" -ge 3 ] || [ "$severity" = "CRITICAL" ]; then
+    log "ax_escalate: CRITICAL/Tier-3 escalation — filing GitHub issue for human visibility"
+    local gh_issue_body
+    gh_issue_body=$(cat <<EOF
+## Escalation: ${severity}/${category}
+
+**Agent:** ${AGENT_NAME:-unknown}
+**Task CR:** ${TASK_CR_NAME:-unknown}
+**Issue:** ${issue_num:-(none)}
+**Escalation ID:** ${escalation_id}
+**Tier:** ${tier} (Human escalation required)
+
+### Description
+${description}
+
+$([ -n "$options" ] && echo "### Options\n${options}" || echo "")
+
+---
+*Auto-filed by ax_escalate() at ${timestamp}*
+*Closes #1839 (escalation protocol)*
+EOF
+)
+    local labels="escalation"
+    case "$category" in
+      security) labels="${labels},security" ;;
+      proliferation) labels="${labels},bug" ;;
+    esac
+
+    local gh_output
+    if gh_output=$(gh issue create \
+      --repo "${REPO:-pnz1990/agentex}" \
+      --title "ESCALATION [${severity}]: ${description:0:80}" \
+      --body "$gh_issue_body" \
+      --label "$labels" 2>/dev/null); then
+      log "ax_escalate: GitHub issue filed for CRITICAL escalation: $gh_output"
+    else
+      log "WARNING: ax_escalate: failed to file GitHub issue for CRITICAL escalation (non-fatal)"
+    fi
+  fi
+
+  # Return structured exit info by writing to temp file (for entrypoint.sh to read)
+  local exit_state_json
+  exit_state_json=$(jq -n \
+    --arg status "escalated" \
+    --arg severity "$severity" \
+    --arg category "$category" \
+    --argjson tier "$tier" \
+    --arg issue "${issue_num:-}" \
+    --arg description "$description" \
+    --arg id "$escalation_id" \
+    '{
+      status: $status,
+      severity: $severity,
+      category: $category,
+      tier: $tier,
+      issue: $issue,
+      description: $description,
+      escalationId: $id,
+      workPreserved: true
+    }')
+  echo "$exit_state_json" > /tmp/agentex-escalation-state.json 2>/dev/null || true
+
+  log "ax_escalate: escalation recorded — id=${escalation_id} tier=${tier} severity=${severity}"
+  log "  Coordinator will process this escalation on next cycle (~30s)"
+
+  return 0
+}
+
+# ── get_escalation_status ─────────────────────────────────────────────────────
+# Query the status of escalations from S3.
+# Usage: get_escalation_status [escalation_id]
+#        With no args: returns all open escalations
+#        With id: returns specific escalation
+# Returns: JSON (single object or array)
+get_escalation_status() {
+  local escalation_id="${1:-}"
+
+  if [ -n "$escalation_id" ]; then
+    # Specific escalation
+    local s3_path="s3://${S3_BUCKET}/escalations/${escalation_id}.json"
+    if aws s3 ls "$s3_path" >/dev/null 2>&1; then
+      aws s3 cp "$s3_path" - 2>/dev/null || echo "{}"
+    else
+      log "get_escalation_status: escalation $escalation_id not found in S3"
+      echo "{}"
+    fi
+    return 0
+  fi
+
+  # All escalations from S3
+  local files
+  files=$(aws s3 ls "s3://${S3_BUCKET}/escalations/" 2>/dev/null | awk '{print $4}')
+  if [ -z "$files" ]; then
+    echo "[]"
+    return 0
+  fi
+
+  local results="[]"
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    local content
+    content=$(aws s3 cp "s3://${S3_BUCKET}/escalations/${file}" - 2>/dev/null || echo "")
+    [ -z "$content" ] && continue
+    results=$(echo "$results" | jq -r --argjson item "$content" '. + [$item]' 2>/dev/null || echo "$results")
+  done <<< "$files"
+
+  echo "$results"
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, ax_escalate, get_escalation_status available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the tiered escalation protocol from issue #1839 — structured recovery paths for agents that are stuck, without crashing.

Closes #1839

## Problem Solved

Previously, agents had exactly one option when stuck: crash. This PR adds a structured `ax_escalate()` function that lets agents signal problems at different severity levels, with the coordinator providing automatic recovery based on escalation tier.

## Architecture

```
Agent → ax_escalate() → S3 + coordinator-state.escalationQueue
                                      ↓ (every ~2.5 min)
                     coordinator → handle_escalations()
                                      ↓
                     Tier 0: re-queue task (retry)
                     Tier 1: directive Thought CR (blocked/conflict/failed)
                     Tier 2: god-delegate Thought CR (decision)
                     Tier 3: CRITICAL directive + GitHub issue (security/proliferation)
```

## Changes

### `images/runner/helpers.sh`
- **`ax_escalate()`** — primary agent CLI for escalations:
  - `--severity LOW|MEDIUM|HIGH|CRITICAL`
  - `--type retry|blocked|conflict|decision|failed|security|proliferation`
  - `--issue N` — related GitHub issue
  - `--options "opt1,opt2"` — for `decision` type
  - Persists to `s3://agentex-thoughts/escalations/<id>.json`
  - Updates `coordinator-state.escalationQueue`
  - Posts blocker Thought CR for peer visibility
  - CRITICAL: files GitHub issue for human attention
  - Writes exit state to `/tmp/agentex-escalation-state.json`
- **`get_escalation_status()`** — query S3 for escalation status

### `images/runner/coordinator.sh`
- **`handle_escalations()`** — processes escalation queue:
  - Tier 0 (retry): re-queues task automatically
  - Tier 1 (blocked/conflict/failed): posts coordinator directive
  - Tier 2 (decision): routes to god-delegate
  - Tier 3 (security/CRITICAL): posts CRITICAL directive
  - Updates S3 escalation records with resolution
- `ensure_state_fields_initialized()` — adds `escalationQueue` field
- Main loop — calls `handle_escalations()` every 5 iterations (~2.5 min)

### `images/runner/entrypoint.sh`
- Section 10.6: detect `/tmp/agentex-escalation-state.json` after OpenCode exits
- Logs escalation details, pushes CloudWatch metrics

### `AGENTS.md`
- Documents `escalationQueue` coordinator state field
- Documents `ax_escalate()` and `get_escalation_status()` with examples

## Usage

```bash
source /agent/helpers.sh

# Transient failure — auto-retry
ax_escalate --severity low --type retry --issue 789 "GitHub API rate-limited, retrying in 5 min"

# Merge conflict — coordinator spawns fresh worker
ax_escalate --severity medium --type conflict --issue 789 "Conflict in coordinator.go — 3 files"

# Architecture decision — routes to god-delegate
ax_escalate --severity high --type decision --issue 789 \
  --options "SQLite,PostgreSQL,DynamoDB" \
  "Which database for the work ledger?"

# Security issue — human notification
ax_escalate --severity critical --type security \
  "Found exposed AWS credentials in PR #1830"
```

## Success Criteria Status

- ✅ Agents can signal "I need help" without crashing
- ✅ Transient failures auto-recover via retry (coordinator re-queues)
- ✅ Merge conflicts trigger coordinator directive for fresh worker spawn
- ✅ Decisions route to god-delegate via directive Thought CR
- ✅ CRITICAL escalations file GitHub issue within the same run
- ⏳ Dashboard integration (#1836) — depends on future dashboard implementation