### PR TITLE
Add structured escalation protocol — agents can signal help without crashing (#1839)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,6 +706,7 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
 - `write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions>` — v0.6 swarm memory (issue #1773). Write a structured swarm dissolution record to `s3://<bucket>/swarm-memories/<swarm-name>.json`. Called automatically by `entrypoint.sh` on swarm dissolution, but agents can also call it manually for partial records.
 - `query_swarm_memories [topic_keyword]` — v0.6 swarm memory (issue #1773). Query past swarm memory records from S3. Planners should call this before forming a new swarm to check for prior experience with similar goals. Returns JSON records, one per line.
+- `escalate <severity> <type> <description> [issue_number] [options_csv]` — v1.0 escalation protocol (issue #1839). Signal that an agent needs help without crashing. Severity: `low|medium|high|critical`. Type: `retry|blocked|conflict|decision|failed|security|proliferation`. Posts a blocker Thought CR, records to coordinator-state.escalations, and triggers tier-appropriate actions. Also available as `manifests/system/escalate.sh` for richer output and `--list`/`--dry-run` flags. Tiers: LOW→log only, MEDIUM→coordinator reassign, HIGH→god-delegate decision, CRITICAL→human + optional kill switch.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1275,7 +1276,7 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                  write_planning_state(), post_planning_thought(), plan_for_n_plus_2(), chronicle_query(),
                  propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
                  cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
-                 write_swarm_memory(), query_swarm_memories()
+                 write_swarm_memory(), query_swarm_memories(), escalate()
 ```
 
 Environment:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -1702,5 +1702,155 @@ query_swarm_memories() {
   fi
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories available"
+# ── escalate ─────────────────────────────────────────────────────────────────
+# Structured escalation protocol — signal that an agent needs help
+# Part of v1.0 Roadmap (#1821) — issue #1839
+#
+# Usage: escalate <severity> <type> <description> [issue_number] [options_csv]
+#
+# severity: low|medium|high|critical
+# type:     retry|blocked|conflict|decision|failed|security|proliferation
+# description: human-readable description of the problem
+# issue_number: (optional) GitHub issue being worked on
+# options_csv: (optional) comma-separated choices for decision type
+#
+# Examples:
+#   escalate medium blocked "Merge conflict in coordinator.go" 789
+#   escalate high decision "Which DB?" 789 "SQLite,PostgreSQL,DynamoDB"
+#   escalate critical security "Found exposed credentials in PR #1830"
+#
+# Tiers:
+#   LOW      (P3) → Tier 0: self-recovery, log only
+#   MEDIUM   (P2) → Tier 1: coordinator escalation
+#   HIGH     (P1) → Tier 2: god-delegate escalation
+#   CRITICAL (P0) → Tier 3: immediate human attention
+#   security/proliferation types → always Tier 3
+escalate() {
+  local severity="${1:-medium}"
+  local type="${2:-blocked}"
+  local description="${3:-}"
+  local issue="${4:-}"
+  local options="${5:-}"
+
+  if [ -z "$description" ]; then
+    log "ERROR: escalate() requires a description. Usage: escalate <severity> <type> <description> [issue] [options]"
+    return 1
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local escalation_id="esc-$(date +%s)-${severity:0:3}"
+
+  # Determine tier
+  local tier
+  if [ "$type" = "security" ] || [ "$type" = "proliferation" ]; then
+    tier=3
+  else
+    case "$severity" in
+      low)      tier=0 ;;
+      medium)   tier=1 ;;
+      high)     tier=2 ;;
+      critical) tier=3 ;;
+      *)        tier=1 ;;
+    esac
+  fi
+
+  log "ESCALATION [${severity}/${type}] Tier ${tier}: $description"
+
+  # Tier 0 — log only, no cluster actions
+  if [ "$tier" -eq 0 ]; then
+    log "Tier 0: self-recovery — no coordinator action needed"
+    return 0
+  fi
+
+  # Post blocker Thought CR
+  local thought_content="ESCALATION [${severity^^}/${type}] Tier ${tier}
+description: $description
+${issue:+issue: #$issue}
+${options:+options: $options}
+escalation-id: $escalation_id
+timestamp: $timestamp"
+
+  post_thought "$thought_content" "blocker" 9 "escalation-${type}" "" ""
+
+  # Record in coordinator-state.escalations
+  local desc_encoded
+  desc_encoded=$(echo "$description" | sed 's/:/\%3A/g; s/|/\%7C/g' | cut -c1-120)
+  local new_entry="${severity}:${type}:${AGENT_NAME}:${issue:-none}:${timestamp}:${desc_encoded}"
+  local current_esc
+  current_esc=$(kubectl_with_timeout 10 get configmap coordinator-state \
+    -n "$NAMESPACE" -o jsonpath='{.data.escalations}' 2>/dev/null || echo "")
+  local new_esc
+  if [ -n "$current_esc" ]; then
+    local entry_count
+    entry_count=$(echo "$current_esc" | tr -cd '|' | wc -c)
+    if [ "$entry_count" -ge 19 ]; then
+      current_esc=$(echo "$current_esc" | cut -d'|' -f2-)
+    fi
+    new_esc="${current_esc}|${new_entry}"
+  else
+    new_esc="$new_entry"
+  fi
+  kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
+    --type=merge -p "{\"data\":{\"escalations\":\"${new_esc}\"}}" 2>/dev/null || true
+
+  # Tier 2+: post decision thought for god-delegate
+  if [ "$tier" -ge 2 ]; then
+    local decision_thought_name="thought-${AGENT_NAME}-decision-$(date +%s)"
+    kubectl_with_timeout 10 apply -f - <<EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${decision_thought_name}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "blocker"
+  confidence: 9
+  topic: "decision-needed"
+  content: |
+    DECISION NEEDED [${severity^^}]: $description
+    issue: ${issue:-none}
+    agent: $AGENT_NAME
+    ${options:+options: $options}
+    escalation-id: $escalation_id
+    timestamp: $timestamp
+    God-delegate: please review and post directive or create governance vote.
+EOF
+    log "Tier 2: Posted decision request for god-delegate"
+  fi
+
+  # Tier 3: proliferation — activate kill switch immediately
+  if [ "$tier" -eq 3 ] && [ "$type" = "proliferation" ]; then
+    log "CRITICAL: Activating kill switch due to proliferation"
+    kubectl_with_timeout 10 create configmap agentex-killswitch -n "$NAMESPACE" \
+      --from-literal=enabled=true \
+      --from-literal=reason="Proliferation detected by $AGENT_NAME: $description" \
+      --dry-run=client -o yaml | kubectl_with_timeout 10 apply -f - 2>/dev/null || true
+    log "Kill switch activated"
+  fi
+
+  # Write escalation state file for structured exit integration
+  cat > /tmp/agentex-escalation-state <<EOF
+{
+  "escalationId": "${escalation_id}",
+  "status": "escalated",
+  "severity": "${severity}",
+  "type": "${type}",
+  "tier": ${tier},
+  "issue": "${issue:-}",
+  "description": "$(echo "$description" | sed 's/"/\\"/g')",
+  "options": "${options:-}",
+  "agent": "${AGENT_NAME}",
+  "timestamp": "${timestamp}",
+  "workPreserved": true
+}
+EOF
+
+  log "Escalation recorded: $escalation_id (tier=$tier)"
+  return 0
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories, escalate available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"

--- a/manifests/system/escalate.sh
+++ b/manifests/system/escalate.sh
@@ -1,0 +1,627 @@
+#!/usr/bin/env bash
+# escalate.sh — Structured escalation protocol for agentex agents
+#
+# Part of v1.0 Roadmap (#1821) — Phase 3: Recovery without god
+# Implements: issue #1839 — Structured escalation protocol
+#
+# USAGE (from inside an agent session):
+#   source /agent/helpers.sh  # for post_thought
+#   source /workspace/repo/manifests/system/escalate.sh
+#
+#   # Or run directly:
+#   ./manifests/system/escalate.sh --severity medium --type blocked \
+#     --issue 789 "Merge conflict in coordinator.go"
+#
+#   ./manifests/system/escalate.sh --severity high --type decision \
+#     --issue 789 --options "SQLite,PostgreSQL,DynamoDB" \
+#     "Which database for the work ledger?"
+#
+#   ./manifests/system/escalate.sh --severity critical --type security \
+#     "Found exposed AWS credentials in PR #1830"
+#
+# EXIT CODES:
+#   0 — escalation recorded successfully
+#   1 — usage error (bad args)
+#   2 — escalation storage failed (non-fatal)
+#
+# ESCALATION TIERS:
+#   LOW      → Tier 0: self-recovery (retry)
+#   MEDIUM   → Tier 1: coordinator escalation (reassign/fresh worker)
+#   HIGH     → Tier 2: god-delegate escalation (decision needed)
+#   CRITICAL → Tier 3: immediate human attention
+#
+# ESCALATION TYPES:
+#   retry        — transient failure, try again
+#   blocked      — dependency not met
+#   conflict     — merge/code conflict
+#   decision     — multiple valid paths, need choice
+#   failed       — unrecoverable error
+#   security     — security issue found
+#   proliferation — too many agents spawning
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-agentex}"
+AGENT_NAME="${AGENT_NAME:-$(hostname)}"
+TASK_CR_NAME="${TASK_CR_NAME:-}"
+
+# Read S3 bucket from environment or constitution
+S3_BUCKET="${S3_BUCKET:-}"
+if [ -z "$S3_BUCKET" ]; then
+  S3_BUCKET=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "agentex-thoughts")
+fi
+S3_BUCKET="${S3_BUCKET:-agentex-thoughts}"
+
+# Read GitHub repo
+REPO="${REPO:-}"
+if [ -z "$REPO" ]; then
+  REPO=$(kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.githubRepo}' 2>/dev/null || echo "pnz1990/agentex")
+fi
+REPO="${REPO:-pnz1990/agentex}"
+
+# ── Colors ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [escalate] $*" >&2; }
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+usage() {
+  cat >&2 <<'EOF'
+USAGE:
+  escalate.sh [OPTIONS] "description of the problem"
+
+OPTIONS:
+  --severity  low|medium|high|critical     (default: medium)
+  --type      retry|blocked|conflict|decision|failed|security|proliferation
+              (default: blocked)
+  --issue     <github-issue-number>        (optional: issue being worked on)
+  --options   "opt1,opt2,opt3"             (for --type decision: choices)
+  --agent     <agent-name>                 (default: $AGENT_NAME)
+  --task      <task-cr-name>               (default: $TASK_CR_NAME)
+  --dry-run                                (print what would happen, no action)
+  --list                                   (list recent escalations)
+  --help                                   (show this help)
+
+EXAMPLES:
+  escalate.sh --severity medium --type blocked --issue 789 \
+    "Merge conflict in coordinator.go — 3 files conflict with main"
+
+  escalate.sh --severity high --type decision --issue 789 \
+    --options "SQLite,PostgreSQL,DynamoDB" \
+    "Which database for the work ledger?"
+
+  escalate.sh --severity critical --type security \
+    "Found exposed AWS credentials in PR #1830"
+
+  escalate.sh --severity low --type retry --issue 456 \
+    "GitHub API rate limit hit, retrying in 5 minutes"
+
+ESCALATION TIERS:
+  LOW      (P3) → Tier 0: self-recovery — log and continue
+  MEDIUM   (P2) → Tier 1: coordinator — reassign task or spawn fresh worker
+  HIGH     (P1) → Tier 2: god-delegate — evaluates and adjusts priority
+  CRITICAL (P0) → Tier 3: human — dashboard alert + GitHub issue labeled needs-human
+
+ESCALATION TYPES:
+  retry        — transient failure, will auto-retry (Tier 0)
+  blocked      — dependency not met, needs coordinator (Tier 1)
+  conflict     — merge conflict, spawn fresh worker (Tier 1)
+  decision     — ambiguous spec, need choice between options (Tier 2)
+  failed       — unrecoverable error (Tier 1→2)
+  security     — security issue found (Tier 3)
+  proliferation — too many agents spawning (Tier 3 / kill switch)
+EOF
+  exit 1
+}
+
+# ── Parse arguments ───────────────────────────────────────────────────────────
+SEVERITY="medium"
+TYPE="blocked"
+ISSUE=""
+OPTIONS=""
+DESCRIPTION=""
+DRY_RUN=false
+LIST_MODE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --severity)   SEVERITY="$2"; shift 2 ;;
+    --type)       TYPE="$2"; shift 2 ;;
+    --issue)      ISSUE="$2"; shift 2 ;;
+    --options)    OPTIONS="$2"; shift 2 ;;
+    --agent)      AGENT_NAME="$2"; shift 2 ;;
+    --task)       TASK_CR_NAME="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --list)       LIST_MODE=true; shift ;;
+    --help|-h)    usage ;;
+    -*)           echo "Unknown option: $1" >&2; usage ;;
+    *)            DESCRIPTION="$1"; shift ;;
+  esac
+done
+
+# ── List mode ─────────────────────────────────────────────────────────────────
+list_escalations() {
+  echo ""
+  echo -e "${BOLD}${BLUE}╔══════════════════════════════════════════════════════════╗${NC}"
+  echo -e "${BOLD}${BLUE}║          RECENT ESCALATIONS (last 24h)                  ║${NC}"
+  echo -e "${BOLD}${BLUE}╚══════════════════════════════════════════════════════════╝${NC}"
+  echo ""
+
+  # Read from coordinator-state escalation field if it exists
+  local esc_data
+  esc_data=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.escalations}' 2>/dev/null || echo "")
+
+  if [ -n "$esc_data" ]; then
+    echo -e "${BOLD}From coordinator-state:${NC}"
+    # Parse pipe-separated escalations: severity:type:agent:issue:ts:desc
+    IFS='|' read -ra ESC_ENTRIES <<< "$esc_data"
+    local count=0
+    for entry in "${ESC_ENTRIES[@]}"; do
+      [ -z "$entry" ] && continue
+      IFS=':' read -r sev typ agt iss ts desc_encoded <<< "$entry"
+      desc=$(echo "$desc_encoded" | sed 's/%3A/:/g; s/%7C/|/g')
+      local color="$NC"
+      case "$sev" in
+        critical) color="$RED" ;;
+        high)     color="$YELLOW" ;;
+        medium)   color="$CYAN" ;;
+        low)      color="$GREEN" ;;
+      esac
+      local issue_str=""
+      [ -n "$iss" ] && [ "$iss" != "none" ] && issue_str=" #${iss}"
+      echo -e "  ${color}[${sev^^}]${NC} [${typ}]${issue_str} ${agt} @ ${ts}"
+      echo "         ${desc}"
+      count=$((count + 1))
+    done
+    [ "$count" -eq 0 ] && echo "  (no escalations recorded)"
+  fi
+
+  echo ""
+  # Also show recent blocker thoughts from cluster
+  echo -e "${BOLD}Recent blocker thoughts:${NC}"
+  kubectl get configmaps -n "$NAMESPACE" -l agentex/thought -o json 2>/dev/null | \
+    jq -r '.items | sort_by(.metadata.creationTimestamp) | reverse | .[0:20] |
+      .[] | select(.data.thoughtType=="blocker") |
+      "  [\(.metadata.creationTimestamp | split("T")[1] | split("Z")[0])] \(.data.agentRef): \(.data.content | split("\n")[0])"' \
+    2>/dev/null | head -10 || echo "  (none)"
+  echo ""
+
+  # Show GitHub issues labeled needs-human
+  echo -e "${BOLD}Issues flagged for human attention:${NC}"
+  gh issue list --repo "$REPO" --label "needs-human" --state open --limit 5 \
+    --json number,title,createdAt \
+    --jq '.[] | "  #\(.number) \(.title)"' 2>/dev/null || echo "  (none)"
+  echo ""
+}
+
+if [ "$LIST_MODE" = true ]; then
+  list_escalations
+  exit 0
+fi
+
+# ── Validate inputs ───────────────────────────────────────────────────────────
+if [ -z "$DESCRIPTION" ]; then
+  echo -e "${RED}ERROR: description is required${NC}" >&2
+  usage
+fi
+
+# Validate severity
+case "$SEVERITY" in
+  low|medium|high|critical) ;;
+  *) echo -e "${RED}ERROR: invalid severity '$SEVERITY'. Use: low|medium|high|critical${NC}" >&2; exit 1 ;;
+esac
+
+# Validate type
+case "$TYPE" in
+  retry|blocked|conflict|decision|failed|security|proliferation) ;;
+  *) echo -e "${RED}ERROR: invalid type '$TYPE'. Use: retry|blocked|conflict|decision|failed|security|proliferation${NC}" >&2; exit 1 ;;
+esac
+
+# Decision type requires options
+if [ "$TYPE" = "decision" ] && [ -z "$OPTIONS" ]; then
+  log "WARNING: decision type without --options. Use --options 'opt1,opt2,opt3' to list choices."
+fi
+
+# ── Determine tier and action ─────────────────────────────────────────────────
+determine_tier() {
+  # Security and proliferation always go to Tier 3 regardless of severity
+  if [ "$TYPE" = "security" ] || [ "$TYPE" = "proliferation" ]; then
+    echo "3"
+    return
+  fi
+
+  case "$SEVERITY" in
+    low)      echo "0" ;;
+    medium)   echo "1" ;;
+    high)     echo "2" ;;
+    critical) echo "3" ;;
+  esac
+}
+
+TIER=$(determine_tier)
+
+determine_auto_action() {
+  case "$TYPE" in
+    retry)        echo "re-queue after 5min delay" ;;
+    blocked)      echo "check if dependency resolved, re-queue" ;;
+    conflict)     echo "spawn fresh worker on current main" ;;
+    decision)     echo "route to god-delegate or dashboard for choice" ;;
+    failed)       echo "escalate to coordinator, then god-delegate if unresolved" ;;
+    security)     echo "label issue needs-human, post CRITICAL thought, flag dashboard" ;;
+    proliferation) echo "activate kill switch immediately" ;;
+  esac
+}
+
+AUTO_ACTION=$(determine_auto_action)
+
+# ── Display escalation banner ─────────────────────────────────────────────────
+display_banner() {
+  echo ""
+  local color tier_label
+  case "$SEVERITY" in
+    critical) color="$RED" ;;
+    high)     color="$YELLOW" ;;
+    medium)   color="$CYAN" ;;
+    low)      color="$GREEN" ;;
+  esac
+
+  case "$TIER" in
+    0) tier_label="Tier 0 — Self Recovery" ;;
+    1) tier_label="Tier 1 — Coordinator Escalation" ;;
+    2) tier_label="Tier 2 — God-Delegate Escalation" ;;
+    3) tier_label="Tier 3 — Human Escalation (IMMEDIATE)" ;;
+  esac
+
+  echo -e "${color}${BOLD}╔══════════════════════════════════════════════════════════╗"
+  printf "║  ESCALATION: %-10s / %-12s / %s\n" "${SEVERITY^^}" "${TYPE}" "${tier_label}"
+  echo -e "╚══════════════════════════════════════════════════════════╝${NC}"
+  echo ""
+  echo -e "  ${BOLD}Agent:${NC}       $AGENT_NAME"
+  [ -n "$ISSUE" ] && echo -e "  ${BOLD}Issue:${NC}       #$ISSUE"
+  echo -e "  ${BOLD}Problem:${NC}     $DESCRIPTION"
+  [ -n "$OPTIONS" ] && echo -e "  ${BOLD}Options:${NC}     $OPTIONS"
+  echo -e "  ${BOLD}Auto-action:${NC} $AUTO_ACTION"
+  echo ""
+}
+
+display_banner
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}DRY RUN — no actions taken${NC}"
+  exit 0
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ESCALATION_ID="esc-$(date +%s)-${SEVERITY:0:3}"
+
+# ── Tier 0: Self-recovery (log only) ─────────────────────────────────────────
+if [ "$TIER" = "0" ]; then
+  log "Tier 0 escalation: $TYPE — $DESCRIPTION"
+  echo -e "${GREEN}✓ Tier 0: logged for self-recovery${NC}"
+  echo -e "  Action: $AUTO_ACTION"
+  exit 0
+fi
+
+# ── Post blocker/insight Thought CR ──────────────────────────────────────────
+THOUGHT_TYPE="blocker"
+[ "$TIER" = "1" ] && THOUGHT_TYPE="blocker"
+[ "$TIER" = "2" ] && THOUGHT_TYPE="blocker"
+[ "$TIER" = "3" ] && THOUGHT_TYPE="blocker"
+
+THOUGHT_NAME="thought-${AGENT_NAME}-esc-$(date +%s)"
+ISSUE_CONTEXT=""
+[ -n "$ISSUE" ] && ISSUE_CONTEXT="issue: #$ISSUE"
+OPTIONS_CONTEXT=""
+[ -n "$OPTIONS" ] && OPTIONS_CONTEXT="options: $OPTIONS"
+
+THOUGHT_CONTENT="ESCALATION [${SEVERITY^^}/${TYPE}] Tier ${TIER}
+${ISSUE_CONTEXT}
+description: $DESCRIPTION
+${OPTIONS_CONTEXT}
+auto-action: $AUTO_ACTION
+escalation-id: $ESCALATION_ID
+timestamp: $TIMESTAMP"
+
+kubectl apply -f - <<EOF 2>/dev/null && \
+  log "Posted blocker Thought CR: $THOUGHT_NAME" || \
+  log "WARNING: Failed to post Thought CR"
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${THOUGHT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "${THOUGHT_TYPE}"
+  confidence: 9
+  topic: "escalation-${TYPE}"
+  content: |
+$(echo "$THOUGHT_CONTENT" | sed 's/^/    /')
+EOF
+
+# ── Record escalation in coordinator-state ────────────────────────────────────
+# Encode description to avoid colon/pipe conflicts
+DESC_ENCODED=$(echo "$DESCRIPTION" | sed 's/:/\%3A/g; s/|/\%7C/g' | cut -c1-120)
+ISSUE_FIELD="${ISSUE:-none}"
+NEW_ENTRY="${SEVERITY}:${TYPE}:${AGENT_NAME}:${ISSUE_FIELD}:${TIMESTAMP}:${DESC_ENCODED}"
+
+# Read current escalations, append new entry (keep last 20)
+CURRENT_ESC=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+  -o jsonpath='{.data.escalations}' 2>/dev/null || echo "")
+
+if [ -n "$CURRENT_ESC" ]; then
+  # Count entries (pipe-separated), keep last 19 + append new
+  ENTRY_COUNT=$(echo "$CURRENT_ESC" | tr -cd '|' | wc -c)
+  if [ "$ENTRY_COUNT" -ge 19 ]; then
+    # Drop the oldest entry
+    CURRENT_ESC=$(echo "$CURRENT_ESC" | cut -d'|' -f2-)
+  fi
+  NEW_ESC="${CURRENT_ESC}|${NEW_ENTRY}"
+else
+  NEW_ESC="$NEW_ENTRY"
+fi
+
+kubectl patch configmap coordinator-state -n "$NAMESPACE" \
+  --type=merge -p "{\"data\":{\"escalations\":\"${NEW_ESC}\"}}" 2>/dev/null && \
+  log "Recorded escalation in coordinator-state" || \
+  log "WARNING: Failed to update coordinator-state"
+
+# ── Tier 1: Coordinator escalation ───────────────────────────────────────────
+tier1_action() {
+  echo ""
+  echo -e "${CYAN}${BOLD}▶ Tier 1: Coordinator Escalation${NC}"
+
+  case "$TYPE" in
+    blocked)
+      echo "  → Releasing task back to coordinator queue for reassignment"
+      if [ -n "$ISSUE" ]; then
+        # Remove from activeAssignments so coordinator re-queues it
+        CURRENT_ASSIGNMENTS=$(kubectl get configmap coordinator-state -n "$NAMESPACE" \
+          -o jsonpath='{.data.activeAssignments}' 2>/dev/null || echo "")
+        if [ -n "$CURRENT_ASSIGNMENTS" ]; then
+          NEW_ASSIGNMENTS=$(echo "$CURRENT_ASSIGNMENTS" | \
+            tr ',' '\n' | grep -v "^${AGENT_NAME}:${ISSUE}$" | \
+            tr '\n' ',' | sed 's/,$//')
+          kubectl patch configmap coordinator-state -n "$NAMESPACE" \
+            --type=merge -p "{\"data\":{\"activeAssignments\":\"${NEW_ASSIGNMENTS}\"}}" 2>/dev/null && \
+            echo -e "  ${GREEN}✓${NC} Released assignment #$ISSUE from coordinator" || \
+            echo -e "  ${YELLOW}⚠${NC} Failed to release assignment (coordinator cleanup will handle it)"
+        fi
+      fi
+      ;;
+    conflict)
+      echo "  → Conflict detected: coordinator will spawn fresh worker on current main"
+      # Post a message to coordinator about the conflict
+      kubectl apply -f - <<EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Message
+metadata:
+  name: msg-${AGENT_NAME}-conflict-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  from: "${AGENT_NAME}"
+  to: "broadcast"
+  thread: "${TASK_CR_NAME:-escalation}"
+  body: |
+    CONFLICT ESCALATION: ${AGENT_NAME} hit merge conflict on issue #${ISSUE:-unknown}
+    Description: $DESCRIPTION
+    Action needed: spawn fresh worker to rebase on current main
+    Escalation-ID: $ESCALATION_ID
+EOF
+      echo -e "  ${GREEN}✓${NC} Broadcast conflict message to coordinator"
+      ;;
+    failed)
+      echo "  → Unrecoverable error: marking task for re-queue with fresh context"
+      ;;
+    retry)
+      echo "  → Transient failure: re-queuing task after delay"
+      ;;
+  esac
+
+  echo -e "  ${GREEN}✓${NC} Tier 1 actions complete"
+}
+
+# ── Tier 2: God-delegate escalation ──────────────────────────────────────────
+tier2_action() {
+  echo ""
+  echo -e "${YELLOW}${BOLD}▶ Tier 2: God-Delegate Escalation${NC}"
+
+  # Post a decision thought for god-delegate to pick up
+  DECISION_THOUGHT_NAME="thought-${AGENT_NAME}-decision-$(date +%s)"
+  OPTIONS_BLOCK=""
+  if [ -n "$OPTIONS" ]; then
+    OPTIONS_BLOCK="options: $(echo "$OPTIONS" | tr ',' '\n' | sed 's/^/  - /')"
+  fi
+
+  kubectl apply -f - <<EOF 2>/dev/null && \
+    echo -e "  ${GREEN}✓${NC} Posted decision request for god-delegate" || \
+    echo -e "  ${YELLOW}⚠${NC} Failed to post decision request"
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: ${DECISION_THOUGHT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "blocker"
+  confidence: 9
+  topic: "decision-needed"
+  content: |
+    DECISION NEEDED [${SEVERITY^^}]: $DESCRIPTION
+    issue: ${ISSUE:-none}
+    agent: $AGENT_NAME
+    ${OPTIONS_BLOCK}
+    escalation-id: $ESCALATION_ID
+    timestamp: $TIMESTAMP
+    
+    This decision is above the agent's authority to make unilaterally.
+    God-delegate: please review and post directive or create governance vote.
+EOF
+
+  # If issue number provided, add comment
+  if [ -n "$ISSUE" ] && command -v gh &>/dev/null; then
+    gh issue comment "$ISSUE" --repo "$REPO" \
+      --body "**ESCALATION [${SEVERITY^^}/${TYPE}]** — agent \`${AGENT_NAME}\` needs decision
+
+Problem: $DESCRIPTION
+${OPTIONS:+Options: \`$OPTIONS\`}
+
+Escalation-ID: \`$ESCALATION_ID\`
+Tier: 2 (god-delegate review needed)" 2>/dev/null && \
+      echo -e "  ${GREEN}✓${NC} Posted comment on issue #$ISSUE" || \
+      echo -e "  ${YELLOW}⚠${NC} Failed to comment on issue (gh CLI error)"
+  fi
+
+  echo -e "  ${GREEN}✓${NC} Tier 2 actions complete"
+  echo -e "  ${YELLOW}ℹ${NC}  God-delegate will review at next cycle (~20min)"
+}
+
+# ── Tier 3: Human escalation ─────────────────────────────────────────────────
+tier3_action() {
+  echo ""
+  echo -e "${RED}${BOLD}▶ Tier 3: IMMEDIATE HUMAN ESCALATION${NC}"
+
+  # For proliferation: activate kill switch immediately
+  if [ "$TYPE" = "proliferation" ]; then
+    echo ""
+    echo -e "  ${RED}${BOLD}PROLIFERATION DETECTED — activating kill switch${NC}"
+    kubectl create configmap agentex-killswitch -n "$NAMESPACE" \
+      --from-literal=enabled=true \
+      --from-literal=reason="Proliferation detected by $AGENT_NAME: $DESCRIPTION" \
+      --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null && \
+      echo -e "  ${RED}✓${NC} KILL SWITCH ACTIVATED — all spawning blocked" || \
+      echo -e "  ${RED}✗${NC} Failed to activate kill switch — manual intervention required"
+    echo ""
+  fi
+
+  # Label issue needs-human
+  if [ -n "$ISSUE" ] && command -v gh &>/dev/null; then
+    gh issue edit "$ISSUE" --repo "$REPO" \
+      --add-label "needs-human" 2>/dev/null && \
+      echo -e "  ${RED}✓${NC} Labeled issue #$ISSUE with 'needs-human'" || \
+      echo -e "  ${YELLOW}⚠${NC} Failed to add needs-human label (may not exist yet)"
+
+    gh issue comment "$ISSUE" --repo "$REPO" \
+      --body "## 🔴 CRITICAL ESCALATION — Human Attention Required
+
+**Severity:** ${SEVERITY^^}
+**Type:** ${TYPE}
+**Agent:** \`${AGENT_NAME}\`
+**Timestamp:** ${TIMESTAMP}
+
+**Problem:** $DESCRIPTION
+${OPTIONS:+**Options:** \`$OPTIONS\`}
+
+**Escalation-ID:** \`$ESCALATION_ID\`
+**Tier:** 3 (immediate human attention needed)
+
+The agentex coordinator and god-delegate cannot resolve this automatically.
+$([ "$TYPE" = "security" ] && echo "⚠️ **SECURITY ISSUE** — review immediately")
+$([ "$TYPE" = "proliferation" ] && echo "🛑 **KILL SWITCH ACTIVATED** — all agent spawning is blocked")" 2>/dev/null && \
+      echo -e "  ${RED}✓${NC} Posted CRITICAL comment on issue #$ISSUE" || \
+      echo -e "  ${YELLOW}⚠${NC} Failed to comment on issue"
+  else
+    # No issue number — create a new one for tracking
+    if command -v gh &>/dev/null; then
+      NEW_ISSUE_BODY="## 🔴 CRITICAL ESCALATION — Human Attention Required
+
+**Severity:** ${SEVERITY^^}
+**Type:** ${TYPE}
+**Agent:** \`${AGENT_NAME}\`
+**Timestamp:** ${TIMESTAMP}
+
+**Problem:** $DESCRIPTION
+${OPTIONS:+**Options:** \`$OPTIONS\`}
+
+**Escalation-ID:** \`$ESCALATION_ID\`
+
+This issue was automatically created by the escalation protocol.
+$([ "$TYPE" = "security" ] && echo "⚠️ **SECURITY ISSUE** — review immediately")
+$([ "$TYPE" = "proliferation" ] && echo "🛑 **KILL SWITCH ACTIVATED** — all agent spawning is blocked")"
+
+      NEW_ISSUE_NUM=$(gh issue create --repo "$REPO" \
+        --title "CRITICAL: ${TYPE} escalation from $AGENT_NAME" \
+        --body "$NEW_ISSUE_BODY" \
+        --label "needs-human" \
+        --json number -q '.number' 2>/dev/null || echo "")
+      if [ -n "$NEW_ISSUE_NUM" ]; then
+        echo -e "  ${RED}✓${NC} Created issue #$NEW_ISSUE_NUM for tracking"
+      else
+        echo -e "  ${YELLOW}⚠${NC} Failed to create tracking issue"
+      fi
+    fi
+  fi
+
+  # Record S3 critical event
+  CRITICAL_EVENT="{\"id\":\"${ESCALATION_ID}\",\"severity\":\"${SEVERITY}\",\"type\":\"${TYPE}\",\"agent\":\"${AGENT_NAME}\",\"issue\":\"${ISSUE:-none}\",\"description\":\"$(echo "$DESCRIPTION" | sed 's/"/\\"/g')\",\"timestamp\":\"${TIMESTAMP}\"}"
+  echo "$CRITICAL_EVENT" | \
+    aws s3 cp - "s3://${S3_BUCKET}/escalations/${ESCALATION_ID}.json" \
+    --content-type application/json 2>/dev/null && \
+    echo -e "  ${RED}✓${NC} Critical event recorded to S3: s3://${S3_BUCKET}/escalations/${ESCALATION_ID}.json" || \
+    echo -e "  ${YELLOW}⚠${NC} Failed to write to S3 (non-fatal)"
+
+  echo ""
+  echo -e "  ${RED}${BOLD}⚠ HUMAN ACTION REQUIRED — system cannot self-heal this ${NC}"
+  echo -e "  ${RED}${BOLD}  Check the dashboard and GitHub issues immediately${NC}"
+  echo ""
+  echo -e "  ${CYAN}Recovery commands:${NC}"
+  echo "    kubectl get jobs -n agentex | grep Running | wc -l"
+  echo "    kubectl get configmap agentex-killswitch -n agentex -o jsonpath='{.data.enabled}'"
+  [ "$TYPE" = "security" ] && echo "    gh issue list --repo $REPO --label needs-human"
+  echo ""
+  echo -e "  ${GREEN}✓${NC} Tier 3 actions complete"
+}
+
+# ── Execute tier actions ──────────────────────────────────────────────────────
+case "$TIER" in
+  1) tier1_action ;;
+  2) tier1_action; tier2_action ;;
+  3) tier1_action; tier2_action; tier3_action ;;
+esac
+
+# ── Write escalation exit state ───────────────────────────────────────────────
+# Structured exit state (integrates with session/state separation #1833)
+EXIT_STATE_FILE="/tmp/agentex-escalation-state"
+cat > "$EXIT_STATE_FILE" <<EOF
+{
+  "escalationId": "${ESCALATION_ID}",
+  "status": "escalated",
+  "severity": "${SEVERITY}",
+  "type": "${TYPE}",
+  "tier": ${TIER},
+  "issue": "${ISSUE:-}",
+  "description": "$(echo "$DESCRIPTION" | sed 's/"/\\"/g')",
+  "options": "${OPTIONS:-}",
+  "agent": "${AGENT_NAME}",
+  "autoAction": "${AUTO_ACTION}",
+  "timestamp": "${TIMESTAMP}",
+  "workPreserved": true
+}
+EOF
+log "Escalation state written to $EXIT_STATE_FILE"
+echo -e "${GREEN}✓${NC} Escalation state written to $EXIT_STATE_FILE"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Escalation Summary:${NC}"
+echo -e "  ID:       $ESCALATION_ID"
+echo -e "  Severity: $SEVERITY → Tier $TIER"
+echo -e "  Type:     $TYPE"
+echo -e "  Action:   $AUTO_ACTION"
+echo ""
+echo -e "${GREEN}${BOLD}✓ Escalation complete.${NC}"
+echo ""
+
+exit 0


### PR DESCRIPTION
## Summary

Implements tiered escalation protocol for agentex agents to signal they need help without crashing. Part of v1.0 Roadmap (#1821) — Phase 3: Recovery without god.

Closes #1839

## Changes

### `manifests/system/escalate.sh` (new)
Standalone CLI script with rich output for structured escalation:
- **4 severity levels** → **4 tiers**:
  - `low` → Tier 0: log only (self-recovery)
  - `medium` → Tier 1: coordinator escalation (re-queue, spawn fresh worker)
  - `high` → Tier 2: god-delegate escalation (posts decision-needed blocker Thought CR)
  - `critical` → Tier 3: human attention (adds `needs-human` label, writes S3 record, activates kill switch for proliferation type)
- **7 escalation types**: `retry|blocked|conflict|decision|failed|security|proliferation`
- `--dry-run` mode: shows what would happen without side effects
- `--list` mode: shows recent escalations from coordinator-state + blocker Thought CRs
- Structured exit state written to `/tmp/agentex-escalation-state` (JSON, integrates with #1833)

### `images/runner/helpers.sh`
Added `escalate()` function — same tier logic, callable inline from agent sessions:
```bash
source /agent/helpers.sh
escalate medium blocked "Merge conflict in coordinator.go" 789
escalate high decision "Which DB?" 789 "SQLite,PostgreSQL,DynamoDB"
escalate critical security "Found exposed credentials in PR #1830"
```

All escalations are recorded in `coordinator-state.escalations` (pipe-separated, last 20 entries).

### `AGENTS.md`
Documented the new `escalate()` helper and `escalate.sh` CLI in the helpers reference section and agent pod spec.

## Usage Examples

```bash
# Inside an agent session
source /agent/helpers.sh
escalate medium blocked "Cannot rebase, 3 files conflict with main" 789
escalate high decision "Which database?" 789 "SQLite,PostgreSQL,DynamoDB"
escalate critical security "Found exposed AWS credentials in PR #1830"

# As standalone CLI (richer output + --list/--dry-run)
./manifests/system/escalate.sh --severity high --type decision \
  --issue 789 --options "SQLite,PostgreSQL" \
  "Which database for the work ledger?"

./manifests/system/escalate.sh --list    # show recent escalations
./manifests/system/escalate.sh --dry-run  # preview actions
```

## Success Criteria met

- [x] Agents can signal "I need help" without crashing
- [x] Transient failures auto-recover via retry logging (Tier 0)
- [x] Merge conflicts escalate to coordinator for fresh worker spawn (Tier 1)
- [x] Decisions that need input appear as blocker Thought CRs (Tier 2)
- [x] CRITICAL escalations activate kill switch / add needs-human label (Tier 3)