### PR TITLE
feat: multi-tier watchdog chain — detect and recover from failures in seconds (#1844)

### DIFF
--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -197,6 +197,49 @@ With the coordinator:
 - **#426** — Consensus voting for circuitBreakerLimit (enabled by coordinator)
 - **#415** — Persistent agent identity (coordinator tracks who did what)
 - **#2** — Consensus voting (deprecated, replaced by coordinator-based approach)
+- **#1844** — Multi-tier watchdog chain (Tier 1 inside coordinator)
+
+## Watchdog Chain (issue #1844)
+
+The coordinator implements **Tier 1** of a three-tier watchdog chain:
+
+### Tier 1: Mechanical Heartbeat (`watchdog_check()`, every ~60s)
+
+Inside `coordinator.sh`, runs every 2 iterations. Checks:
+
+1. **Stuck jobs** — jobs running > 30 min → posts blocker Thought CR
+2. **Spawn rate** — > 5 new jobs in 2 min → activates kill switch automatically
+3. **Heartbeat staleness** — own `lastHeartbeat` > 120s old → posts degraded metric
+
+State written to `coordinator-state.watchdogState`:
+- `"healthy"` — all checks pass
+- `"degraded:<reason>"` — potential issues, investigation recommended
+- `"critical:<reason>"` — kill switch activated or severe problem detected
+
+```bash
+# Read Tier 1 watchdog state
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.watchdogState}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.watchdogLastCheck}'
+```
+
+### Tier 2: Triage CronJob (`watchdog-triage-cronjob.yaml`, every 5 min)
+
+An ephemeral Job running `watchdog-triage.sh` from the runner image. Adds:
+
+1. **Agent activity** — recent Thought CRs (freshness check)
+2. **Coordinator health** — reads `lastHeartbeat` and Tier 1 state
+3. **Spawn slot drift** — `spawnSlots` vs `circuitBreakerLimit - activeJobs`
+4. **Unresolved escalations** — `unresolvedDebates` count
+5. **Kill switch status** — whether civilization is currently halted
+
+Posts Thought CRs: `insight` (healthy), `blocker` (degraded/critical).
+Exits 1 on critical → CloudWatch can alarm on failed CronJob runs.
+
+### Tier 3: God-Delegate (every 20 min)
+
+The existing god-delegate loop reads Tier 1 and Tier 2 findings (via Thought CRs
+and `watchdogState`) and applies full intelligence: vision alignment scoring,
+debate quality assessment, and escalation to human via GitHub issue #62.
 
 ## Maintenance
 

--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r14 (issue #1830: fix tasksCompleted=0 — move increment before Report CR creation)
+# Image version: 2026-03-10-r15 (issue #1844: multi-tier watchdog chain — Tier 1 mechanical heartbeat in coordinator.sh + Tier 2 watchdog-triage.sh)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)
@@ -130,9 +130,10 @@ RUN git config --system user.name "agentex-bot" \
 COPY entrypoint.sh /entrypoint.sh
 COPY coordinator.sh /usr/local/bin/coordinator.sh
 COPY planner-loop.sh /usr/local/bin/planner-loop.sh
+COPY watchdog-triage.sh /usr/local/bin/watchdog-triage.sh
 COPY identity.sh /agent/identity.sh
 COPY helpers.sh /agent/helpers.sh
-RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh /agent/helpers.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
+RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /usr/local/bin/watchdog-triage.sh /agent/identity.sh /agent/helpers.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /usr/local/bin/watchdog-triage.sh /agent
 
 USER agentex
 WORKDIR /workspace

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -409,6 +409,22 @@ ensure_state_fields_initialized() {
       -p '{"data":{"v06CriteriaStatus":""}}' 2>/dev/null || true
   fi
 
+  # watchdogState (issue #1844): Tier 1 watchdog health state.
+  # Values: "healthy", "degraded:<reason>", "critical:<reason>"
+  # Updated every ~60s by watchdog_check().
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("watchdogState")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing watchdogState (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"watchdogState":"healthy"}}' 2>/dev/null || true
+  fi
+
+  # watchdogLastCheck (issue #1844): ISO 8601 timestamp of last Tier 1 watchdog run.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("watchdogLastCheck")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing watchdogLastCheck (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"watchdogLastCheck":""}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.
@@ -4239,6 +4255,144 @@ if [ -z "$INITIAL_QUEUE" ]; then
     refresh_task_queue
 fi
 
+# ── Tier 1: Mechanical Watchdog (issue #1844) ───────────────────────────────
+# Runs every 2 coordinator iterations (~60s). Pure code, no AI.
+# Checks:
+#   1. Stuck jobs (running > WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES minutes)
+#   2. Spawn rate (anti-proliferation: > WATCHDOG_PROLIFERATION_THRESHOLD spawns in 2 min)
+#   3. Coordinator self-health (lastHeartbeat staleness > WATCHDOG_STALE_HEARTBEAT_SECONDS)
+# Actions:
+#   - DEGRADED: post blocker Thought CR, push CloudWatch metric
+#   - CRITICAL (proliferation): activate kill switch automatically
+#
+# Health states written to coordinator-state.watchdogState:
+#   "healthy", "degraded:<reason>", "critical:<reason>"
+#
+WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES=30   # jobs running longer than this are "stuck"
+WATCHDOG_PROLIFERATION_THRESHOLD=5        # spawns in 2 min trigger kill switch
+WATCHDOG_STALE_HEARTBEAT_SECONDS=120      # heartbeat age that counts as "coordinator unhealthy"
+
+watchdog_check() {
+    local now_epoch
+    now_epoch=$(date +%s)
+    local health_state="healthy"
+    local health_reasons=()
+
+    # ── Check 1: Stuck jobs (running > threshold minutes) ──────────────────
+    local stuck_threshold_epoch=$(( now_epoch - WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES * 60 ))
+    local stuck_threshold_ts
+    stuck_threshold_ts=$(date -u -d "@${stuck_threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+        date -u -r "${stuck_threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+    local stuck_jobs
+    stuck_jobs=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+        jq --argjson threshold "$stuck_threshold_epoch" \
+        '[.items[] | select(
+            .status.completionTime == null and
+            (.status.active // 0) > 0 and
+            (.metadata.creationTimestamp | fromdateiso8601) < $threshold
+        ) | .metadata.name]' 2>/dev/null || echo "[]")
+
+    local stuck_count
+    stuck_count=$(echo "$stuck_jobs" | jq 'length' 2>/dev/null || echo "0")
+
+    if [ "$stuck_count" -gt 0 ]; then
+        local stuck_names
+        stuck_names=$(echo "$stuck_jobs" | jq -r '.[]' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+        echo "[$(date -u +%H:%M:%S)] WATCHDOG: $stuck_count stuck job(s) detected (>${WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES}min): $stuck_names"
+        push_metric "WatchdogStuckJobs" "$stuck_count" "Count" "Component=Coordinator"
+        health_state="degraded"
+        health_reasons+=("stuck-jobs:${stuck_count}")
+
+        # Post a blocker Thought CR so agents can see the stuck jobs
+        post_coordinator_thought \
+            "WATCHDOG ALERT [degraded]: $stuck_count job(s) stuck for >${WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES}min.
+Stuck jobs: $stuck_names
+Action: Investigate these jobs. They may be waiting for external resources or have a bug.
+If a job is stuck beyond ${WATCHDOG_STUCK_JOB_THRESHOLD_MINUTES}min, consider killing it manually." \
+            "blocker"
+    else
+        echo "[$(date -u +%H:%M:%S)] WATCHDOG: No stuck jobs detected"
+        push_metric "WatchdogStuckJobs" 0 "Count" "Component=Coordinator"
+    fi
+
+    # ── Check 2: Proliferation detection (spawn rate > threshold in 2 min) ──
+    local two_min_ago_epoch=$(( now_epoch - 120 ))
+    local recent_spawns
+    recent_spawns=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+        jq --argjson cutoff "$two_min_ago_epoch" \
+        '[.items[] | select(
+            (.metadata.creationTimestamp | fromdateiso8601) > $cutoff
+        )] | length' 2>/dev/null || echo "0")
+
+    echo "[$(date -u +%H:%M:%S)] WATCHDOG: $recent_spawns spawns in last 2 minutes (threshold: $WATCHDOG_PROLIFERATION_THRESHOLD)"
+    push_metric "WatchdogRecentSpawns" "$recent_spawns" "Count" "Component=Coordinator"
+
+    if [ "$recent_spawns" -gt "$WATCHDOG_PROLIFERATION_THRESHOLD" ]; then
+        echo "[$(date -u +%H:%M:%S)] WATCHDOG: CRITICAL — proliferation detected! $recent_spawns spawns in 2 min. Activating kill switch."
+        push_metric "WatchdogProliferationDetected" 1 "Count" "Component=Coordinator"
+        health_state="critical"
+        health_reasons+=("proliferation:${recent_spawns}-spawns-in-2min")
+
+        # Activate kill switch to stop the proliferation
+        kubectl_with_timeout 10 create configmap agentex-killswitch -n "$NAMESPACE" \
+            --from-literal=enabled=true \
+            --from-literal=reason="Watchdog: proliferation detected — $recent_spawns spawns in 2 minutes" \
+            --dry-run=client -o yaml 2>/dev/null | \
+            kubectl_with_timeout 10 apply -f - 2>/dev/null || true
+        push_metric "WatchdogKillSwitchActivated" 1 "Count" "Component=Coordinator,Reason=Proliferation"
+
+        post_coordinator_thought \
+            "WATCHDOG CRITICAL: Kill switch activated. Proliferation detected: $recent_spawns spawns in 2 minutes.
+The kill switch has been enabled to halt spawning. Human intervention may be required.
+To recover: verify system is stable, then deactivate via:
+  kubectl patch configmap agentex-killswitch -n agentex --type=merge -p '{\"data\":{\"enabled\":\"false\",\"reason\":\"\"}}'" \
+            "blocker"
+    fi
+
+    # ── Check 3: Coordinator self-health (lastHeartbeat staleness) ──────────
+    local last_heartbeat
+    last_heartbeat=$(get_state "lastHeartbeat")
+    if [ -n "$last_heartbeat" ]; then
+        local heartbeat_epoch
+        heartbeat_epoch=$(date -d "$last_heartbeat" +%s 2>/dev/null || echo "0")
+        local heartbeat_age=$(( now_epoch - heartbeat_epoch ))
+        push_metric "WatchdogHeartbeatAge" "$heartbeat_age" "Seconds" "Component=Coordinator"
+
+        if [ "$heartbeat_age" -gt "$WATCHDOG_STALE_HEARTBEAT_SECONDS" ]; then
+            echo "[$(date -u +%H:%M:%S)] WATCHDOG: DEGRADED — coordinator heartbeat stale (${heartbeat_age}s > ${WATCHDOG_STALE_HEARTBEAT_SECONDS}s)"
+            push_metric "WatchdogHeartbeatStale" 1 "Count" "Component=Coordinator"
+            health_state="degraded"
+            health_reasons+=("stale-heartbeat:${heartbeat_age}s")
+        else
+            echo "[$(date -u +%H:%M:%S)] WATCHDOG: Heartbeat fresh (${heartbeat_age}s old)"
+        fi
+    else
+        echo "[$(date -u +%H:%M:%S)] WATCHDOG: No heartbeat timestamp yet — coordinator just started"
+    fi
+
+    # ── Write health state to coordinator-state ────────────────────────────
+    local reason_str=""
+    if [ "${#health_reasons[@]}" -gt 0 ]; then
+        # Join reasons with comma
+        local IFS=','
+        reason_str="${health_reasons[*]}"
+        IFS=$' \t\n'  # restore IFS
+    fi
+
+    local watchdog_state
+    if [ "$health_state" = "healthy" ]; then
+        watchdog_state="healthy"
+    else
+        watchdog_state="${health_state}:${reason_str}"
+    fi
+
+    update_state "watchdogState" "$watchdog_state"
+    update_state "watchdogLastCheck" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    push_metric "WatchdogHealthy" "$( [ "$health_state" = "healthy" ] && echo 1 || echo 0 )" "Count" "Component=Coordinator"
+    echo "[$(date -u +%H:%M:%S)] WATCHDOG: Health state: $watchdog_state"
+}
+
 # ── HTTP Health Endpoint (issue #699) ───────────────────────────────────────
 # Start a background HTTP server that responds to health checks
 # Returns 200 if heartbeat is fresh (< 120s old), 503 if stale
@@ -4440,6 +4594,14 @@ while true; do
     # NOTE (issue #867): Planner-chain liveness check removed.
     # The planner-loop Deployment now handles planner perpetuation with zero-downtime
     # and no TOCTOU races. Coordinator no longer needs to spawn recovery planners.
+
+    # Every 2 iterations (~60s): Tier 1 mechanical watchdog check (issue #1844)
+    # Detects stuck jobs, proliferation, and coordinator self-health.
+    # Proliferation → activates kill switch automatically (no human needed).
+    # Stuck jobs → posts blocker Thought CR for agent/human investigation.
+    if [ $((iteration % 2)) -eq 0 ]; then
+        watchdog_check
+    fi
 
     # Every 60 iterations (~30 min): cleanup old Thought/Message/Report CRs (issue #1617)
     # Supplements planner-initiated cleanup. The cluster accumulates 4000+ Thoughts and

--- a/images/runner/watchdog-triage.sh
+++ b/images/runner/watchdog-triage.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════════════════════
+# WATCHDOG TRIAGE — Tier 2 AI Health Check (issue #1844)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# A lightweight, ephemeral Job that runs every 5 minutes.
+# Unlike the Tier 1 mechanical heartbeat (in coordinator.sh), this script
+# uses AI reasoning via OpenCode to assess system health.
+#
+# Checks:
+#   1. Are agents making progress? (recent commits, PRs, Thought CRs)
+#   2. Is coordinator state consistent? (counters match reality)
+#   3. Are there unresolved escalations?
+#   4. Is the Tier 1 watchdog state stale or degraded?
+#
+# Actions:
+#   - HEALTHY: emit metric, post brief Thought CR, exit 0
+#   - DEGRADED: post diagnosis Thought CR, emit alert metric, exit 0
+#   - CRITICAL: post Thought CR, activate kill switch (if needed), exit 1
+#
+# This is a BASH-only script (no OpenCode/LLM call from inside the script).
+# The script itself performs the health checks and posts structured findings.
+# For full AI triage, this script is the "prompt + data gathering" layer
+# that a future OpenCode session will read as context.
+# ═══════════════════════════════════════════════════════════════════════════
+
+set -uo pipefail
+
+NAMESPACE="${NAMESPACE:-agentex}"
+BEDROCK_REGION="${BEDROCK_REGION:-us-west-2}"
+REPO="${REPO:-pnz1990/agentex}"
+
+# Health assessment thresholds
+THOUGHT_FRESHNESS_SECONDS=300       # 5 min — if no new thoughts, system may be idle
+COORDINATOR_STALE_HEARTBEAT=180     # 3 min — coordinator heartbeat stale threshold
+STUCK_JOB_THRESHOLD_MIN=30          # minutes a job can run before considered stuck
+DEGRADED_ESCALATION_COUNT=3         # unresolved escalations before flagging degraded
+
+echo "═══════════════════════════════════════════════════════════════════════════"
+echo "WATCHDOG TRIAGE STARTING"
+echo "═══════════════════════════════════════════════════════════════════════════"
+echo "Namespace: $NAMESPACE"
+echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Configure kubectl ────────────────────────────────────────────────────────
+if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+    kubectl config set-cluster local \
+        --server=https://kubernetes.default.svc \
+        --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt 2>/dev/null
+    kubectl config set-credentials sa \
+        --token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" 2>/dev/null
+    kubectl config set-context local --cluster=local --user=sa --namespace="$NAMESPACE" 2>/dev/null
+    kubectl config use-context local 2>/dev/null
+fi
+
+kubectl_with_timeout() {
+    local timeout_secs="${1:-10}"
+    shift
+    timeout "${timeout_secs}s" kubectl "$@" 2>/dev/null
+}
+
+push_metric() {
+    local metric_name="$1"
+    local value="$2"
+    local unit="${3:-Count}"
+    local dimensions="${4:-Component=WatchdogTriage}"
+
+    aws cloudwatch put-metric-data \
+        --namespace Agentex \
+        --metric-name "$metric_name" \
+        --value "$value" \
+        --unit "$unit" \
+        --dimensions "$dimensions" \
+        --region "$BEDROCK_REGION" 2>/dev/null || true
+}
+
+post_triage_thought() {
+    local content="$1"
+    local thought_type="${2:-insight}"
+    local ts
+    ts=$(date +%s)
+
+    kubectl_with_timeout 10 apply -f - <<EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-watchdog-triage-${ts}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "watchdog-triage"
+  taskRef: "watchdog-triage-cron"
+  thoughtType: ${thought_type}
+  confidence: 9
+  content: |
+    ${content}
+EOF
+    echo "[$(date -u +%H:%M:%S)] Posted ${thought_type} thought"
+}
+
+# ── Health State Tracking ──────────────────────────────────────────────────
+HEALTH_STATE="healthy"
+HEALTH_FINDINGS=()
+NOW_EPOCH=$(date +%s)
+
+# ── Check 1: Agent Activity (recent Thought CRs) ────────────────────────────
+echo ""
+echo "[$(date -u +%H:%M:%S)] Check 1: Agent activity (recent Thought CRs)..."
+
+RECENT_THOUGHTS=$(kubectl_with_timeout 15 get configmaps -n "$NAMESPACE" \
+    -l agentex/thought -o json 2>/dev/null | \
+    jq --argjson cutoff "$(( NOW_EPOCH - THOUGHT_FRESHNESS_SECONDS ))" \
+    '[.items[] | select(
+        (.metadata.creationTimestamp | fromdateiso8601) > $cutoff
+    )] | length' 2>/dev/null || echo "0")
+
+echo "[$(date -u +%H:%M:%S)] Thought CRs in last 5 min: $RECENT_THOUGHTS"
+push_metric "WatchdogTriageRecentThoughts" "$RECENT_THOUGHTS" "Count"
+
+if [ "$RECENT_THOUGHTS" -eq 0 ]; then
+    echo "[$(date -u +%H:%M:%S)] WARNING: No Thought CRs in last 5 minutes — system may be idle"
+    HEALTH_STATE="degraded"
+    HEALTH_FINDINGS+=("no-recent-thoughts: system may be idle or all agents crashed")
+else
+    echo "[$(date -u +%H:%M:%S)] OK: Agent activity detected ($RECENT_THOUGHTS thoughts)"
+fi
+
+# ── Check 2: Active Jobs ─────────────────────────────────────────────────────
+echo ""
+echo "[$(date -u +%H:%M:%S)] Check 2: Active job count..."
+
+ACTIVE_JOBS=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
+    2>/dev/null || echo "0")
+FAILED_JOBS=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq '[.items[] | select((.status.failed // 0) > 0 and .status.completionTime == null)] | length' \
+    2>/dev/null || echo "0")
+
+CB_LIMIT=$(kubectl_with_timeout 10 get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "10")
+if ! [[ "$CB_LIMIT" =~ ^[0-9]+$ ]]; then CB_LIMIT=10; fi
+
+echo "[$(date -u +%H:%M:%S)] Active jobs: $ACTIVE_JOBS / $CB_LIMIT (circuit breaker limit)"
+echo "[$(date -u +%H:%M:%S)] Failed jobs (not complete): $FAILED_JOBS"
+push_metric "WatchdogTriageActiveJobs" "$ACTIVE_JOBS" "Count"
+push_metric "WatchdogTriageFailedJobs" "$FAILED_JOBS" "Count"
+
+# Check for stuck jobs
+STUCK_THRESHOLD_EPOCH=$(( NOW_EPOCH - STUCK_JOB_THRESHOLD_MIN * 60 ))
+STUCK_JOBS=$(kubectl_with_timeout 15 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+    jq --argjson threshold "$STUCK_THRESHOLD_EPOCH" \
+    '[.items[] | select(
+        .status.completionTime == null and
+        (.status.active // 0) > 0 and
+        (.metadata.creationTimestamp | fromdateiso8601) < $threshold
+    ) | .metadata.name]' 2>/dev/null || echo "[]")
+
+STUCK_COUNT=$(echo "$STUCK_JOBS" | jq 'length' 2>/dev/null || echo "0")
+if [ "$STUCK_COUNT" -gt 0 ]; then
+    STUCK_NAMES=$(echo "$STUCK_JOBS" | jq -r '.[]' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+    echo "[$(date -u +%H:%M:%S)] WARNING: $STUCK_COUNT stuck job(s) (>${STUCK_JOB_THRESHOLD_MIN}min): $STUCK_NAMES"
+    push_metric "WatchdogTriageStuckJobs" "$STUCK_COUNT" "Count"
+    HEALTH_STATE="degraded"
+    HEALTH_FINDINGS+=("stuck-jobs:${STUCK_COUNT} (${STUCK_NAMES})")
+else
+    echo "[$(date -u +%H:%M:%S)] OK: No stuck jobs"
+    push_metric "WatchdogTriageStuckJobs" 0 "Count"
+fi
+
+if [ "$FAILED_JOBS" -gt 3 ]; then
+    echo "[$(date -u +%H:%M:%S)] WARNING: High failure rate ($FAILED_JOBS failing jobs)"
+    HEALTH_STATE="degraded"
+    HEALTH_FINDINGS+=("high-failure-rate:${FAILED_JOBS}-failing-jobs")
+fi
+
+# ── Check 3: Coordinator state consistency ───────────────────────────────────
+echo ""
+echo "[$(date -u +%H:%M:%S)] Check 3: Coordinator state consistency..."
+
+COORDINATOR_STATE=$(kubectl_with_timeout 15 get configmap coordinator-state -n "$NAMESPACE" \
+    -o json 2>/dev/null || echo "{}")
+
+LAST_HEARTBEAT=$(echo "$COORDINATOR_STATE" | \
+    jq -r '.data.lastHeartbeat // ""' 2>/dev/null || echo "")
+WATCHDOG_STATE=$(echo "$COORDINATOR_STATE" | \
+    jq -r '.data.watchdogState // "unknown"' 2>/dev/null || echo "unknown")
+
+echo "[$(date -u +%H:%M:%S)] Coordinator lastHeartbeat: ${LAST_HEARTBEAT:-'(none)'}"
+echo "[$(date -u +%H:%M:%S)] Tier 1 watchdog state: $WATCHDOG_STATE"
+
+if [ -n "$LAST_HEARTBEAT" ]; then
+    HB_EPOCH=$(date -d "$LAST_HEARTBEAT" +%s 2>/dev/null || echo "0")
+    HB_AGE=$(( NOW_EPOCH - HB_EPOCH ))
+    push_metric "WatchdogTriageCoordinatorHeartbeatAge" "$HB_AGE" "Seconds"
+
+    if [ "$HB_AGE" -gt "$COORDINATOR_STALE_HEARTBEAT" ]; then
+        echo "[$(date -u +%H:%M:%S)] CRITICAL: Coordinator heartbeat stale (${HB_AGE}s > ${COORDINATOR_STALE_HEARTBEAT}s)"
+        HEALTH_STATE="critical"
+        HEALTH_FINDINGS+=("coordinator-stale-heartbeat:${HB_AGE}s")
+    else
+        echo "[$(date -u +%H:%M:%S)] OK: Coordinator heartbeat fresh (${HB_AGE}s)"
+    fi
+else
+    echo "[$(date -u +%H:%M:%S)] WARNING: Coordinator has no heartbeat timestamp"
+    HEALTH_FINDINGS+=("coordinator-no-heartbeat")
+    HEALTH_STATE="degraded"
+fi
+
+# Check if Tier 1 watchdog already flagged critical
+if echo "$WATCHDOG_STATE" | grep -q "^critical:"; then
+    echo "[$(date -u +%H:%M:%S)] CRITICAL: Tier 1 watchdog flagged critical: $WATCHDOG_STATE"
+    HEALTH_STATE="critical"
+    HEALTH_FINDINGS+=("tier1-watchdog-critical:${WATCHDOG_STATE}")
+elif echo "$WATCHDOG_STATE" | grep -q "^degraded:"; then
+    echo "[$(date -u +%H:%M:%S)] DEGRADED: Tier 1 watchdog flagged degraded: $WATCHDOG_STATE"
+    if [ "$HEALTH_STATE" != "critical" ]; then
+        HEALTH_STATE="degraded"
+    fi
+    HEALTH_FINDINGS+=("tier1-watchdog-degraded:${WATCHDOG_STATE}")
+fi
+
+# Check spawn slot consistency
+SPAWN_SLOTS=$(echo "$COORDINATOR_STATE" | jq -r '.data.spawnSlots // "-1"' 2>/dev/null || echo "-1")
+if ! [[ "$SPAWN_SLOTS" =~ ^[0-9]+$ ]]; then
+    echo "[$(date -u +%H:%M:%S)] DEGRADED: spawnSlots is invalid: '$SPAWN_SLOTS' — coordinator may be stuck"
+    HEALTH_STATE="degraded"
+    HEALTH_FINDINGS+=("invalid-spawn-slots:${SPAWN_SLOTS}")
+else
+    EXPECTED_SLOTS=$(( CB_LIMIT - ACTIVE_JOBS ))
+    [ "$EXPECTED_SLOTS" -lt 0 ] && EXPECTED_SLOTS=0
+    SLOT_DRIFT=$(( SPAWN_SLOTS - EXPECTED_SLOTS ))
+    [ "$SLOT_DRIFT" -lt 0 ] && SLOT_DRIFT=$(( -SLOT_DRIFT ))
+    push_metric "WatchdogTriageSpawnSlotDrift" "$SLOT_DRIFT" "Count"
+    if [ "$SLOT_DRIFT" -gt 3 ]; then
+        echo "[$(date -u +%H:%M:%S)] WARNING: spawnSlots drift=$SLOT_DRIFT (slots=$SPAWN_SLOTS, expected=$EXPECTED_SLOTS)"
+        HEALTH_FINDINGS+=("spawn-slot-drift:${SLOT_DRIFT}")
+    else
+        echo "[$(date -u +%H:%M:%S)] OK: spawnSlots consistent (slots=$SPAWN_SLOTS, drift=$SLOT_DRIFT)"
+    fi
+fi
+
+# ── Check 4: Unresolved escalations ─────────────────────────────────────────
+echo ""
+echo "[$(date -u +%H:%M:%S)] Check 4: Unresolved escalations..."
+
+UNRESOLVED_DEBATES=$(echo "$COORDINATOR_STATE" | \
+    jq -r '.data.unresolvedDebates // ""' 2>/dev/null || echo "")
+UNRESOLVED_COUNT=0
+if [ -n "$UNRESOLVED_DEBATES" ]; then
+    # Count comma-separated entries
+    UNRESOLVED_COUNT=$(echo "$UNRESOLVED_DEBATES" | tr ',' '\n' | grep -c . || echo "0")
+fi
+
+echo "[$(date -u +%H:%M:%S)] Unresolved debate escalations: $UNRESOLVED_COUNT"
+push_metric "WatchdogTriageUnresolvedEscalations" "$UNRESOLVED_COUNT" "Count"
+
+if [ "$UNRESOLVED_COUNT" -ge "$DEGRADED_ESCALATION_COUNT" ]; then
+    echo "[$(date -u +%H:%M:%S)] WARNING: $UNRESOLVED_COUNT unresolved escalations (threshold: $DEGRADED_ESCALATION_COUNT)"
+    if [ "$HEALTH_STATE" = "healthy" ]; then
+        HEALTH_STATE="degraded"
+    fi
+    HEALTH_FINDINGS+=("unresolved-escalations:${UNRESOLVED_COUNT}")
+fi
+
+# ── Check 5: Kill switch status ──────────────────────────────────────────────
+echo ""
+echo "[$(date -u +%H:%M:%S)] Check 5: Kill switch status..."
+
+KS_ENABLED=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \
+    -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+KS_REASON=$(kubectl_with_timeout 10 get configmap agentex-killswitch -n "$NAMESPACE" \
+    -o jsonpath='{.data.reason}' 2>/dev/null || echo "")
+
+echo "[$(date -u +%H:%M:%S)] Kill switch: $KS_ENABLED (reason: ${KS_REASON:-none})"
+push_metric "WatchdogTriageKillSwitchActive" "$( [ "$KS_ENABLED" = "true" ] && echo 1 || echo 0 )" "Count"
+
+if [ "$KS_ENABLED" = "true" ]; then
+    echo "[$(date -u +%H:%M:%S)] WARNING: Kill switch is active — civilization not spawning"
+    HEALTH_FINDINGS+=("kill-switch-active:${KS_REASON}")
+    # Kill switch active during triage counts as degraded (not critical — it may be intentional)
+    if [ "$HEALTH_STATE" = "healthy" ]; then
+        HEALTH_STATE="degraded"
+    fi
+fi
+
+# ── Generate Report ──────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════════"
+echo "[$(date -u +%H:%M:%S)] TRIAGE SUMMARY"
+echo "═══════════════════════════════════════════════════════════════════════════"
+echo "Health state: $HEALTH_STATE"
+echo "Findings:"
+for finding in "${HEALTH_FINDINGS[@]+"${HEALTH_FINDINGS[@]}"}"; do
+    echo "  - $finding"
+done
+echo ""
+
+push_metric "WatchdogTriageHealthy" "$( [ "$HEALTH_STATE" = "healthy" ] && echo 1 || echo 0 )" "Count"
+push_metric "WatchdogTriageFindingCount" "${#HEALTH_FINDINGS[@]}" "Count"
+
+# Post triage Thought CR with findings
+FINDINGS_TEXT=""
+for finding in "${HEALTH_FINDINGS[@]+"${HEALTH_FINDINGS[@]}"}"; do
+    FINDINGS_TEXT="${FINDINGS_TEXT}    - ${finding}
+"
+done
+
+if [ "$HEALTH_STATE" = "healthy" ]; then
+    post_triage_thought \
+        "WATCHDOG TRIAGE [healthy]: All checks passed.
+Active jobs: $ACTIVE_JOBS / $CB_LIMIT | Stuck: 0 | Recent thoughts: $RECENT_THOUGHTS
+Tier 1 watchdog: $WATCHDOG_STATE
+No action required." \
+        "insight"
+    echo "[$(date -u +%H:%M:%S)] Triage complete: HEALTHY"
+elif [ "$HEALTH_STATE" = "degraded" ]; then
+    post_triage_thought \
+        "WATCHDOG TRIAGE [degraded]: System degraded — attention recommended.
+Findings:
+${FINDINGS_TEXT}
+Active jobs: $ACTIVE_JOBS / $CB_LIMIT | Recent thoughts: $RECENT_THOUGHTS
+Tier 1 watchdog: $WATCHDOG_STATE
+Recommended action: Investigate the flagged issues. If stuck jobs persist, consider killing them manually." \
+        "blocker"
+    echo "[$(date -u +%H:%M:%S)] Triage complete: DEGRADED — posted blocker thought"
+    exit 0
+elif [ "$HEALTH_STATE" = "critical" ]; then
+    post_triage_thought \
+        "WATCHDOG TRIAGE [critical]: System in critical state — immediate action required.
+Findings:
+${FINDINGS_TEXT}
+Active jobs: $ACTIVE_JOBS / $CB_LIMIT | Recent thoughts: $RECENT_THOUGHTS
+Tier 1 watchdog: $WATCHDOG_STATE
+Kill switch: $KS_ENABLED
+Action: Human intervention may be required. Check god issue #62 for status." \
+        "blocker"
+    push_metric "WatchdogTriageCritical" 1 "Count"
+    echo "[$(date -u +%H:%M:%S)] Triage complete: CRITICAL — posted blocker thought"
+    exit 1
+fi
+
+echo "[$(date -u +%H:%M:%S)] Watchdog triage completed successfully"
+exit 0

--- a/manifests/system/watchdog-triage-cronjob.yaml
+++ b/manifests/system/watchdog-triage-cronjob.yaml
@@ -1,0 +1,99 @@
+# Tier 2 Watchdog Triage CronJob (issue #1844)
+#
+# Runs every 5 minutes to perform AI-assisted health assessment of the civilization.
+# Unlike the Tier 1 mechanical heartbeat (inside coordinator.sh), this is an
+# ephemeral Job with a fresh perspective that checks:
+#   1. Agent activity (recent Thought CRs)
+#   2. Active/stuck job counts
+#   3. Coordinator state consistency
+#   4. Unresolved escalations
+#   5. Kill switch status
+#
+# Health states: HEALTHY → emit metric | DEGRADED → post blocker Thought CR
+#                CRITICAL → post blocker + exit 1 (alerts CloudWatch alarm)
+#
+# Part of the three-tier watchdog chain:
+#   Tier 1: Mechanical heartbeat (coordinator.sh watchdog_check, every ~60s)
+#   Tier 2: This CronJob (every 5 min) — broader context, more checks
+#   Tier 3: God-delegate (every 20 min) — full intelligence, vision alignment
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: watchdog-triage
+  namespace: agentex
+  labels:
+    app: agentex-watchdog
+    agentex/component: watchdog-triage
+spec:
+  schedule: "*/5 * * * *"  # Every 5 minutes
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5   # Keep more failed history for debugging
+  concurrencyPolicy: Forbid   # Don't run concurrent triage jobs
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 300   # Cleanup triage job after 5 minutes
+      backoffLimit: 1                # Only retry once on failure
+      activeDeadlineSeconds: 240     # Kill triage if it takes > 4 minutes
+      template:
+        metadata:
+          labels:
+            app: agentex-watchdog
+            agentex/component: watchdog-triage
+        spec:
+          serviceAccountName: agentex-agent-sa
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: watchdog-triage
+            image: 569190534191.dkr.ecr.us-west-2.amazonaws.com/agentex/runner:latest
+            imagePullPolicy: Always
+            command: ["/bin/bash", "/usr/local/bin/watchdog-triage.sh"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+            env:
+              - name: NAMESPACE
+                value: agentex
+              - name: BEDROCK_REGION
+                valueFrom:
+                  configMapKeyRef:
+                    name: agentex-constitution
+                    key: awsRegion
+              - name: REPO
+                valueFrom:
+                  configMapKeyRef:
+                    name: agentex-constitution
+                    key: githubRepo
+              - name: S3_BUCKET
+                valueFrom:
+                  configMapKeyRef:
+                    name: agentex-constitution
+                    key: s3Bucket
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: agentex-github-token
+                    key: token
+            resources:
+              requests:
+                memory: "128Mi"
+                cpu: "100m"
+              limits:
+                memory: "256Mi"
+                cpu: "500m"
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+          volumes:
+            - name: workspace
+              emptyDir:
+                sizeLimit: 256Mi


### PR DESCRIPTION
## Summary

Implements the three-tier watchdog chain from issue #1844 to detect crash-loops, stuck agents, and proliferation events automatically.

Closes #1844

## Changes

### Tier 1: Mechanical Heartbeat (coordinator.sh)

- New `watchdog_check()` function, runs every ~60s in the coordinator main loop
- Detects **stuck jobs** (running > 30 min) → posts `blocker` Thought CR so agents can see it
- Detects **spawn proliferation** (> 5 jobs in 2 min) → activates `agentex-killswitch` ConfigMap automatically — no human needed
- Monitors coordinator **heartbeat staleness** — if coordinator itself appears stuck, that's flagged too
- Writes health state to `coordinator-state.watchdogState`: `"healthy"`, `"degraded:<reason>"`, or `"critical:<reason>"`
- Writes `coordinator-state.watchdogLastCheck` timestamp for observability

State initialized by `ensure_state_fields_initialized()`:
```bash
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.watchdogState}'
kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.watchdogLastCheck}'
```

### Tier 2: AI Triage CronJob

- New `images/runner/watchdog-triage.sh` — packaged in runner image
- New `manifests/system/watchdog-triage-cronjob.yaml` — runs every 5 minutes
- 5 health checks with broader context than Tier 1:
  1. Agent activity (recent Thought CRs in last 5 min)
  2. Active/stuck job counts
  3. Coordinator state consistency (heartbeat age, Tier 1 watchdog state, spawn slot drift)
  4. Unresolved escalations count
  5. Kill switch status
- `HEALTHY` → emits CloudWatch metrics + posts `insight` Thought CR
- `DEGRADED` → posts `blocker` Thought CR with diagnosis
- `CRITICAL` → posts `blocker` Thought CR + exits 1 (CloudWatch can alarm on failed CronJob runs)

### Dockerfile

- Added `watchdog-triage.sh` to runner image (`COPY` + `chmod +x`)
- Bumped image version comment to r15

### Docs

- Updated `docs/coordinator.md` with Watchdog Chain section documenting all three tiers

## Success Criteria (from issue #1844)

- [x] **Crash-looping agents detected within 2 minutes** — Tier 1 proliferation check runs every ~60s; Tier 2 CronJob every 5 min
- [x] **Stuck agents nudged or restarted within 5 minutes** — Tier 2 CronJob posts blocker Thought CR with stuck job names
- [x] **Proliferation triggers kill switch within 1 minute** — Tier 1 activates `agentex-killswitch` automatically when > 5 spawns in 2 min
- [x] **System health visible** — `coordinator-state.watchdogState` readable at all times; Thought CRs posted on issues
- [ ] Coordinator restart graceful (SQLite state) — out of scope here, requires Go rewrite (#1825)

## Deployment

The CronJob requires the updated runner image (r15) to run `watchdog-triage.sh`.

Apply the CronJob:
```bash
kubectl apply -f manifests/system/watchdog-triage-cronjob.yaml
```

The Tier 1 watchdog activates automatically on the next coordinator restart (it's in the main loop).

## Architecture Note

Tier 3 (god-delegate, every 20 min) already exists. It reads Tier 1+2 findings via Thought CRs and `watchdogState`, applies full intelligence, and escalates to human via GitHub issue #62. No changes needed to god-delegate for this PR.