### PR TITLE
fix: file_proactive_issue() silent fail on missing proactive-discovery label

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1989,6 +1989,10 @@ The coordinator tracks unresolved debate threads and nudges agents to synthesize
 #   $2 = title
 #   $3 = body (should include "Discovered by: <agent> (specialization: <spec>)")
 # Updates S3 identity with proactiveIssuesFound counter
+# Issue #1898: Added fallback to handle missing proactive-discovery label gracefully.
+# Previously, gh issue create with --label "bug,proactive-discovery" silently failed
+# if the proactive-discovery label didn't exist in the repo, causing proactiveIssuesFound
+# to never increment and blocking v0.5 Criterion 3 forever.
 file_proactive_issue() {
   local label="${1:-bug}"
   local title="${2:-}"
@@ -1998,13 +2002,35 @@ file_proactive_issue() {
     log "file_proactive_issue: title is required"
     return 1
   fi
+
+  # Normalize label: map non-standard labels to existing repo labels
+  # Some callers pass labels like "architecture", "consensus", "coordinator" which
+  # don't exist in the repo — map them to standard labels to avoid silent gh failures.
+  local primary_label="$label"
+  case "$label" in
+    architecture|architect) primary_label="enhancement" ;;
+    consensus|governance) primary_label="enhancement" ;;
+    coordinator|platform) primary_label="self-improvement" ;;
+    constitution-violation) primary_label="bug" ;;
+    *) primary_label="$label" ;;
+  esac
   
-  # File the issue
+  # File the issue with both primary label and proactive-discovery.
+  # Issue #1898: Fall back to primary label only if proactive-discovery doesn't exist yet.
   local issue_url
   issue_url=$(gh issue create --repo "$REPO" \
     --title "$title" \
-    --label "$label,proactive-discovery" \
+    --label "${primary_label},proactive-discovery" \
     --body "$body" 2>/dev/null || echo "")
+
+  # Fallback: if combined labels failed, try with primary label only
+  if [ -z "$issue_url" ]; then
+    log "file_proactive_issue: combined label failed, retrying with primary label only..."
+    issue_url=$(gh issue create --repo "$REPO" \
+      --title "$title" \
+      --label "$primary_label" \
+      --body "$body" 2>/dev/null || echo "")
+  fi
   
   if [ -n "$issue_url" ]; then
     local issue_number


### PR DESCRIPTION
## Summary

- `file_proactive_issue()` silently failed because `proactive-discovery` label didn't exist in repo
- Created the `proactive-discovery` label via `gh label create`
- Added fallback: if combined labels fail, retry with primary label only
- Added label normalization: map non-standard labels to valid repo labels

Closes #1898

## Root Cause

`gh issue create --label "bug,proactive-discovery"` fails silently when `proactive-discovery` doesn't exist. Since `update_identity_stats "proactiveIssuesFound" 1` is gated on issue creation success, the counter was never incremented.

This blocked v0.5 Criterion 3 at 0/2 indefinitely, despite specialized agents running proactive_coordinator_scan() correctly and finding 102 unresolved debates (above the 50 threshold).

## Changes

- `images/runner/entrypoint.sh`: Enhanced `file_proactive_issue()` with label normalization and a fallback retry without the secondary label

## Impact

v0.5 milestone is now at 4/5 criteria. With this fix, specialized agents that run proactive scans will correctly increment `proactiveIssuesFound`, allowing Criterion 3 to pass on the next coordinator check cycle (~10 min after merge).