### PR TITLE
perf: merge criteria 1/3/4 S3 loops into single pass in check_v05_milestone() (closes #1764)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2942,9 +2942,11 @@ check_v05_milestone() {
     local criteria_met=0
     local criteria_report=""
 
-    # ── Criterion 1: 3+ agents with promotedRole ─────────────────────────────
-    local promoted_count=0
-    # Scan identity files in S3 for promotedRole field.
+    # ── Criteria 1, 3, 4: Single S3 download loop (issue #1764) ─────────────
+    # All three criteria use the same identity files — download each file once
+    # and extract all three metrics in a single pass. This reduces S3 API calls
+    # from 150 (3 loops × 50 files) to 50 (1 loop × 50 files).
+    #
     # Issue #1808: Sort by modification date DESCENDING (newest first) to ensure recent
     # worker identities are sampled. Without this, alphabetical S3 ordering returns
     # god-delegates and planners first (alphabetically earlier), and workers last —
@@ -2955,16 +2957,33 @@ check_v05_milestone() {
         --region "$BEDROCK_REGION" 2>/dev/null | \
         sort -k1,2 -r | awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -50 || echo "")
 
+    local promoted_count=0
+    local proactive_count=0
+    local mentor_credit_count=0
+
     for ifile in $identity_files; do
         local ijson
         ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
             --region "$BEDROCK_REGION" 2>/dev/null || echo "")
         [ -z "$ijson" ] && continue
+
+        # Criterion 1: promotedRole
         local prole
         prole=$(echo "$ijson" | jq -r '.promotedRole // ""' 2>/dev/null || echo "")
         [ -n "$prole" ] && promoted_count=$((promoted_count + 1))
+
+        # Criterion 3: proactiveIssuesFound (under .stats.proactiveIssuesFound per issue #1759)
+        local pif
+        pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
+        [ "$pif" -gt 0 ] 2>/dev/null && proactive_count=$((proactive_count + 1))
+
+        # Criterion 4: mentorCredits array length (under .specializationDetail.mentorCredits per issue #1759)
+        local mc
+        mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
+        [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
     done
 
+    # ── Criterion 1: 3+ agents with promotedRole ─────────────────────────────
     if [ "$promoted_count" -ge 3 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 1: Dynamic role promotions — ${promoted_count} agents promoted\n"
@@ -2993,19 +3012,7 @@ check_v05_milestone() {
     echo "[$(date -u +%H:%M:%S)] v0.5 Criterion 2: ${edge_count} trust graph edges (need 5)"
 
     # ── Criterion 3: 2+ agents with proactiveIssuesFound > 0 ─────────────────
-    local proactive_count=0
-    for ifile in $identity_files; do
-        local ijson
-        ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
-            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
-        [ -z "$ijson" ] && continue
-        local pif
-        # Issue #1759: proactiveIssuesFound is stored under .stats.proactiveIssuesFound
-        # NOT at top-level .proactiveIssuesFound (which is how identity.sh writes it).
-        pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber' 2>/dev/null || echo "0")
-        [ "$pif" -gt 0 ] 2>/dev/null && proactive_count=$((proactive_count + 1))
-    done
-
+    # (counts computed in combined S3 loop above)
     if [ "$proactive_count" -ge 2 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 3: Proactive issue discovery — ${proactive_count} agents discovered issues\n"
@@ -3015,21 +3022,7 @@ check_v05_milestone() {
     echo "[$(date -u +%H:%M:%S)] v0.5 Criterion 3: ${proactive_count} agents with proactiveIssuesFound > 0 (need 2)"
 
     # ── Criterion 4: 1+ agent with mentorCredits > 0 ─────────────────────────
-    local mentor_credit_count=0
-    for ifile in $identity_files; do
-        local ijson
-        ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
-            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
-        [ -z "$ijson" ] && continue
-        local mc
-        # Issue #1759: mentorCredits is stored as an ARRAY at
-        # .specializationDetail.mentorCredits (written by credit_mentor_for_success() in helpers.sh).
-        # It is NOT a top-level integer .mentorCredits.
-        # Check if array has at least 1 entry using | length.
-        mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
-        [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
-    done
-
+    # (counts computed in combined S3 loop above)
     if [ "$mentor_credit_count" -ge 1 ]; then
         criteria_met=$((criteria_met + 1))
         criteria_report="${criteria_report}✅ Criterion 4: Mentor credit loop — ${mentor_credit_count} mentor(s) credited\n"


### PR DESCRIPTION
## Summary

Merges three separate S3 download loops for criteria 1, 3, and 4 in `check_v05_milestone()` into a single loop that downloads each identity file once and extracts all metrics in one pass.

Closes #1764

## Problem

`check_v05_milestone()` in `coordinator.sh` previously had three separate `for ifile in $identity_files` loops that each downloaded the same 50 S3 identity files:

- **Loop 1** (Criterion 1): Downloads all 50 files to check `promotedRole`
- **Loop 2** (Criterion 3): Downloads all 50 files **again** to check `stats.proactiveIssuesFound`
- **Loop 3** (Criterion 4): Downloads all 50 files **a third time** to check `specializationDetail.mentorCredits`

Total: **150 S3 API calls** per `check_v05_milestone()` invocation (every ~10 minutes)

## Fix

Single loop that extracts all three metrics per file in one pass:

```bash
# Before: 3 separate loops × 50 files = 150 aws s3 cp calls
# After:  1 combined loop × 50 files = 50 aws s3 cp calls (67% reduction)

for ifile in $identity_files; do
    ijson=$(aws s3 cp ...)
    # Criterion 1: promotedRole
    prole=$(echo "$ijson" | jq -r '.promotedRole // ""')
    [ -n "$prole" ] && promoted_count=$((promoted_count + 1))
    # Criterion 3: proactiveIssuesFound
    pif=$(echo "$ijson" | jq -r '.stats.proactiveIssuesFound // 0 | tonumber')
    [ "$pif" -gt 0 ] && proactive_count=$((proactive_count + 1))
    # Criterion 4: mentorCredits
    mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length')
    [ "$mc" -gt 0 ] && mentor_credit_count=$((mentor_credit_count + 1))
done
```

## Impact

- **67% reduction in S3 API calls** per milestone check (150 → 50)
- **5-10 seconds saved** per check (each `aws s3 cp` ~50-100ms × 100 fewer calls)
- **No behavioral change** — criteria still evaluate identically
- **Only `coordinator.sh` modified** (not a protected file)

## Files Changed

- `images/runner/coordinator.sh` — merged three S3 loops into one in `check_v05_milestone()` (~55 lines changed)