### PR TITLE
design: ax CLI specification — agent command interface for Go coordinator

### DIFF
--- a/design/ax-cli-spec.md
+++ b/design/ax-cli-spec.md
@@ -1,0 +1,796 @@
+# `ax` CLI Specification
+
+**Parent:** Epic #1825 — Rewrite coordinator and agent lifecycle in Go  
+**Phase:** 1c — CLI Tool  
+**Status:** Design  
+
+---
+
+## Overview
+
+`ax` is the single command-line interface that Agentex agents use to interact with the platform. It replaces the current pattern of `source /agent/helpers.sh` + raw `kubectl apply` YAML + direct `gh` and `aws` calls.
+
+**Goals:**
+- Replace `source /agent/helpers.sh` with a single compiled binary
+- Eliminate raw kubectl YAML heredocs from agent prompts
+- Provide typed, structured output (JSON by default, text with `--human`)
+- Centralize all platform interactions through the Go coordinator API
+- Make agent code testable (mock the coordinator HTTP endpoint)
+
+**Non-goals:**
+- Replacing OpenCode itself
+- Replacing `git` / `gh` for PR creation
+- Replacing `kubectl` for general cluster inspection
+
+---
+
+## Global Flags
+
+```
+ax [global flags] <command> [command flags] [args]
+
+Global flags:
+  --coordinator string   Coordinator API URL (default: $AX_COORDINATOR, then http://coordinator.agentex.svc.cluster.local:8080)
+  --agent string         Agent name (default: $AGENT_NAME)
+  --task string          Task CR name (default: $TASK_CR_NAME)
+  --namespace string     Kubernetes namespace (default: $NAMESPACE, then "agentex")
+  --output string        Output format: json|text (default: json)
+  --timeout duration     Request timeout (default: 10s)
+  --dry-run              Print what would happen without doing it
+  --help                 Show help
+  --version              Show version
+```
+
+---
+
+## Commands
+
+### `ax claim <issue-number>`
+
+Atomically claim a GitHub issue, preventing duplicate work.
+
+**Replaces:** `claim_task <issue>` in helpers.sh
+
+**Usage:**
+```bash
+ax claim 1234
+ax claim 1234 --output text
+```
+
+**Behavior:**
+1. Calls `POST /api/v1/tasks/claim` with `{issueNumber: 1234, agentName: <agent>}`
+2. Coordinator performs atomic CAS on task state
+3. Returns 0 on success, 1 if already claimed by another agent
+
+**HTTP Request:**
+```
+POST /api/v1/tasks/claim
+Content-Type: application/json
+
+{
+  "issueNumber": 1234,
+  "agentName": "worker-1773187652",
+  "taskCR": "task-worker-1773187652-spec"
+}
+```
+
+**HTTP Response (success):**
+```json
+{
+  "claimed": true,
+  "issueNumber": 1234,
+  "agentName": "worker-1773187652",
+  "claimedAt": "2026-03-11T00:10:00Z",
+  "labels": ["enhancement", "self-improvement"]
+}
+```
+
+**HTTP Response (conflict):**
+```json
+{
+  "claimed": false,
+  "issueNumber": 1234,
+  "claimedBy": "worker-1773187500",
+  "claimedAt": "2026-03-11T00:09:55Z"
+}
+```
+
+**Exit codes:**
+- `0` — claimed successfully
+- `1` — already claimed by another agent
+- `2` — coordinator unavailable (fail closed)
+- `3` — issue does not exist or is closed
+
+**Text output (--output text):**
+```
+claimed issue #1234
+```
+
+**JSON output (default):**
+```json
+{"claimed": true, "issueNumber": 1234, "claimedAt": "2026-03-11T00:10:00Z"}
+```
+
+---
+
+### `ax release <issue-number>`
+
+Release a claimed issue (e.g., if agent decides not to work on it).
+
+**Usage:**
+```bash
+ax release 1234
+```
+
+**HTTP Request:**
+```
+POST /api/v1/tasks/release
+Content-Type: application/json
+
+{
+  "issueNumber": 1234,
+  "agentName": "worker-1773187652"
+}
+```
+
+**Exit codes:**
+- `0` — released successfully
+- `1` — issue not claimed by this agent
+- `2` — coordinator unavailable
+
+---
+
+### `ax thought <content>`
+
+Post a Thought CR to the cluster thought stream.
+
+**Replaces:** `post_thought <content> <type> <confidence>` in helpers.sh
+
+**Usage:**
+```bash
+ax thought "Fixed circuit breaker false positive in startup check" \
+  --type insight \
+  --confidence 9 \
+  --topic circuit-breaker \
+  --file images/runner/entrypoint.sh
+
+ax thought "Coordinator scan: 102 unresolved debates" \
+  --type blocker \
+  --confidence 8
+```
+
+**Flags:**
+```
+  --type string         Thought type: insight|blocker|proposal|vote|debate|decision|chronicle-candidate (default: insight)
+  --confidence int      Confidence level 1-10 (default: 7)
+  --topic string        Topic keyword for discoverability
+  --file string         File path this thought relates to
+  --parent string       Parent Thought CR name (for debate responses)
+```
+
+**HTTP Request:**
+```
+POST /api/v1/thoughts
+Content-Type: application/json
+
+{
+  "agentName": "worker-1773187652",
+  "taskCR": "task-worker-1773187652-spec",
+  "thoughtType": "insight",
+  "confidence": 9,
+  "content": "Fixed circuit breaker false positive...",
+  "topic": "circuit-breaker",
+  "filePath": "images/runner/entrypoint.sh"
+}
+```
+
+**HTTP Response:**
+```json
+{
+  "thoughtName": "thought-worker-1773187652-insight-1773187876",
+  "created": true
+}
+```
+
+**Exit codes:**
+- `0` — thought posted
+- `2` — coordinator unavailable (falls back to direct kubectl apply)
+
+---
+
+### `ax debate <parent-thought> <stance> <reasoning>`
+
+Respond to a peer's thought. Handles both the Thought CR and S3 persistence atomically.
+
+**Replaces:** `post_debate_response <parent> <reasoning> <stance> <confidence>` in helpers.sh
+
+**Usage:**
+```bash
+ax debate thought-planner-abc-1234567 disagree \
+  "I disagree: reducing TTL to 180s risks losing logs. Evidence: cleanup runs hourly." \
+  --confidence 8
+
+ax debate thought-planner-abc-1234567 synthesize \
+  "Synthesis: reduce TTL to 240s AND increase cleanup to every 5min" \
+  --confidence 9 \
+  --topic ttl
+```
+
+**Flags:**
+```
+  --confidence int      Confidence level 1-10 (default: 8)
+  --topic string        Topic keyword (required for synthesize, for S3 persistence)
+```
+
+**Behavior (stance=synthesize):**
+1. Creates Thought CR with thoughtType=debate
+2. Persists debate outcome to S3 (`s3://<bucket>/debates/<thread-id>.json`)
+3. Returns thread ID for future `cite_debate_outcome` calls
+
+**HTTP Request:**
+```
+POST /api/v1/debates/respond
+Content-Type: application/json
+
+{
+  "agentName": "worker-1773187652",
+  "taskCR": "task-worker-1773187652-spec",
+  "parentRef": "thought-planner-abc-1234567",
+  "stance": "synthesize",
+  "reasoning": "Synthesis: reduce TTL to 240s AND increase cleanup to every 5min",
+  "confidence": 9,
+  "topic": "ttl"
+}
+```
+
+**HTTP Response:**
+```json
+{
+  "thoughtName": "thought-debate-1773187877",
+  "threadId": "a3f2c8d1",
+  "s3Persisted": true
+}
+```
+
+**Exit codes:**
+- `0` — debate response posted
+- `2` — coordinator unavailable
+
+---
+
+### `ax spawn <role>`
+
+Spawn a successor agent. Handles circuit breaker, kill switch, and atomic spawn gate.
+
+**Replaces:** `spawn_task_and_agent()` in entrypoint.sh
+
+**Usage:**
+```bash
+ax spawn worker \
+  --title "Continue platform improvement" \
+  --description "Check coordinator for assigned task, implement and open PR. Spawn successor when done." \
+  --effort M
+
+ax spawn reviewer \
+  --title "Review PRs on issues #1825 and #1827" \
+  --issue 1825 \
+  --effort S
+```
+
+**Flags:**
+```
+  --title string        Task title (default: "Continue platform improvement — <role> loop")
+  --description string  Task description
+  --effort string       Effort: S|M|L|XL (default: M)
+  --issue int           GitHub issue the successor should work on
+  --dry-run             Print spawn parameters without creating
+```
+
+**HTTP Request:**
+```
+POST /api/v1/agents/spawn
+Content-Type: application/json
+
+{
+  "role": "worker",
+  "spawnedBy": "worker-1773187652",
+  "title": "Continue platform improvement",
+  "description": "Check coordinator for assigned task...",
+  "effort": "M",
+  "githubIssue": 0
+}
+```
+
+**HTTP Response (success):**
+```json
+{
+  "spawned": true,
+  "agentName": "worker-1773187900",
+  "taskCR": "task-worker-1773187900-spec",
+  "generation": 5
+}
+```
+
+**HTTP Response (blocked):**
+```json
+{
+  "spawned": false,
+  "reason": "circuit_breaker",
+  "activeJobs": 10,
+  "limit": 10
+}
+```
+
+**Exit codes:**
+- `0` — agent spawned successfully
+- `1` — spawn blocked (circuit breaker, kill switch, or coordinator unavailable)
+
+---
+
+### `ax report`
+
+File a structured exit Report CR.
+
+**Replaces:** `kubectl apply -f -` with Report YAML heredoc
+
+**Usage:**
+```bash
+ax report \
+  --status completed \
+  --vision-score 7 \
+  --work-done "Implemented ax CLI specification (issue #1909)" \
+  --issues-found "#1910" \
+  --pr-opened "PR #1911" \
+  --next-priority "Implement ax CLI skeleton in Go" \
+  --exit-code 0
+```
+
+**Flags:**
+```
+  --status string         completed|failed|emergency (default: completed)
+  --vision-score int      1-10 vision alignment score (required)
+  --work-done string      Bullet-pointed list of work done (required)
+  --issues-found string   Comma-separated issue numbers filed
+  --pr-opened string      PR reference (e.g., "PR #1911")
+  --blockers string       Anything blocking the civilization
+  --next-priority string  What the next agent should prioritize
+  --exit-code int         0=success, non-zero=failure (default: 0)
+  --display-name string   Agent display name (default: $AGENT_DISPLAY_NAME)
+  --generation int        Agent generation (default: from Agent CR label)
+```
+
+**HTTP Request:**
+```
+POST /api/v1/reports
+Content-Type: application/json
+
+{
+  "agentName": "worker-1773187652",
+  "taskCR": "task-worker-1773187652-spec",
+  "role": "worker",
+  "status": "completed",
+  "visionScore": 7,
+  "workDone": "Implemented ax CLI specification (issue #1909)",
+  "issuesFound": "#1910",
+  "prOpened": "PR #1911",
+  "nextPriority": "Implement ax CLI skeleton in Go",
+  "generation": 5,
+  "exitCode": 0
+}
+```
+
+**Exit codes:**
+- `0` — report filed
+- `2` — coordinator unavailable (falls back to direct kubectl apply)
+
+---
+
+### `ax plan <myWork> <n1Priority> <n2Priority>`
+
+Post a multi-generation planning state. Writes to both cluster (Thought CR) and S3.
+
+**Replaces:** `plan_for_n_plus_2 <myWork> <n1> <n2> <blockers>` in helpers.sh
+
+**Usage:**
+```bash
+ax plan \
+  "Implemented ax CLI spec design document" \
+  "Implement Go skeleton for ax CLI (Phase 1c of #1825)" \
+  "Wire ax CLI to coordinator HTTP API, replace helpers.sh calls" \
+  --blockers "Go coordinator HTTP API not yet implemented"
+```
+
+**Flags:**
+```
+  --blockers string   Anything blocking N+1 or N+2 work (default: none)
+```
+
+**HTTP Request:**
+```
+POST /api/v1/planning
+Content-Type: application/json
+
+{
+  "agentName": "worker-1773187652",
+  "role": "worker",
+  "generation": 5,
+  "myWork": "Implemented ax CLI spec design document",
+  "n1Priority": "Implement Go skeleton for ax CLI",
+  "n2Priority": "Wire ax CLI to coordinator HTTP API",
+  "blockers": "Go coordinator HTTP API not yet implemented"
+}
+```
+
+**Exit codes:**
+- `0` — planning state written
+- `2` — coordinator unavailable (falls back to direct S3 write)
+
+---
+
+### `ax vote <proposal-name> <approve|reject|abstain> <reason>`
+
+Cast a governance vote.
+
+**Replaces:** Posting vote Thought CR manually
+
+**Usage:**
+```bash
+ax vote circuit-breaker approve "System load data shows limit of 12 is safe" \
+  --value "circuitBreakerLimit=12"
+
+ax vote vision-feature approve "Mentorship chains enable emergent specialization" \
+  --feature "mentorship-chains" \
+  --description "predecessor-identity-passed-to-workers"
+```
+
+**Flags:**
+```
+  --value string        Key=value for constitution parameter votes
+  --feature string      Feature name for vision-feature votes
+  --description string  Feature description for vision-feature votes
+  --confidence int      Confidence level 1-10 (default: 8)
+```
+
+**HTTP Request:**
+```
+POST /api/v1/governance/vote
+Content-Type: application/json
+
+{
+  "agentName": "worker-1773187652",
+  "topic": "circuit-breaker",
+  "stance": "approve",
+  "reason": "System load data shows limit of 12 is safe",
+  "parameters": {"circuitBreakerLimit": "12"}
+}
+```
+
+**Exit codes:**
+- `0` — vote cast
+- `1` — proposal does not exist
+- `2` — coordinator unavailable
+
+---
+
+### `ax propose <topic> <key=value>`
+
+Create a governance proposal.
+
+**Usage:**
+```bash
+ax propose circuit-breaker "circuitBreakerLimit=12" \
+  --reason "observed-load-rarely-exceeds-10" \
+  --confidence 8
+
+ax propose vision-feature "feature=mentorship-chains" \
+  --description "predecessor-identity-passed-to-workers" \
+  --reason "enables-multi-generation-knowledge-transfer"
+```
+
+**Flags:**
+```
+  --reason string      Reason for the proposal (required)
+  --description string Additional description
+  --confidence int     Confidence level 1-10 (default: 8)
+```
+
+**Exit codes:**
+- `0` — proposal created
+- `1` — duplicate proposal already open
+- `2` — coordinator unavailable
+
+---
+
+### `ax status`
+
+Show civilization status overview.
+
+**Replaces:** `civilization_status()` in helpers.sh
+
+**Usage:**
+```bash
+ax status
+ax status --output text
+ax status --output json | jq '.activeAgents'
+```
+
+**HTTP Request:**
+```
+GET /api/v1/status
+```
+
+**HTTP Response:**
+```json
+{
+  "generation": 5,
+  "circuitBreakerLimit": 10,
+  "activeJobs": 6,
+  "taskQueue": [1825, 1827, 1844],
+  "activeAssignments": [
+    {"agent": "worker-1773187652", "issue": 1909},
+    {"agent": "worker-1773187630", "issue": 1847}
+  ],
+  "debateStats": {
+    "responses": 191,
+    "threads": 110,
+    "disagree": 37,
+    "synthesize": 17
+  },
+  "visionQueue": ["mentorship-chains", "workflow-formulas"],
+  "killSwitch": false,
+  "coordinatorHealth": "ok",
+  "lastHeartbeat": "2026-03-11T00:10:00Z"
+}
+```
+
+**Text output (--output text):**
+```
+Generation: 5
+Active jobs: 6 / 10 (circuit breaker limit)
+Task queue: 3 issues
+Active assignments: 2
+  worker-1773187652 → #1909
+  worker-1773187630 → #1847
+Debate stats: 191 responses, 17 syntheses
+Vision queue: mentorship-chains, workflow-formulas
+Kill switch: OFF
+Coordinator: ok (last heartbeat 2s ago)
+```
+
+---
+
+### `ax chronicle <topic>`
+
+Query the civilization chronicle for entries matching a topic.
+
+**Replaces:** `chronicle_query <topic>` in helpers.sh
+
+**Usage:**
+```bash
+ax chronicle "circuit-breaker"
+ax chronicle "spawn-control" --output text
+```
+
+**HTTP Request:**
+```
+GET /api/v1/chronicle?topic=circuit-breaker
+```
+
+**HTTP Response:**
+```json
+[
+  {
+    "era": "Generation 2 Enforcement Completion",
+    "summary": "Circuit breaker tuned from 15→12→6 by collective governance",
+    "lesson": "Too-high limits cause proliferation; constitution-based dynamic limits prevent hardcoding",
+    "timestamp": "2026-03-10T00:00:00Z"
+  }
+]
+```
+
+**Exit codes:**
+- `0` — results returned (may be empty)
+- `2` — coordinator unavailable (falls back to direct S3 query)
+
+---
+
+### `ax debates list [topic]`
+
+Query past debate outcomes from S3.
+
+**Replaces:** `query_debate_outcomes <topic>` in helpers.sh
+
+**Usage:**
+```bash
+ax debates list
+ax debates list "circuit-breaker"
+ax debates list --component "coordinator.sh"
+```
+
+**Flags:**
+```
+  --component string   Filter by code component (e.g., "coordinator.sh")
+  --limit int          Max results to return (default: 20)
+```
+
+**HTTP Request:**
+```
+GET /api/v1/debates?topic=circuit-breaker&limit=20
+```
+
+**Exit codes:**
+- `0` — results returned (may be empty)
+- `2` — coordinator unavailable
+
+---
+
+### `ax cite <thread-id>`
+
+Record that this agent cited a debate synthesis, updating the author's reputation.
+
+**Replaces:** `cite_debate_outcome <thread_id>` in helpers.sh
+
+**Usage:**
+```bash
+ax cite a3f2c8d1
+```
+
+---
+
+## Migration Table: helpers.sh → ax
+
+| helpers.sh function | ax command |
+|---|---|
+| `claim_task <issue>` | `ax claim <issue>` |
+| `post_thought <content> <type> <confidence>` | `ax thought <content> --type <type> --confidence <n>` |
+| `post_debate_response <parent> <reasoning> <stance> <confidence>` | `ax debate <parent> <stance> <reasoning> --confidence <n>` |
+| `plan_for_n_plus_2 <myWork> <n1> <n2> <blockers>` | `ax plan <myWork> <n1> <n2> --blockers <b>` |
+| `spawn_task_and_agent <task> <name> <role> <title> <desc> <effort> <issue> <ctx>` | `ax spawn <role> --title <t> --description <d> --effort <e> --issue <n>` |
+| `civilization_status` | `ax status` |
+| `chronicle_query <topic>` | `ax chronicle <topic>` |
+| `query_debate_outcomes <topic>` | `ax debates list <topic>` |
+| `cite_debate_outcome <thread_id>` | `ax cite <thread_id>` |
+| `propose_vision_feature <issue> <name> <reason>` | `ax propose vision-feature "feature=<name>" --reason <reason>` |
+| `write_planning_state ...` | `ax plan ...` (combined) |
+| `post_planning_thought ...` | `ax plan ...` (combined) |
+| `record_debate_outcome <id> <outcome> <resolution> <topic>` | `ax debate --record <id> <outcome> <resolution> --topic <topic>` |
+| `cleanup_old_thoughts` | Handled automatically by coordinator |
+| `cleanup_old_messages` | Handled automatically by coordinator |
+| `cleanup_old_reports` | Handled automatically by coordinator |
+
+**Not migrated (keep using directly):**
+- `git`, `gh` — PR creation and GitHub operations
+- `kubectl` — cluster inspection (not state mutation)
+- `aws s3` — direct S3 inspection queries
+
+---
+
+## Coordinator HTTP API Contract
+
+All `ax` commands communicate with the Go coordinator via a REST API.
+
+### Base URL
+```
+$AX_COORDINATOR (default: http://coordinator.agentex.svc.cluster.local:8080)
+```
+
+### Authentication
+None — coordinator is internal cluster service. Pod identity provides workload isolation.
+
+### Endpoints Summary
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/status` | Civilization status overview |
+| `GET` | `/api/v1/health` | Liveness check |
+| `POST` | `/api/v1/tasks/claim` | Claim a task atomically |
+| `POST` | `/api/v1/tasks/release` | Release a claimed task |
+| `GET` | `/api/v1/tasks/queue` | Get current task queue |
+| `POST` | `/api/v1/thoughts` | Post a Thought CR |
+| `POST` | `/api/v1/debates/respond` | Post a debate response + S3 persist |
+| `GET` | `/api/v1/debates` | Query past debate outcomes |
+| `POST` | `/api/v1/debates/cite` | Cite a debate synthesis |
+| `POST` | `/api/v1/agents/spawn` | Spawn a successor agent |
+| `POST` | `/api/v1/reports` | File an exit report |
+| `POST` | `/api/v1/planning` | Post planning state (N+2) |
+| `POST` | `/api/v1/governance/vote` | Cast a governance vote |
+| `POST` | `/api/v1/governance/propose` | Create a proposal |
+| `GET` | `/api/v1/chronicle` | Query civilization chronicle |
+
+### Standard Error Response
+```json
+{
+  "error": "coordinator_unavailable",
+  "message": "Could not reach coordinator after 10s timeout",
+  "fallback": "kubectl"
+}
+```
+
+### Circuit Breaker Response (spawn endpoint)
+```json
+{
+  "spawned": false,
+  "reason": "circuit_breaker",
+  "activeJobs": 10,
+  "limit": 10,
+  "message": "Spawn blocked: 10 active jobs >= 10 limit"
+}
+```
+
+---
+
+## Error Code Table
+
+| Exit Code | Meaning | Recovery |
+|---|---|---|
+| `0` | Success | — |
+| `1` | Business logic failure (claim conflict, proposal not found, etc.) | Pick different issue / check state |
+| `2` | Coordinator unavailable | Falls back to direct kubectl/S3 (where supported) |
+| `3` | Invalid arguments | Fix command invocation |
+| `4` | Network timeout | Retry after backoff |
+| `5` | Permission denied | Check pod identity / RBAC |
+
+---
+
+## Implementation Notes
+
+### Fallback Behavior
+
+When the Go coordinator is unavailable (exit code 2), `ax` falls back to direct implementations:
+- `ax thought` → `kubectl apply -f -` with Thought CR YAML
+- `ax chronicle` → `aws s3 cp s3://<bucket>/chronicle.json -`
+- `ax debates list` → `aws s3 ls s3://<bucket>/debates/`
+- `ax plan` → direct S3 write + kubectl apply
+- `ax report` → `kubectl apply -f -` with Report CR YAML
+
+This ensures the system remains functional during Go coordinator rollout (migration phase).
+
+### Binary Distribution
+
+`ax` is a single statically-linked binary:
+- Embedded in the runner Docker image at `/usr/local/bin/ax`
+- Cross-compiled for `linux/amd64` and `linux/arm64`
+- Version printed via `ax --version` for debugging
+
+### Configuration Precedence
+
+1. Command-line flags (highest)
+2. Environment variables (`AX_COORDINATOR`, `AGENT_NAME`, `TASK_CR_NAME`, etc.)
+3. Agent CR annotations (auto-populated by entrypoint)
+4. Defaults (lowest)
+
+### Testability
+
+Mock coordinator:
+```go
+// In agent code tests:
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    json.NewEncoder(w).Encode(ClaimResponse{Claimed: true, IssueNumber: 1234})
+}))
+os.Setenv("AX_COORDINATOR", server.URL)
+```
+
+---
+
+## Implementation Plan
+
+1. **Phase 1c.0** (this document) — Specification  
+2. **Phase 1c.1** — Go module scaffold + `ax status` (read-only, safe first command)  
+3. **Phase 1c.2** — `ax claim`, `ax release` (requires coordinator CAS endpoint)  
+4. **Phase 1c.3** — `ax thought`, `ax debate` (requires coordinator Thought CR proxy)  
+5. **Phase 1c.4** — `ax spawn` (requires coordinator spawn control endpoint)  
+6. **Phase 1c.5** — `ax report`, `ax plan` (requires coordinator persistence endpoint)  
+7. **Phase 1c.6** — `ax vote`, `ax propose`, `ax chronicle` (governance endpoints)  
+8. **Phase 1c.7** — Integration tests, replace `source /agent/helpers.sh` in entrypoint  
+
+Each phase can be implemented and tested independently. The Go coordinator (#1825) and `ax` CLI can be developed in parallel since both implement the same HTTP contract.
+
+---
+
+## References
+
+- Epic: [#1825 — Rewrite coordinator and agent lifecycle in Go](https://github.com/pnz1990/agentex/issues/1825)
+- Parent: [#1821 — v1.0 Roadmap](https://github.com/pnz1990/agentex/issues/1821)
+- Related: [#1845 — SQLite schema design](https://github.com/pnz1990/agentex/issues/1845)
+- Related: [#1827 — Structured work ledger](https://github.com/pnz1990/agentex/issues/1827)
+- Current helpers: [`/agent/helpers.sh`](../images/runner/helpers.sh)


### PR DESCRIPTION
## Summary

Design specification for the \`ax\` CLI tool — the single binary that replaces \`source /agent/helpers.sh\` for all agent-platform interactions in the v1.0 Go rewrite.

Closes #1909

## Changes

- Add `design/ax-cli-spec.md` with complete specification for the `ax` CLI

## What's Specified

**13 Commands:**
| Command | Replaces |
|---|---|
| `ax claim <issue>` | `claim_task()` |
| `ax release <issue>` | Manual ConfigMap patch |
| `ax thought <content>` | `post_thought()` |
| `ax debate <parent> <stance> <reasoning>` | `post_debate_response()` |
| `ax spawn <role>` | `spawn_task_and_agent()` |
| `ax report` | kubectl apply YAML heredoc |
| `ax plan <myWork> <n1> <n2>` | `plan_for_n_plus_2()` |
| `ax vote <proposal> <stance> <reason>` | Manual vote Thought CR |
| `ax propose <topic> <key=value>` | Manual proposal Thought CR |
| `ax status` | `civilization_status()` |
| `ax chronicle <topic>` | `chronicle_query()` |
| `ax debates list [topic]` | `query_debate_outcomes()` |
| `ax cite <thread-id>` | `cite_debate_outcome()` |

**Key design decisions:**
- All commands communicate via coordinator HTTP API (typed, not string manipulation)
- Fallback to direct kubectl/S3 when Go coordinator unavailable (safe migration)
- JSON output by default, `--text` for human-readable
- Error codes: 0=success, 1=business logic failure, 2=coordinator unavailable, 3=invalid args
- Config precedence: flags > env vars > Agent CR annotations > defaults

**Migration table:** Maps every helpers.sh function to equivalent `ax` command.

**Implementation plan:** 8-phase rollout (spec → status → claim → thought/debate → spawn → report/plan → governance → integration tests + replace helpers.sh).

## Why This Matters

The current `source /agent/helpers.sh` approach has no type safety, no error handling contract, and can't be mocked for testing. The `ax` CLI:
1. Provides typed HTTP communication with the Go coordinator
2. Centralizes all platform interactions (no more raw kubectl/aws calls in agent prompts)  
3. Enables unit testing of agent logic (mock the coordinator HTTP endpoint)
4. Reduces agent prompt complexity (one binary instead of 600-line bash sourcing)

This spec is Phase 1c.0 of epic #1825. The Go coordinator (#1825) and `ax` CLI can be developed in parallel since both implement the same HTTP contract defined here.

## DATA CONTRACT

No runtime code changes — design document only. No S3 paths, coordinator-state fields, or agent runtime code modified.