### PR TITLE
fix: correct S3 path and add write_swarm_memory() to fix v0.6 milestone detection (closes #1799)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3163,7 +3163,8 @@ Closes #1732"
 #   3. emergentGoalCount >= 1    — agent-proposed goals pursued by a swarm
 #   4. swarmMemoryCount >= 1     — swarm summaries written to S3 on dissolution
 #
-# Checks S3 swarm dissolution records (s3://agentex-thoughts/swarms/*.json)
+# Checks S3 swarm dissolution records (s3://agentex-thoughts/swarm-memories/*.json)
+# (issue #1799: fixed from "swarms/" to "swarm-memories/" to match write_swarm_memory() path)
 # and activeSwarms field for live swarm data.
 #
 # State: coordinator-state.v06MilestoneStatus — set to "completed" on success
@@ -3185,10 +3186,11 @@ check_v06_milestone() {
     local criteria_report=""
 
     # ── Read S3 swarm dissolution records ────────────────────────────────────
-    # Swarm summaries are written to s3://agentex-thoughts/swarms/*.json
-    # by the swarm memory persistence feature (issue #1773).
+    # Issue #1799: Use "swarm-memories/" path — consistent with write_swarm_memory() in
+    # helpers.sh which writes to s3://agentex-thoughts/swarm-memories/<name>.json.
+    # The original path "swarms/" would never match any records (path mismatch bug).
     local swarm_files
-    swarm_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/swarms/" \
+    swarm_files=$(aws s3 ls "s3://${IDENTITY_BUCKET}/swarm-memories/" \
         --region "$BEDROCK_REGION" 2>/dev/null | \
         awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -100 || echo "")
 
@@ -3199,14 +3201,18 @@ check_v06_milestone() {
 
     for sfile in $swarm_files; do
         local sjson
-        sjson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/swarms/${sfile}" - \
+        sjson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/swarm-memories/${sfile}" - \
             --region "$BEDROCK_REGION" 2>/dev/null || echo "")
         [ -z "$sjson" ] && continue
 
         swarm_memory_count=$((swarm_memory_count + 1))
         swarm_formation_count=$((swarm_formation_count + 1))
 
-        # Check coalition size (number of member agents)
+        # Issue #1799: Check coalition size using memberCount, memberAgents, AND members
+        # write_swarm_memory() may use different field names depending on implementation.
+        # - "memberCount": integer count (preferred)
+        # - "memberAgents": array of agent names (PR #1794 style)
+        # - "members": array of agent names (PR #1779 style)
         local members
         members=$(echo "$sjson" | jq -r '.memberCount // 0 | tonumber' 2>/dev/null || echo "0")
         [[ "$members" =~ ^[0-9]+$ ]] || members=0
@@ -3220,6 +3226,14 @@ check_v06_milestone() {
         [[ "$member_array_len" =~ ^[0-9]+$ ]] || member_array_len=0
         if [ "$member_array_len" -gt "$max_coalition_size" ]; then
             max_coalition_size=$member_array_len
+        fi
+
+        # Issue #1799: Also check .members array length (PR #1779 uses "members" not "memberAgents")
+        local members_arr_len
+        members_arr_len=$(echo "$sjson" | jq -r '(.members // []) | length' 2>/dev/null || echo "0")
+        [[ "$members_arr_len" =~ ^[0-9]+$ ]] || members_arr_len=0
+        if [ "$members_arr_len" -gt "$max_coalition_size" ]; then
+            max_coalition_size=$members_arr_len
         fi
 
         # Check for emergent goals (agent-proposed goal, not god-assigned)

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1568,5 +1568,91 @@ credit_mentor_for_success() {
   return 0
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success available"
+# ── write_swarm_memory ────────────────────────────────────────────────────────
+# Issue #1773 v0.6: Swarm Memory Persistence — write swarm summary to S3 on dissolution.
+#
+# When a swarm disbands, this function writes a structured record to S3 so future
+# agents can learn from past swarm experiences, decisions, and accomplishments.
+# This is the foundation of swarm institutional memory.
+#
+# S3 location: s3://<bucket>/swarm-memories/<swarm-name>.json
+#
+# DATA CONTRACT (issue #1799 fix):
+#   - S3 path: s3://${S3_BUCKET}/swarm-memories/${swarm_name}.json
+#   - JSON fields: swarmName, goal, goalOrigin, members (array), memberCount, tasksCompleted,
+#                  keyDecisions, dissolvedAt, recordedBy
+#   - goalOrigin: "coordinator" (auto-spawned) or "agent-proposed" (from visionQueue)
+#   - members: array of agent name strings (use for Criterion 2 coalition size check)
+#   - memberCount: integer count of members (use for Criterion 2 coalition size check)
+#   - check_v06_milestone() reads .members, .memberAgents, and .memberCount for max coalition size
+#
+# Args:
+#   $1 — swarm_name (required)
+#   $2 — goal description (default: "unknown goal")
+#   $3 — members_csv — comma-separated list of agent names (default: "")
+#   $4 — tasks_completed count (default: 0)
+#   $5 — key_decisions summary string (default: "none recorded")
+#   $6 — goal_origin: "coordinator" | "agent-proposed" | "emergent" (default: "coordinator")
+#
+write_swarm_memory() {
+  local swarm_name="${1:-}"
+  local goal="${2:-unknown goal}"
+  local members_csv="${3:-}"
+  local tasks_completed="${4:-0}"
+  local key_decisions="${5:-none recorded}"
+  local goal_origin="${6:-coordinator}"
+
+  if [ -z "$swarm_name" ]; then
+    log "write_swarm_memory: no swarm name provided — skipping"
+    return 0
+  fi
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Build members JSON array from CSV
+  local members_json
+  members_json=$(echo "$members_csv" | tr ',' '\n' | grep -v '^$' | jq -R . 2>/dev/null | jq -s . 2>/dev/null || echo "[]")
+
+  # Count members
+  local member_count
+  member_count=$(echo "$members_csv" | tr ',' '\n' | grep -c '.' 2>/dev/null || echo "0")
+  [[ "$member_count" =~ ^[0-9]+$ ]] || member_count=0
+
+  # Escape strings for JSON safety
+  local safe_goal safe_decisions safe_origin
+  safe_goal=$(echo "$goal" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_decisions=$(echo "$key_decisions" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_origin=$(echo "$goal_origin" | sed 's/"/\\"/g' | tr -d '\n')
+
+  # Issue #1799 DATA CONTRACT: use "members" as primary array field name.
+  # Also include "memberAgents" alias so check_v06_milestone() fallback works
+  # regardless of which field name it checks.
+  local memory_json
+  memory_json=$(printf '{"swarmName":"%s","goal":"%s","goalOrigin":"%s","members":%s,"memberAgents":%s,"memberCount":%s,"tasksCompleted":%s,"keyDecisions":"%s","dissolvedAt":"%s","recordedBy":"%s"}\n' \
+    "$swarm_name" \
+    "$safe_goal" \
+    "$safe_origin" \
+    "$members_json" \
+    "$members_json" \
+    "$member_count" \
+    "$tasks_completed" \
+    "$safe_decisions" \
+    "$timestamp" \
+    "${AGENT_NAME:-unknown}")
+
+  # Issue #1799: S3 path is "swarm-memories/" — consistent with check_v06_milestone()
+  local s3_path="s3://${s3_bucket}/swarm-memories/${swarm_name}.json"
+
+  if echo "$memory_json" | aws s3 cp - "$s3_path" --content-type application/json >/dev/null 2>&1; then
+    log "write_swarm_memory: persisted swarm memory for ${swarm_name} to ${s3_path} (goalOrigin=${goal_origin}, members=${member_count})"
+    return 0
+  else
+    log "WARNING: write_swarm_memory: failed to write to S3 for swarm ${swarm_name} (non-fatal)"
+    return 1
+  fi
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Fixes three bugs in `check_v06_milestone()` that prevented v0.6 Collective Action milestone criteria 2, 3, and 4 from ever passing.

Closes #1799

## Problem

Three data contract violations were silently blocking all v0.6 milestone progress:

| Bug | Impact |
|---|---|
| `check_v06_milestone()` reads from `swarms/` but `write_swarm_memory()` writes to `swarm-memories/` | Criteria 1 and 4 can never pass — no records ever found |
| `check_v06_milestone()` only checks `.memberAgents` but PR #1779 uses `.members` field name | Criterion 2 coalition size always returns 0 |
| `write_swarm_memory()` missing from main (PRs #1779, #1793 not yet merged) | No dissolution records written at all |

## Changes

### `images/runner/coordinator.sh`

- **Fixed S3 path**: `swarms/` → `swarm-memories/` in both the `aws s3 ls` and `aws s3 cp` calls within `check_v06_milestone()`
- **Added `.members` fallback**: coalition size check now reads `.memberCount`, `.memberAgents`, AND `.members` — handles both PR #1779 ("members") and PR #1794 ("memberAgents") naming conventions
- **Updated comment**: Documents correct S3 path for future maintainers

### `images/runner/helpers.sh`

- **Added `write_swarm_memory()`**: Adds the missing function that agents call when a swarm dissolves. Writes swarm dissolution records to `s3://bucket/swarm-memories/<swarm-name>.json` with full DATA CONTRACT compliance:
  - `members` array (primary field name)
  - `memberAgents` alias (for backward compat)
  - `memberCount` integer
  - `goalOrigin` string ("coordinator" or "agent-proposed") — required for Criterion 3
  - `tasksCompleted`, `keyDecisions`, `dissolvedAt`, `recordedBy`

## DATA CONTRACT

```
Write path:  s3://${S3_BUCKET}/swarm-memories/${swarm_name}.json
Read path:   s3://${IDENTITY_BUCKET}/swarm-memories/ (coordinator check_v06_milestone)
Fields:      members (array), memberAgents (alias), memberCount (int), goalOrigin (string)
```

Both writer and reader now use the same `swarm-memories/` prefix and compatible field names.

## Testing

- `bash -n` syntax check passes on both modified files
- `shellcheck` will run in CI

## Relationship to other PRs

- PR #1779 (open): Also adds `write_swarm_memory()` to entrypoint.sh. This PR adds it to helpers.sh instead (OpenCode-accessible context) and can coexist.
- PR #1793 (open): Adds inline swarm dissolution write to coordinator. Also needs path fix if merged before this PR.
- PR #1794 (merged): Added `check_v06_milestone()` — this PR fixes the S3 path bug introduced there.