### PR TITLE
fix: coordinator check_swarm_dissolution() now persists swarm memory to S3

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1179,7 +1179,7 @@ check_swarm_dissolution() {
     local checked=0
 
     # Process each swarm state CM
-    while IFS=$'\t' read -r swarm_name phase last_ts member_agents total_tasks; do
+    while IFS=$'\t' read -r swarm_name phase last_ts member_agents total_tasks swarm_goal; do
         [ -z "$swarm_name" ] && continue
         [ "$phase" = "Disbanded" ] && continue
 
@@ -1223,12 +1223,50 @@ check_swarm_dissolution() {
         # DISSOLUTION: all tasks done, idle > 300s, not yet Disbanded
         echo "[$(date -u +%H:%M:%S)] SWARM DISSOLUTION: $swarm_ref completed all $total tasks, idle ${idle_seconds}s — disbanding"
 
+        # CRITICAL (issue #1790): Write swarm memory to S3 before disbanding
+        # The entrypoint.sh path calls write_swarm_memory() from helpers.sh when an agent
+        # with SWARM_REF exits. The coordinator path must also persist swarm memory so that
+        # coordinator-driven dissolutions (the common path) don't silently lose institutional knowledge.
+        #
+        # Inline implementation (coordinator.sh doesn't source helpers.sh):
+        local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+        local timestamp
+        timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        
+        # Build members JSON array from member_agents (already CSV format from CM data)
+        local members_json
+        members_json=$(echo "$member_agents" | tr ',' '\n' | jq -R . 2>/dev/null | jq -s . 2>/dev/null || echo "[]")
+        
+        # Escape strings for JSON
+        local safe_goal
+        safe_goal=$(echo "$swarm_goal" | sed 's/"/\\"/g' | tr '\n' ' ')
+        
+        # Key decisions: extract from coordinator thought history or swarm state if available
+        local key_decisions="Coordinator-driven dissolution: all tasks completed, idle threshold met"
+        
+        local memory_json
+        memory_json=$(printf '{"swarmName":"%s","goal":"%s","members":%s,"tasksCompleted":%s,"keyDecisions":"%s","dissolvedAt":"%s","recordedBy":"coordinator"}\n' \
+          "$swarm_ref" \
+          "$safe_goal" \
+          "$members_json" \
+          "$total" \
+          "$key_decisions" \
+          "$timestamp")
+        
+        local s3_path="s3://${s3_bucket}/swarm-memories/${swarm_ref}.json"
+        
+        if echo "$memory_json" | aws s3 cp - "$s3_path" --content-type application/json >/dev/null 2>&1; then
+          echo "[$(date -u +%H:%M:%S)] Swarm memory persisted to ${s3_path}"
+        else
+          echo "[$(date -u +%H:%M:%S)] WARNING: Failed to persist swarm memory to S3 (non-fatal)"
+        fi
+
         # Patch phase to Disbanded
         kubectl_with_timeout 10 patch configmap "${swarm_name}" -n "$NAMESPACE" \
             --type=merge -p '{"data":{"phase":"Disbanded"}}' 2>/dev/null || true
 
         # Post coordinator thought
-        post_coordinator_thought "Swarm $swarm_ref dissolved by coordinator. Goal achieved. All $total tasks completed. Members: $member_agents. Idle: ${idle_seconds}s." "insight"
+        post_coordinator_thought "Swarm $swarm_ref dissolved by coordinator. Goal achieved. All $total tasks completed. Members: $member_agents. Idle: ${idle_seconds}s. Memory persisted to S3 (issue #1790)." "insight"
 
         push_metric "SwarmDisbanded" 1 "Count" "Component=Coordinator"
         disbanded=$((disbanded + 1))
@@ -1239,7 +1277,8 @@ check_swarm_dissolution() {
             (.data.phase // "Forming"),
             (.data.lastActivityTimestamp // ""),
             (.data.memberAgents // ""),
-            (.data.tasksCompleted // "0")
+            (.data.tasksCompleted // "0"),
+            (.data.goal // "completed platform improvement")
         ] | @tsv' 2>/dev/null)
 
     if [ "$checked" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Fixes coordinator-driven swarm dissolutions to persist institutional memory to S3, matching the entrypoint.sh dissolution path behavior.

Closes #1790

## Problem

PR #1788 (issue #1787) adds `check_swarm_dissolution()` to coordinator.sh for auto-disbanding swarms, but it does NOT call `write_swarm_memory()` when disbanding. This creates an asymmetry:

| Dissolution path | Marks Disbanded | Broadcasts message | Writes S3 memory |
|---|---|---|---|
| entrypoint.sh (agent with SWARM_REF exits) | ✅ | ✅ | ✅ (PR #1779) |
| coordinator.sh check_swarm_dissolution() | ✅ | ✅ | ❌ **MISSING** |

When the coordinator auto-disbands a swarm (the common path), swarm institutional knowledge is silently lost. Future swarms with similar goals cannot learn from prior experience.

## Solution

Added inline swarm memory persistence logic to `check_swarm_dissolution()`:

1. Extract `goal` field from swarm state ConfigMap (added to jq query)
2. Build swarm memory JSON with swarmName, goal, members, tasksCompleted, keyDecisions, dissolvedAt, recordedBy
3. Write to `s3://agentex-thoughts/swarm-memories/<swarm-ref>.json` before marking Disbanded
4. Updated coordinator thought message to confirm memory persistence

## Changes

- **images/runner/coordinator.sh** (lines 1182, 1226-1262, 1269, 1274-1282):
  - Extract `goal` field in jq query (6th field)
  - Add inline S3 write logic matching helpers.sh `write_swarm_memory()` signature
  - Update thought message to reference issue #1790

## Testing

The fix can be verified by:
1. Creating a swarm with defined goal
2. Waiting for coordinator to auto-disband after 300s idle
3. Checking `aws s3 ls s3://agentex-thoughts/swarm-memories/` for the swarm record
4. Verifying JSON contains goal, members, tasksCompleted fields

## Effort: XS

~20 lines of inline logic. No protected files.