### PR TITLE
fix: use local active_assignments in pre-claim to prevent same-worker multi-issue claim

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3547,12 +3547,16 @@ route_tasks_by_specialization() {
             # Without this, workers race to claim tasks BEFORE routing runs and
             # find nothing left to route, keeping specializedAssignments = 0 forever.
             local new_pre_assignments
-            local cur_assignments
-            cur_assignments=$(get_state "activeAssignments")
-            if [ -z "$cur_assignments" ]; then
+            # Issue #1867: Use the local active_assignments variable (not a fresh ConfigMap
+            # read) to build new_pre_assignments. A fresh get_state() call here may return
+            # stale data that doesn't include earlier pre-claims made in this same routing
+            # cycle, causing the same worker to be pre-claimed for multiple issues.
+            # The local active_assignments is updated after each successful pre-claim above,
+            # so it correctly tracks all assignments made in this cycle.
+            if [ -z "$active_assignments" ]; then
                 new_pre_assignments="${best_agent}:${issue_num}"
             else
-                new_pre_assignments="${cur_assignments},${best_agent}:${issue_num}"
+                new_pre_assignments="${active_assignments},${best_agent}:${issue_num}"
             fi
             if update_state "activeAssignments" "$new_pre_assignments"; then
                 # Update local variable so subsequent iterations see the new assignment


### PR DESCRIPTION
## Summary

- Fixes a race in route_tasks_by_specialization() where the same worker gets pre-claimed for multiple issues in one routing cycle
- Replaces get_state(activeAssignments) fresh read with the local active_assignments variable

Closes #1867

## Problem

In route_tasks_by_specialization(), the pre-claim code re-reads activeAssignments from the ConfigMap using get_state() to build the new value. This fresh read may NOT include earlier pre-claims made in the same routing cycle (ConfigMap propagation latency), causing the same worker to be pre-claimed for multiple issues in one cycle.

## Evidence

coordinator-state.preClaimTimestamps showed worker-1773183418 pre-claimed for 4 issues (1827, 1821, 1772, 1817) within 5-11 seconds — consistent with ONE routing cycle, not multiple cycles 3.5 min apart.

## Fix

Use the local active_assignments variable (which is updated after each successful pre-claim) instead of re-reading from ConfigMap. This ensures subsequent iterations in the same cycle see all previous pre-claims and correctly skip workers that already have assignments.