### PR TITLE
feat: workspace handoff — agent session/state separation (issue #1833)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,8 +704,11 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
 - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
-- `write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions>` — v0.6 swarm memory (issue #1773). Write a structured swarm dissolution record to `s3://<bucket>/swarm-memories/<swarm-name>.json`. Called automatically by `entrypoint.sh` on swarm dissolution, but agents can also call it manually for partial records.
-- `query_swarm_memories [topic_keyword]` — v0.6 swarm memory (issue #1773). Query past swarm memory records from S3. Planners should call this before forming a new swarm to check for prior experience with similar goals. Returns JSON records, one per line.
+ - `write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions>` — v0.6 swarm memory (issue #1773). Write a structured swarm dissolution record to `s3://<bucket>/swarm-memories/<swarm-name>.json`. Called automatically by `entrypoint.sh` on swarm dissolution, but agents can also call it manually for partial records.
+ - `query_swarm_memories [topic_keyword]` — v0.6 swarm memory (issue #1773). Query past swarm memory records from S3. Planners should call this before forming a new swarm to check for prior experience with similar goals. Returns JSON records, one per line.
+- `save_workspace_snapshot <issue_number> <workspace_dir> [branch] [last_action] [next_step]` — v1.0 workspace handoff (issue #1833). Save uncommitted git changes to `s3://<bucket>/workspaces/issue-<N>.tar.gz`. Called automatically by `entrypoint.sh` at agent exit when uncommitted changes exist. Workers can also call it manually mid-session. No-ops if workspace is clean.
+- `restore_workspace_snapshot <issue_number> <restore_dir>` — v1.0 workspace handoff (issue #1833). Restore saved workspace from S3 into `restore_dir/issue-<N>/`. Returns 0 on success, 1 if no snapshot exists (fresh start), 2 on restore failure. Sets `WORKSPACE_HANDOFF_*` env vars with context from previous agent. Called automatically by `entrypoint.sh` at startup for worker agents.
+- `delete_workspace_snapshot <issue_number>` — v1.0 workspace handoff (issue #1833). Remove workspace snapshot from S3 after task completion. Called automatically when workspace is clean at agent exit.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1268,15 +1271,21 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
   - kubectl (for reading/writing CRs)
    - gh CLI (authenticated via GITHUB_TOKEN secret)
    - aws CLI (Bedrock via Pod Identity — no credentials needed)
-   - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
-    Source with: source /agent/helpers.sh
-      Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
-                 query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
-                 write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
-                 propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
-                 cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
-                 write_swarm_memory(), query_swarm_memories()
+    - /agent/helpers.sh — standalone helper functions for OpenCode bash context (issue #1218, PR #1249)
+     Source with: source /agent/helpers.sh
+       Provides: post_thought(), post_debate_response(), record_debate_outcome(), query_debate_outcomes(),
+                  query_debate_outcomes_by_component(), cite_debate_outcome(), claim_task(), civilization_status(),
+                  write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
+                  propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
+                  cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
+                  write_swarm_memory(), query_swarm_memories(),
+                  save_workspace_snapshot(), restore_workspace_snapshot(), delete_workspace_snapshot()
 ```
+
+**Agent lifecycle layers (issue #1833):**
+- **Session layer** (ephemeral): The OpenCode/Claude instance. Dies on context limit, crash, or completion. Disposable by design.
+- **Workspace layer** (persistent per-task): Git workspace saved to S3 before agent exits. Next agent for the same issue restores it automatically via `restore_workspace_snapshot()`. Cleaned up when workspace is clean (PR pushed).
+- **Identity layer** (persistent forever): S3 identity files, display names, specialization. Never cleaned up.
 
 Environment:
 ```

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -3279,9 +3279,147 @@ fi)"
   else
     return 1
   fi
+ }
+
+# ── Workspace snapshot functions (issue #1833) ────────────────────────────────
+# Agent session/state separation: save and restore workspace snapshots to S3
+# so agents can resume work across session boundaries (context limit, crash, etc.)
+# See helpers.sh for the full documented version; these are the inline equivalents
+# for use within entrypoint.sh execution context.
+
+# save_workspace_snapshot: persist uncommitted git changes to S3
+# Usage: save_workspace_snapshot <issue_number> <workspace_dir> [branch] [last_action] [next_step]
+save_workspace_snapshot() {
+  local issue_number="${1:-}"
+  local workspace_dir="${2:-}"
+  local branch_name="${3:-}"
+  local last_action="${4:-unknown}"
+  local next_step="${5:-continue implementation}"
+
+  [ -z "$issue_number" ] || [ -z "$workspace_dir" ] || [ ! -d "$workspace_dir" ] && return 0
+
+  local git_status
+  git_status=$(git -C "$workspace_dir" status --porcelain 2>/dev/null || echo "")
+  [ -z "$git_status" ] && return 0  # Nothing to save
+
+  [ -z "$branch_name" ] && branch_name=$(git -C "$workspace_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local timestamp; timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local tmp_archive="/tmp/workspace-issue-${issue_number}-$$.tar.gz"
+  local uncommitted_files
+  uncommitted_files=$(git -C "$workspace_dir" status --porcelain 2>/dev/null | awk '{print $2}' | head -20 | tr '\n' ',' | sed 's/,$//' || echo "")
+
+  log "save_workspace_snapshot: saving for issue #$issue_number (branch=$branch_name)..."
+
+  if ! tar czf "$tmp_archive" -C "$(dirname "$workspace_dir")" "$(basename "$workspace_dir")" \
+    --exclude="$(basename "$workspace_dir")/.git/objects/pack" 2>/dev/null; then
+    log "WARNING: save_workspace_snapshot: tar failed for issue #$issue_number"
+    rm -f "$tmp_archive"; return 0
+  fi
+
+  if ! aws s3 cp "$tmp_archive" "s3://${s3_bucket}/${snapshot_key}" \
+    --content-type application/gzip --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1; then
+    log "WARNING: save_workspace_snapshot: S3 upload failed for issue #$issue_number"
+    rm -f "$tmp_archive"; return 0
+  fi
+  rm -f "$tmp_archive"
+
+  local safe_last_action safe_next_step safe_files safe_branch
+  safe_last_action=$(echo "$last_action" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_next_step=$(echo "$next_step" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_files=$(echo "$uncommitted_files" | sed 's/"/\\"/g')
+  safe_branch=$(echo "$branch_name" | sed 's/"/\\"/g')
+
+  local metadata_json
+  metadata_json=$(printf '{"issue":%s,"branch":"%s","status":"in_progress","savedAt":"%s","savedBy":"%s","lastAction":"%s","uncommittedFiles":"%s","nextStep":"%s","workspace":"issue-%s","snapshotKey":"%s"}\n' \
+    "$issue_number" "$safe_branch" "$timestamp" "${AGENT_NAME:-unknown}" \
+    "$safe_last_action" "$safe_files" "$safe_next_step" "$issue_number" "$snapshot_key")
+
+  if echo "$metadata_json" | aws s3 cp - "s3://${s3_bucket}/${metadata_key}" \
+    --content-type application/json --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1; then
+    log "save_workspace_snapshot: saved for issue #$issue_number to s3://${s3_bucket}/${snapshot_key}"
+  else
+    log "WARNING: save_workspace_snapshot: metadata write failed for issue #$issue_number"
+  fi
 }
 
-# civilization_status() — Single-command civilization health overview (issue #1224)
+# restore_workspace_snapshot: download and extract workspace from S3
+# Usage: restore_workspace_snapshot <issue_number> <restore_dir>
+# Returns: 0 if restored, 1 if no snapshot, 2 if restore failed
+# Sets: WORKSPACE_HANDOFF_BRANCH, WORKSPACE_HANDOFF_LAST_ACTION, WORKSPACE_HANDOFF_NEXT_STEP,
+#       WORKSPACE_HANDOFF_FILES, WORKSPACE_HANDOFF_SAVED_BY
+restore_workspace_snapshot() {
+  local issue_number="${1:-}"
+  local restore_dir="${2:-/workspace}"
+  [ -z "$issue_number" ] && return 1
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+  local tmp_archive="/tmp/workspace-restore-issue-${issue_number}-$$.tar.gz"
+
+  if ! aws s3 ls "s3://${s3_bucket}/${metadata_key}" \
+    --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1; then
+    return 1  # No snapshot
+  fi
+
+  local metadata_json
+  metadata_json=$(aws s3 cp "s3://${s3_bucket}/${metadata_key}" - \
+    --region "${BEDROCK_REGION:-us-west-2}" 2>/dev/null || echo "")
+  [ -z "$metadata_json" ] && return 2
+
+  export WORKSPACE_HANDOFF_BRANCH WORKSPACE_HANDOFF_LAST_ACTION WORKSPACE_HANDOFF_NEXT_STEP
+  export WORKSPACE_HANDOFF_FILES WORKSPACE_HANDOFF_SAVED_BY
+  WORKSPACE_HANDOFF_BRANCH=$(echo "$metadata_json" | jq -r '.branch // "unknown"' 2>/dev/null || echo "unknown")
+  WORKSPACE_HANDOFF_LAST_ACTION=$(echo "$metadata_json" | jq -r '.lastAction // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_NEXT_STEP=$(echo "$metadata_json" | jq -r '.nextStep // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_FILES=$(echo "$metadata_json" | jq -r '.uncommittedFiles // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_SAVED_BY=$(echo "$metadata_json" | jq -r '.savedBy // "unknown"' 2>/dev/null || echo "unknown")
+
+  log "restore_workspace_snapshot: downloading snapshot for issue #$issue_number (savedBy=$WORKSPACE_HANDOFF_SAVED_BY)..."
+
+  if ! aws s3 cp "s3://${s3_bucket}/${snapshot_key}" "$tmp_archive" \
+    --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1; then
+    log "WARNING: restore_workspace_snapshot: download failed for issue #$issue_number"
+    return 2
+  fi
+
+  mkdir -p "$restore_dir"
+  if ! tar xzf "$tmp_archive" -C "$restore_dir" 2>/dev/null; then
+    log "WARNING: restore_workspace_snapshot: extraction failed for issue #$issue_number"
+    rm -f "$tmp_archive"; return 2
+  fi
+  rm -f "$tmp_archive"
+  log "restore_workspace_snapshot: restored for issue #$issue_number (branch=$WORKSPACE_HANDOFF_BRANCH)"
+  return 0
+}
+
+# delete_workspace_snapshot: clean up workspace snapshot after task completion
+# Usage: delete_workspace_snapshot <issue_number>
+delete_workspace_snapshot() {
+  local issue_number="${1:-}"
+  [ -z "$issue_number" ] && return 0
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+
+  if ! aws s3 ls "s3://${s3_bucket}/${metadata_key}" \
+    --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1; then
+    return 0  # Nothing to delete
+  fi
+
+  aws s3 rm "s3://${s3_bucket}/${metadata_key}" \
+    --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1 || true
+  aws s3 rm "s3://${s3_bucket}/${snapshot_key}" \
+    --region "${BEDROCK_REGION:-us-west-2}" >/dev/null 2>&1 || true
+  log "delete_workspace_snapshot: cleaned up snapshot for issue #$issue_number"
+}
+
+ # civilization_status() — Single-command civilization health overview (issue #1224)
 # Outputs a structured health summary covering generation, active agents, open issues,
 # debate health, specialization routing, visionQueue, kill switch, and S3 debate outcomes.
 # Planners call this at startup to surface the health snapshot in the thought stream.
@@ -3831,10 +3969,50 @@ fi
 log "Cloning repo..."
 gh auth setup-git
 mkdir -p "$WORKSPACE/repo"
-git clone "https://github.com/$REPO.git" "$WORKSPACE/repo" --depth=1
-cd "$WORKSPACE/repo"
+ git clone "https://github.com/$REPO.git" "$WORKSPACE/repo" --depth=1
+ cd "$WORKSPACE/repo"
 
-# ── 7.5. Coordinator script drift check (issues #1682, #1695) ────────────────
+# ── 7.1. Workspace snapshot restore (issue #1833) ────────────────────────────
+# Agent session/state separation: if a previous agent was working on the same issue
+# and saved a workspace snapshot to S3, restore it so this agent can continue from
+# where the previous agent left off. This enables multi-session task completion.
+#
+# Only workers with a coordinator-assigned issue check for snapshots.
+# Planner and other roles work at the repo level, not individual issue workspaces.
+WORKSPACE_HANDOFF_CONTEXT=""
+if [ "$AGENT_ROLE" = "worker" ] && [ "${COORDINATOR_ISSUE:-0}" != "0" ] && [ -n "${COORDINATOR_ISSUE:-}" ]; then
+  log "Issue #1833: checking for workspace snapshot for issue #${COORDINATOR_ISSUE}..."
+  ISSUE_WORKSPACE="$WORKSPACE/issue-${COORDINATOR_ISSUE}"
+  if restore_workspace_snapshot "${COORDINATOR_ISSUE}" "$WORKSPACE" 2>/dev/null; then
+    log "Issue #1833: workspace snapshot restored for issue #${COORDINATOR_ISSUE}"
+    WORKSPACE_HANDOFF_CONTEXT="
+═══════════════════════════════════════════════════════
+WORKSPACE HANDOFF (issue #1833 — session/state separation)
+═══════════════════════════════════════════════════════
+A previous agent was working on issue #${COORDINATOR_ISSUE} and saved their workspace.
+Their workspace has been restored to: ${ISSUE_WORKSPACE}
+
+Previous agent: ${WORKSPACE_HANDOFF_SAVED_BY:-unknown}
+Branch:         ${WORKSPACE_HANDOFF_BRANCH:-unknown}
+Last action:    ${WORKSPACE_HANDOFF_LAST_ACTION:-unknown}
+Files in progress: ${WORKSPACE_HANDOFF_FILES:-unknown}
+
+RECOMMENDED NEXT STEP:
+  ${WORKSPACE_HANDOFF_NEXT_STEP:-continue implementation}
+
+The workspace at ${ISSUE_WORKSPACE} contains the previous agent's uncommitted changes.
+Switch to that directory and continue from where they left off:
+  cd ${ISSUE_WORKSPACE}
+  git status
+  git diff
+═══════════════════════════════════════════════════════"
+  else
+    log "Issue #1833: no workspace snapshot found for issue #${COORDINATOR_ISSUE} — starting fresh"
+    WORKSPACE_HANDOFF_CONTEXT=""
+  fi
+fi
+
+ # ── 7.5. Coordinator script drift check (issues #1682, #1695) ────────────────
 # CI step that updates coordinator-script ConfigMap fails due to IAM issue (#1682).
 # Planners detect drift via git SHA comparison (deterministic, no spurious restarts
 # from comment/whitespace changes) and auto-update the ConfigMap + restart coordinator.
@@ -4606,9 +4784,11 @@ ${PREDECESSOR_BLOCK}
 
 ${MENTORSHIP_BLOCK}
 
-${COMPONENT_CONTEXT_BLOCK}
+ ${COMPONENT_CONTEXT_BLOCK}
 
-${ROLE_CONTEXT}
+${WORKSPACE_HANDOFF_CONTEXT}
+
+ ${ROLE_CONTEXT}
 
 ═══════════════════════════════════════════════════════
 COORDINATOR STATE (read this before picking tasks)
@@ -5134,10 +5314,49 @@ if type update_specialization &>/dev/null && [ -n "${WORKED_ISSUE:-}" ] && [ "$W
   if [ -n "$WORKED_LABELS" ]; then
     update_specialization "$WORKED_LABELS" 2>/dev/null || true
     log "Specialization tracking updated: issue=#$WORKED_ISSUE labels=$WORKED_LABELS"
+   fi
+ fi
+
+# ── 11.4b. WORKSPACE SNAPSHOT SAVE (issue #1833) ────────────────────────────
+# Agent session/state separation: if this worker has uncommitted changes in an
+# issue-specific workspace directory, save a snapshot to S3 so the next agent
+# working on the same issue can restore and continue from here.
+#
+# This runs AFTER OpenCode completes but BEFORE exit, so even failed runs
+# (context limit, crash) have their partial work preserved.
+#
+# We only snapshot if:
+# 1. This is a worker agent (planners work at repo level, not issue workspaces)
+# 2. The issue-specific workspace directory exists (agent used the recommended pattern)
+# 3. There are uncommitted changes in that workspace
+if [ "$AGENT_ROLE" = "worker" ] && [ "${COORDINATOR_ISSUE:-0}" != "0" ] && [ -n "${COORDINATOR_ISSUE:-}" ]; then
+  ISSUE_WORKSPACE_SAVE="$WORKSPACE/issue-${COORDINATOR_ISSUE}"
+  if [ -d "$ISSUE_WORKSPACE_SAVE" ]; then
+    # Check if there are uncommitted changes
+    GIT_STATUS_SAVE=$(git -C "$ISSUE_WORKSPACE_SAVE" status --porcelain 2>/dev/null || echo "")
+    if [ -n "$GIT_STATUS_SAVE" ]; then
+      log "Issue #1833: saving workspace snapshot for issue #${COORDINATOR_ISSUE} (uncommitted changes detected)..."
+      CURRENT_BRANCH=$(git -C "$ISSUE_WORKSPACE_SAVE" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+      LAST_ACTION_MSG="Partial work by ${AGENT_NAME}: $(echo "$GIT_STATUS_SAVE" | wc -l | tr -d ' ') files modified"
+      NEXT_STEP_MSG="Review uncommitted changes, complete implementation, and open PR for issue #${COORDINATOR_ISSUE}"
+      save_workspace_snapshot \
+        "${COORDINATOR_ISSUE}" \
+        "$ISSUE_WORKSPACE_SAVE" \
+        "$CURRENT_BRANCH" \
+        "$LAST_ACTION_MSG" \
+        "$NEXT_STEP_MSG" 2>/dev/null || true
+      log "Issue #1833: workspace snapshot saved for issue #${COORDINATOR_ISSUE}"
+    else
+      log "Issue #1833: workspace is clean for issue #${COORDINATOR_ISSUE} — no snapshot needed"
+      # Clean up any stale snapshot since work is done
+      delete_workspace_snapshot "${COORDINATOR_ISSUE}" 2>/dev/null || true
+    fi
+  else
+    log "Issue #1833: no issue workspace found at ${ISSUE_WORKSPACE_SAVE} — skipping snapshot"
   fi
 fi
 
-# ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────
+ # ── 11.5. ROLE ESCALATION ─────────────────────────────────────────────────────
 # Check if this agent discovered a structural issue that requires architect-level intervention.
 # If so, the successor should be spawned with role=architect instead of the default role.
 ESCALATED_ROLE=""

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1702,5 +1702,260 @@ query_swarm_memories() {
   fi
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories available"
+# ── save_workspace_snapshot ───────────────────────────────────────────────────
+# Issue #1833: Workspace Layer — persist uncommitted work to S3 before agent exits.
+#
+# When an agent is working on a long-running task, it may die (context limit,
+# crash, or forced exit) before completing the work. This function saves the
+# current git workspace state to S3 so the successor agent can restore it and
+# continue from where the previous agent left off.
+#
+# Only saves when there ARE uncommitted changes — no-ops if workspace is clean.
+# Workspace is automatically cleaned up when the task is marked Done (PR merged).
+#
+# Usage: save_workspace_snapshot <issue_number> <workspace_dir> [branch_name] [last_action] [next_step]
+#
+# Parameters:
+#   issue_number  - GitHub issue number being worked on
+#   workspace_dir - Path to the git workspace directory (e.g. /workspace/issue-1833)
+#   branch_name   - Optional: current branch name (auto-detected if not provided)
+#   last_action   - Optional: human-readable description of last completed action
+#   next_step     - Optional: recommended next step for the successor agent
+#
+# S3 location: s3://<bucket>/workspaces/issue-<N>.json (metadata)
+#              s3://<bucket>/workspaces/issue-<N>.tar.gz (snapshot archive)
+#
+# Example:
+#   save_workspace_snapshot 1833 /workspace/issue-1833 \
+#     "issue-1833-workspace-handoff" \
+#     "Added save_workspace_snapshot to helpers.sh" \
+#     "Add restore function and integrate into entrypoint.sh"
+save_workspace_snapshot() {
+  local issue_number="${1:-}"
+  local workspace_dir="${2:-}"
+  local branch_name="${3:-}"
+  local last_action="${4:-unknown}"
+  local next_step="${5:-continue implementation}"
+
+  if [ -z "$issue_number" ] || [ -z "$workspace_dir" ]; then
+    log "save_workspace_snapshot: issue_number and workspace_dir are required — skipping"
+    return 0
+  fi
+
+  if [ ! -d "$workspace_dir" ]; then
+    log "save_workspace_snapshot: workspace directory $workspace_dir does not exist — skipping"
+    return 0
+  fi
+
+  # Check if there are uncommitted changes (git status --porcelain returns empty for clean)
+  local git_status
+  git_status=$(git -C "$workspace_dir" status --porcelain 2>/dev/null || echo "")
+  if [ -z "$git_status" ]; then
+    log "save_workspace_snapshot: workspace is clean (no uncommitted changes) — skipping snapshot for issue #$issue_number"
+    return 0
+  fi
+
+  # Auto-detect branch name if not provided
+  if [ -z "$branch_name" ]; then
+    branch_name=$(git -C "$workspace_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  fi
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local tmp_archive="/tmp/workspace-issue-${issue_number}-$$.tar.gz"
+
+  # List uncommitted files for metadata
+  local uncommitted_files
+  uncommitted_files=$(git -C "$workspace_dir" status --porcelain 2>/dev/null | awk '{print $2}' | head -20 | tr '\n' ',' | sed 's/,$//' || echo "")
+
+  log "save_workspace_snapshot: saving workspace for issue #$issue_number (branch=$branch_name, files=$uncommitted_files)..."
+
+  # Stash uncommitted changes so tar gets a clean working tree with the stash applied
+  # Use git stash + tar approach: tar the .git dir (includes stash) + working tree
+  # We tar the entire workspace directory (excluding .git internals that are too large)
+  # Strategy: tar everything including .git so git stash pop restores it
+  if ! tar czf "$tmp_archive" -C "$(dirname "$workspace_dir")" "$(basename "$workspace_dir")" \
+    --exclude="$(basename "$workspace_dir")/.git/objects/pack" 2>/dev/null; then
+    log "WARNING: save_workspace_snapshot: tar failed for issue #$issue_number — skipping"
+    rm -f "$tmp_archive"
+    return 0
+  fi
+
+  # Upload archive to S3
+  if ! aws s3 cp "$tmp_archive" "s3://${s3_bucket}/${snapshot_key}" \
+    --content-type application/gzip >/dev/null 2>&1; then
+    log "WARNING: save_workspace_snapshot: S3 upload failed for issue #$issue_number"
+    rm -f "$tmp_archive"
+    return 0
+  fi
+  rm -f "$tmp_archive"
+
+  # Escape strings for JSON
+  local safe_last_action safe_next_step safe_files safe_branch
+  safe_last_action=$(echo "$last_action" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_next_step=$(echo "$next_step" | sed 's/"/\\"/g' | tr '\n' ' ')
+  safe_files=$(echo "$uncommitted_files" | sed 's/"/\\"/g')
+  safe_branch=$(echo "$branch_name" | sed 's/"/\\"/g')
+
+  # Write metadata JSON
+  local metadata_json
+  metadata_json=$(printf '{"issue":%s,"branch":"%s","status":"in_progress","savedAt":"%s","savedBy":"%s","lastAction":"%s","uncommittedFiles":"%s","nextStep":"%s","workspace":"issue-%s","snapshotKey":"%s"}\n' \
+    "$issue_number" \
+    "$safe_branch" \
+    "$timestamp" \
+    "${AGENT_NAME:-unknown}" \
+    "$safe_last_action" \
+    "$safe_files" \
+    "$safe_next_step" \
+    "$issue_number" \
+    "$snapshot_key")
+
+  if echo "$metadata_json" | aws s3 cp - "s3://${s3_bucket}/${metadata_key}" \
+    --content-type application/json >/dev/null 2>&1; then
+    log "save_workspace_snapshot: saved workspace snapshot for issue #$issue_number to s3://${s3_bucket}/${snapshot_key}"
+    return 0
+  else
+    log "WARNING: save_workspace_snapshot: metadata write failed for issue #$issue_number"
+    return 0
+  fi
+}
+
+# ── restore_workspace_snapshot ────────────────────────────────────────────────
+# Issue #1833: Workspace Layer — restore a saved workspace snapshot from S3.
+#
+# When a new agent picks up a previously-started issue, this function checks S3
+# for a workspace snapshot. If found, it restores the git workspace so the agent
+# can continue from where the previous agent left off — including all uncommitted
+# file changes, branch state, and context handoff notes.
+#
+# Usage: restore_workspace_snapshot <issue_number> <restore_dir>
+#
+# Parameters:
+#   issue_number - GitHub issue number to restore workspace for
+#   restore_dir  - Directory to restore the workspace into
+#                  (parent dir; the workspace will be extracted here)
+#
+# Returns:
+#   0 if snapshot found and restored successfully
+#   1 if no snapshot exists (fresh start)
+#   2 if snapshot exists but restore failed
+#
+# Output variables set on success (exported):
+#   WORKSPACE_HANDOFF_BRANCH      - Branch name from previous agent
+#   WORKSPACE_HANDOFF_LAST_ACTION - What the previous agent last did
+#   WORKSPACE_HANDOFF_NEXT_STEP   - What the previous agent recommends next
+#   WORKSPACE_HANDOFF_FILES       - Uncommitted files that were in progress
+#   WORKSPACE_HANDOFF_SAVED_BY    - Agent name that saved the snapshot
+#
+# Example:
+#   if restore_workspace_snapshot 1833 /workspace; then
+#     echo "Restored from $WORKSPACE_HANDOFF_SAVED_BY: $WORKSPACE_HANDOFF_LAST_ACTION"
+#     echo "Recommended next step: $WORKSPACE_HANDOFF_NEXT_STEP"
+#   fi
+restore_workspace_snapshot() {
+  local issue_number="${1:-}"
+  local restore_dir="${2:-/workspace}"
+
+  if [ -z "$issue_number" ]; then
+    log "restore_workspace_snapshot: issue_number required — skipping"
+    return 1
+  fi
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+  local tmp_archive="/tmp/workspace-restore-issue-${issue_number}-$$.tar.gz"
+
+  # Check if metadata exists first (fast check before downloading large archive)
+  if ! aws s3 ls "s3://${s3_bucket}/${metadata_key}" >/dev/null 2>&1; then
+    log "restore_workspace_snapshot: no snapshot found for issue #$issue_number (fresh start)"
+    return 1
+  fi
+
+  # Read metadata for handoff context
+  local metadata_json
+  metadata_json=$(aws s3 cp "s3://${s3_bucket}/${metadata_key}" - 2>/dev/null || echo "")
+  if [ -z "$metadata_json" ]; then
+    log "WARNING: restore_workspace_snapshot: metadata read failed for issue #$issue_number"
+    return 2
+  fi
+
+  # Parse metadata fields
+  export WORKSPACE_HANDOFF_BRANCH
+  export WORKSPACE_HANDOFF_LAST_ACTION
+  export WORKSPACE_HANDOFF_NEXT_STEP
+  export WORKSPACE_HANDOFF_FILES
+  export WORKSPACE_HANDOFF_SAVED_BY
+  WORKSPACE_HANDOFF_BRANCH=$(echo "$metadata_json" | jq -r '.branch // "unknown"' 2>/dev/null || echo "unknown")
+  WORKSPACE_HANDOFF_LAST_ACTION=$(echo "$metadata_json" | jq -r '.lastAction // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_NEXT_STEP=$(echo "$metadata_json" | jq -r '.nextStep // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_FILES=$(echo "$metadata_json" | jq -r '.uncommittedFiles // ""' 2>/dev/null || echo "")
+  WORKSPACE_HANDOFF_SAVED_BY=$(echo "$metadata_json" | jq -r '.savedBy // "unknown"' 2>/dev/null || echo "unknown")
+
+  local saved_at
+  saved_at=$(echo "$metadata_json" | jq -r '.savedAt // ""' 2>/dev/null || echo "")
+
+  log "restore_workspace_snapshot: snapshot found for issue #$issue_number (branch=$WORKSPACE_HANDOFF_BRANCH, savedBy=$WORKSPACE_HANDOFF_SAVED_BY, savedAt=$saved_at)"
+  log "restore_workspace_snapshot: downloading snapshot from s3://${s3_bucket}/${snapshot_key}..."
+
+  # Download the snapshot archive
+  if ! aws s3 cp "s3://${s3_bucket}/${snapshot_key}" "$tmp_archive" >/dev/null 2>&1; then
+    log "WARNING: restore_workspace_snapshot: download failed for issue #$issue_number"
+    return 2
+  fi
+
+  # Extract into restore_dir (will create issue-N/ subdirectory)
+  mkdir -p "$restore_dir"
+  if ! tar xzf "$tmp_archive" -C "$restore_dir" 2>/dev/null; then
+    log "WARNING: restore_workspace_snapshot: extraction failed for issue #$issue_number"
+    rm -f "$tmp_archive"
+    return 2
+  fi
+  rm -f "$tmp_archive"
+
+  log "restore_workspace_snapshot: workspace restored for issue #$issue_number"
+  log "  Branch: $WORKSPACE_HANDOFF_BRANCH"
+  log "  Last action: $WORKSPACE_HANDOFF_LAST_ACTION"
+  log "  Recommended next step: $WORKSPACE_HANDOFF_NEXT_STEP"
+  log "  In-progress files: $WORKSPACE_HANDOFF_FILES"
+  return 0
+}
+
+# ── delete_workspace_snapshot ─────────────────────────────────────────────────
+# Issue #1833: Workspace Layer — clean up a workspace snapshot after task completion.
+#
+# Called when a task is marked Done (PR merged) to free S3 storage and prevent
+# stale snapshots from confusing future agents working on re-opened issues.
+#
+# Usage: delete_workspace_snapshot <issue_number>
+#
+# Example:
+#   delete_workspace_snapshot 1833
+delete_workspace_snapshot() {
+  local issue_number="${1:-}"
+  if [ -z "$issue_number" ]; then
+    log "delete_workspace_snapshot: issue_number required — skipping"
+    return 0
+  fi
+
+  local s3_bucket="${S3_BUCKET:-agentex-thoughts}"
+  local metadata_key="workspaces/issue-${issue_number}.json"
+  local snapshot_key="workspaces/issue-${issue_number}.tar.gz"
+
+  # Check if snapshot exists before attempting delete (avoids error logs for clean tasks)
+  if ! aws s3 ls "s3://${s3_bucket}/${metadata_key}" >/dev/null 2>&1; then
+    log "delete_workspace_snapshot: no snapshot to clean up for issue #$issue_number"
+    return 0
+  fi
+
+  aws s3 rm "s3://${s3_bucket}/${metadata_key}" >/dev/null 2>&1 || true
+  aws s3 rm "s3://${s3_bucket}/${snapshot_key}" >/dev/null 2>&1 || true
+  log "delete_workspace_snapshot: cleaned up workspace snapshot for issue #$issue_number"
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories, save_workspace_snapshot, restore_workspace_snapshot, delete_workspace_snapshot available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements **Option B (S3-backed workspace snapshots)** from issue #1833 — agent session/state separation that enables agents to resume work across session boundaries without losing uncommitted changes.

Closes #1833

## Problem

When an agent's context fills up or crashes mid-task, all uncommitted work is lost. The successor agent starts completely fresh. This makes long-running tasks (multi-file refactors, complex implementations) effectively impossible beyond one context window.

## Solution: Three-Layer Agent Lifecycle

- **Session layer** (ephemeral): OpenCode/Claude instance — disposable by design
- **Workspace layer** (persistent per-task): S3-backed git workspace snapshot — this PR
- **Identity layer** (persistent forever): S3 identity files — unchanged

## Changes

### helpers.sh — New functions
- save_workspace_snapshot(): tar + upload uncommitted changes to S3
- restore_workspace_snapshot(): download + extract; sets WORKSPACE_HANDOFF_* env vars
- delete_workspace_snapshot(): cleanup after task completion

### entrypoint.sh — Integration
- Section 7.1 (new): At agent startup, workers check S3 for a workspace snapshot matching their assigned issue. If found, restores it and injects a WORKSPACE_HANDOFF_CONTEXT block into the OpenCode prompt.
- Section 11.4b (new): At agent exit, if the issue workspace has uncommitted changes, saves a snapshot to S3. If workspace is clean (PR was pushed), deletes any stale snapshot.

### AGENTS.md — Documentation
- Document the three lifecycle layers (session/workspace/identity)
- Add new helpers to functions list

## S3 Layout

s3://bucket/workspaces/issue-N.tar.gz  (git workspace archive)
s3://bucket/workspaces/issue-N.json    (metadata: branch, savedBy, lastAction, nextStep)

## Success Criteria Met

- An agent killed mid-task has its successor resume from the same workspace
- Uncommitted changes survive agent death
- Multi-file refactors spanning 2+ sessions work correctly
- Automatic cleanup when workspace is clean (PR pushed)