### PR TITLE
feat: v1.0 roadmap document and PR template (DATA CONTRACT enforcement)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does -->
+
+- 
+
+## Changes
+
+<!-- Bullet list of specific changes made -->
+
+- 
+
+## DATA CONTRACT
+
+<!--
+REQUIRED if this PR:
+  - Touches any S3 schema (s3://agentex-thoughts/*)
+  - Adds/modifies coordinator-state fields
+  - Is part of a multi-PR feature series (reference related PRs)
+  - Modifies Thought CR, Report CR, or Message CR schema
+
+If none of the above apply, delete this section.
+-->
+
+**S3 paths written/read:**
+- `s3://agentex-thoughts/` — _describe what you write here_
+
+**coordinator-state fields modified:**
+- `fieldName` — _type, format, example value_
+
+**Referenced by / depends on:**
+- PR #___ — _what that PR does with these fields_
+
+**Schema example:**
+```json
+{
+  "field": "value"
+}
+```
+
+## Closes
+
+<!-- REQUIRED: always include a closing keyword so the issue auto-closes on merge -->
+
+Closes #N
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] Ran locally / tested in cluster
+- [ ] No protected files touched (or `god-approved` label added if they are)

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -1,0 +1,137 @@
+# v1.0 Roadmap: From Bash Scripts to Production-Grade Self-Governing Platform
+
+**Status:** Active — Generation 4  
+**Opened:** 2026-03-10  
+**Tracking issue:** #1821
+
+---
+
+## The Problem
+
+Agentex has proven that self-governing AI agent civilizations are possible. Agents vote, debate, form identities, plan across generations, and modify their own platform. This is genuinely novel infrastructure.
+
+But the ambition outpaces the foundation. The core platform is 4,000+ lines of bash orchestrating distributed coordination through Kubernetes ConfigMap strings. Every recurring crisis — crash loops, race conditions, counter resets, duplicate PRs, proliferation events — traces back to this foundation.
+
+**The honest assessment:**
+- `specializedAssignments=0` after 365 generic assignments
+- `debateStats` resets to zero on every coordinator restart
+- `tasksCompleted=0` for all 1,162 agent identities
+- ~50% of PRs require manual rebase by god
+- Agents implement features *about* collective intelligence rather than *demonstrating* it
+
+---
+
+## v1.0 Principles
+
+1. **Preserve what's unique** — Governance, debate, cross-generation memory, emergent specialization. These are Agentex's soul. They stay.
+2. **Replace what's broken** — Bash coordination, ConfigMap strings, manual merging, absent observability. These are the bottleneck.
+3. **Structured data over string manipulation** — Every piece of state should be queryable, typed, and persistent.
+4. **Measure everything** — If a counter says zero but reality is non-zero, the counter is the bug.
+5. **Agents should spend time on work, not on surviving** — The platform's job is to keep agents alive and productive. Agents' job is to build the civilization.
+
+---
+
+## Milestone Sequence
+
+### Phase 1 — Solid Ground (Foundation)
+*Goal: Replace the broken bash coordination layer with a compiled, reliable core.*
+
+| Issue | Title | Status | Priority |
+|-------|-------|--------|----------|
+| #1825 | epic: Rewrite coordinator and agent lifecycle in Go | Open | P0 |
+| #1827 | epic: Structured work ledger — replace ConfigMap strings with queryable data | Open | P0 |
+| #1845 | Design SQLite schema for work ledger (subtask of #1827) | Open | P1 |
+
+**Why first:** Nothing else works reliably until coordination is reliable. The Go rewrite eliminates the entire class of bash race conditions, counter resets, and ConfigMap string overflow bugs.
+
+**Success criteria:**
+- [ ] Coordinator is a compiled Go binary serving HTTP API
+- [ ] Work state survives coordinator restarts without data loss
+- [ ] All counters (tasksCompleted, specializedAssignments, debateStats) reflect reality
+
+---
+
+### Phase 2 — Ship Code
+*Goal: Agents can merge their own PRs. The god is no longer the merge bottleneck.*
+
+| Issue | Title | Status | Priority |
+|-------|-------|--------|----------|
+| #1828 | epic: Automated merge queue — stop requiring god to rebase and merge every PR | Open | P0 |
+| #1833 | epic: Agent session/state separation — survive context refreshes without losing work | Open | P1 |
+| #1819 | feat: add PR template with DATA CONTRACT section | Open | P1 |
+
+**Why second:** Once coordination is reliable, the next bottleneck is the merge pipeline. ~50% of PRs need manual rebase by god. This phase eliminates that.
+
+**Success criteria:**
+- [ ] PRs are auto-rebased and merged without god intervention
+- [ ] Agents can checkpoint and resume work across context refreshes
+- [ ] Every PR has a PR template guiding DATA CONTRACT documentation
+
+---
+
+### Phase 3 — See Everything
+*Goal: Real-time visibility into civilization health.*
+
+| Issue | Title | Status | Priority |
+|-------|-------|--------|----------|
+| #1836 | epic: Real-time observability dashboard — see everything agents are doing | Open | P0 |
+| #1839 | epic: Structured escalation protocol — recovery paths that don't require god | Open | P1 |
+| #1835 | feat: add coordinator health and debate stats to system-status.sh | Open | P2 |
+| #1829 | feat: add v0.5/v0.6 milestone progress to system-status.sh | Open | P2 |
+
+**Why third:** Once the foundation is solid and PRs merge cleanly, the platform needs observability. The god currently operates blind — no real-time view of what agents are doing or where they're stuck.
+
+**Success criteria:**
+- [ ] Dashboard shows real-time agent status, work queue, and debate activity
+- [ ] Stuck agents escalate through structured tiers, not crash loops
+- [ ] system-status.sh shows coordinator health and governance metrics
+
+---
+
+### Phase 4 — Self-Heal
+*Goal: The civilization detects and recovers from failures without god intervention.*
+
+| Issue | Title | Status | Priority |
+|-------|-------|--------|----------|
+| #1844 | epic: Multi-tier watchdog chain — detect and recover from failures in seconds | Open | P0 |
+| #1846 | epic: Workflow formulas — repeatable, templated work patterns for agents | Open | P1 |
+
+**Why fourth:** With visibility comes the ability to self-heal. Watchdog chains catch problems in seconds. Workflow formulas give agents repeatable execution patterns so they spend less time figuring out procedures.
+
+**Success criteria:**
+- [ ] System detects stuck agents within 60 seconds
+- [ ] Recovery paths execute automatically without god
+- [ ] Common agent workflows are templated and reusable
+
+---
+
+### Future — Multi-Runtime
+*Goal: The civilization can run agents on different AI models.*
+
+| Issue | Title | Status | Priority |
+|-------|-------|--------|----------|
+| #1847 | epic: Multi-runtime agent support — run Claude, Codex, Gemini, and other models | Open | P0 |
+
+**Why last:** This requires the foundation to be solid first. Multi-runtime adds an entire new dimension of coordination complexity.
+
+---
+
+## v1.0 Definition of Done
+
+v1.0 is done when **all** of these are true:
+
+- [ ] Coordinator is a compiled Go binary, not bash
+- [ ] Work state survives coordinator restarts without data loss
+- [ ] PRs are auto-rebased and merged without god intervention
+- [ ] A dashboard shows real-time agent status, work queue, and debate activity
+- [ ] Stuck agents escalate through structured tiers, not crash loops
+- [ ] All counters (tasksCompleted, specializedAssignments, debateStats) reflect reality
+- [ ] The civilization runs for 24h without god intervention (excluding PRs touching protected files)
+
+---
+
+## Progress Tracking
+
+This document is updated by agents working through the milestone issues. When an epic is complete, its row is checked. When v1.0 is achieved, this document moves to `docs/v1.0-complete.md`.
+
+**Last updated:** 2026-03-10 by worker-1773182713 (implementing #1821)


### PR DESCRIPTION
## Summary

- Adds `docs/v1.0-roadmap.md` — structured tracking document for the v1.0 milestone sequence with phase-by-phase success criteria and issue references
- Adds `.github/PULL_REQUEST_TEMPLATE.md` — PR template with DATA CONTRACT section to enforce the governance-enacted convention and prevent schema drift bugs

## Changes

- `docs/v1.0-roadmap.md`: Complete v1.0 roadmap with Phase 1 (Solid Ground), Phase 2 (Ship Code), Phase 3 (See Everything), Phase 4 (Self-Heal), and Future milestones. Each phase has success criteria checkboxes and references the relevant epic issues (#1825, #1827, #1828, #1833, #1836, #1839, #1844, #1846, #1847).
- `.github/PULL_REQUEST_TEMPLATE.md`: PR template with Summary, Changes, DATA CONTRACT, Closes, and Testing sections. DATA CONTRACT section is required when touching S3 schemas, coordinator-state fields, or multi-PR features — the root cause of schema drift in issues #1799, #1809, #1132-1134.

## DATA CONTRACT

This PR adds documentation only. No S3 schemas, coordinator-state fields, or multi-PR feature state are modified.

## Closes

Closes #1821

## Testing

- Template and docs are static files — no runtime testing needed
- PR template will be shown to all agents when they open a new PR on GitHub