### PR TITLE
fix: make file_proactive_issue() non-fatal and add deduplication (issue #1901)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1989,6 +1989,9 @@ The coordinator tracks unresolved debate threads and nudges agents to synthesize
 #   $2 = title
 #   $3 = body (should include "Discovered by: <agent> (specialization: <spec>)")
 # Updates S3 identity with proactiveIssuesFound counter
+# NOTE (issue #1901): This function ALWAYS returns 0. Filing failure is non-fatal.
+# With set -euo pipefail, returning 1 would crash the agent. Proactive issue filing
+# is best-effort — if it fails (rate limit, duplicate, etc.), the agent continues normally.
 file_proactive_issue() {
   local label="${1:-bug}"
   local title="${2:-}"
@@ -1996,7 +1999,18 @@ file_proactive_issue() {
   
   if [ -z "$title" ]; then
     log "file_proactive_issue: title is required"
-    return 1
+    return 0  # Issue #1901: return 0 (non-fatal), not 1
+  fi
+
+  # Issue #1901: Check for existing open issues with same title before filing
+  # Prevents duplicate filing when multiple specialized agents discover same anomaly simultaneously
+  local existing_issue
+  existing_issue=$(gh issue list --repo "$REPO" --state open \
+    --search "$(echo "$title" | cut -c1-50)" \
+    --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+  if [ "${existing_issue:-0}" -gt 0 ]; then
+    log "file_proactive_issue: similar open issue already exists — skipping duplicate filing"
+    return 0
   fi
   
   # File the issue
@@ -2019,12 +2033,12 @@ file_proactive_issue() {
     
     # Push metric
     push_metric "ProactiveIssueDiscovered" 1
-    
-    return 0
   else
-    log "WARNING: Failed to file proactive issue"
-    return 1
+    # Issue #1901: Non-fatal — log warning but continue. Do NOT return 1.
+    # set -euo pipefail would otherwise crash the agent on filing failure.
+    log "WARNING: Failed to file proactive issue (rate limit or duplicate) — continuing"
   fi
+  return 0  # Issue #1901: always return 0, filing failure is non-fatal
 }
 
 # request_coordinator_task() - Claim an unassigned issue from the coordinator queue


### PR DESCRIPTION
## Summary

`file_proactive_issue()` was crashing workers on startup by returning 1 when GitHub issue creation failed. With `set -euo pipefail` in entrypoint.sh, this caused immediate agent termination.

## Root Cause

Multiple specialized workers discover the same anomaly (e.g., >50 unresolved debates) simultaneously. The first files the issue successfully. All subsequent workers fail with a rate limit or duplicate error, causing `gh issue create` to return non-zero, `file_proactive_issue()` to return 1, and the entire agent to exit with code 1.

**Observed**: 5+ workers (worker-1773186742, -1773186709, -1773186740, -1773186782, -1773186846) crashed simultaneously at startup on 2026-03-10T23:54.

## Changes

- `file_proactive_issue()` now always returns 0 — filing failure is non-fatal
- Added deduplication check: searches for existing open issue with same title before filing
- Changed the empty-title guard to return 0 instead of 1 (consistent behavior)
- Improved error log message: "rate limit or duplicate" instead of generic "Failed"

## Impact

Workers with `platform-specialist` specialization can now continue past the proactive scan even when issue filing fails. This restores specialized worker capacity and prevents cascade failures.

Closes #1901