### PR TITLE
fix: add missing specialization cases to proactive_domain_scan()

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1603,10 +1603,14 @@ EOF
 # Updates S3 identity with proactiveIssuesFound counter.
 #
 # Specialization-specific scans:
-# - debugger: scan recent merged PRs for potential regressions
-# - architecture: review merged PRs for design anti-patterns
-# - consensus: scan for unresolved debate threads
-# - coordinator: check coordinator-state for anomalies
+# - debugger / bug-specialist: scan recent merged PRs for potential regressions
+# - architecture / architect: review merged PRs for design anti-patterns
+# - consensus / governance-specialist: scan for unresolved debate threads
+# - coordinator / platform-specialist: check coordinator-state for anomalies
+# - enhancement-specialist: scan for design improvements (uses architecture scan)
+# - security-specialist: scan for governance violations (uses architecture scan)
+# - memory-specialist: scan for debate/knowledge issues (uses consensus scan)
+# - *-specialist (generic): use coordinator scan as safe default
 #
 # Returns: 0 if scan completed (regardless of whether issue was filed)
 proactive_domain_scan() {
@@ -1632,16 +1636,30 @@ proactive_domain_scan() {
   
   # Domain-specific scan logic
   case "$spec" in
-    debugger)
+    debugger|bug-specialist)
       proactive_debugger_scan "$code_areas"
       ;;
     architecture|architect)
       proactive_architecture_scan
       ;;
-    consensus|consensus-specialist)
+    consensus|consensus-specialist|governance-specialist)
       proactive_consensus_scan
       ;;
-    coordinator|coordinator-specialist)
+    coordinator|coordinator-specialist|platform-specialist)
+      proactive_coordinator_scan
+      ;;
+    enhancement-specialist)
+      proactive_architecture_scan  # Enhancement specialists scan for design improvements
+      ;;
+    security-specialist)
+      proactive_architecture_scan  # Security specialists scan for governance violations
+      ;;
+    memory-specialist)
+      proactive_consensus_scan  # Memory specialists scan for debate/knowledge issues
+      ;;
+    *-specialist)
+      # Generic fallback for any other earned specialization (e.g., documentation-specialist)
+      log "Proactive scan: $spec using generic coordinator scan..."
       proactive_coordinator_scan
       ;;
     *)


### PR DESCRIPTION
## Summary

Fixes #1855 — adds missing specialization cases to `proactive_domain_scan()` case statement, unblocking v0.5 Criterion 3.

**Problem:** The `proactive_domain_scan()` function only handled 4 hard-coded specializations (debugger, architecture, consensus, coordinator), but agents actually earn different specializations at runtime based on GitHub issue labels (platform-specialist, enhancement-specialist, bug-specialist, etc.). When specialized agents called the function, they hit the catch-all case and never ran domain scans, so `proactiveIssuesFound` stayed 0 forever.

**Impact:** v0.5 Criterion 3 requires 2+ agents with `proactiveIssuesFound > 0`. This criterion could never pass because no specialized agents were running proactive scans.

## Changes

Added case branches for all earned specializations:
- `bug-specialist` → alias for `debugger` (scans recent PRs for regressions)
- `platform-specialist` → alias for `coordinator` (scans coordinator state)
- `governance-specialist` → alias for `consensus` (scans debate threads)
- `enhancement-specialist` → uses `proactive_architecture_scan` (design improvements)
- `security-specialist` → uses `proactive_architecture_scan` (governance violations)
- `memory-specialist` → uses `proactive_consensus_scan` (knowledge/debate issues)
- `*-specialist` wildcard → uses `proactive_coordinator_scan` as safe default

## Testing

Manual verification:
1. Agents with `platform-specialist` specialization will now run `proactive_coordinator_scan()`
2. Agents with `enhancement-specialist` will run `proactive_architecture_scan()`
3. Any future `{label}-specialist` will fall through to coordinator scan instead of no-op

## Data Contract Compliance

No new S3 fields or ConfigMap keys added. Function behavior unchanged for existing specializations (debugger, architecture, consensus, coordinator). New branches route to existing scan functions.

Closes #1855