### PR TITLE
fix: prevent agent crash when file_proactive_issue() fails (issue #1901)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1770,7 +1770,7 @@ Review the added functions and add appropriate error handling:
 - \`|| return 1\` on critical commands
 - error traps if needed
 
-This is a potential regression — the code may work now but could fail silently under error conditions."
+This is a potential regression — the code may work now but could fail silently under error conditions." || true
             return 0
           fi
         fi
@@ -1819,7 +1819,7 @@ AGENTS.md Protected Files section states:
 > - manifests/rgds/*.yaml
 
 ## Action Required
-God should review PR #$suspicious_pr to verify changes were intentional and safe."
+God should review PR #$suspicious_pr to verify changes were intentional and safe." || true
     return 0
   fi
   
@@ -1855,7 +1855,7 @@ Debates require synthesis when multiple agents disagree. When debate count excee
 ## Action Required
 1. Review unresolved debates: \`kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.unresolvedDebates}'\`
 2. Post synthesis thoughts for debates where you can bridge positions
-3. Update coordinator to prune debates older than 48h"
+3. Update coordinator to prune debates older than 48h" || true
       return 0
     fi
   fi
@@ -1915,7 +1915,7 @@ This issue was proactively filed by a domain specialist during systematic scan.
 ## Action Required
 1. Review \`cleanup_stale_assignments()\` in coordinator.sh
 2. Check coordinator logs for cleanup failures
-3. Verify coordinator heartbeat is current (check \`coordinator-state.lastHeartbeat\`)"
+3. Verify coordinator heartbeat is current (check \`coordinator-state.lastHeartbeat\`)" || true
       return 0
     fi
   fi
@@ -1945,7 +1945,7 @@ The coordinator updates \`lastHeartbeat\` every iteration (~30s). A stale heartb
 ## Action Required
 1. Check coordinator pod status: \`kubectl get pods -n agentex -l app=coordinator\`
 2. Check coordinator logs for errors
-3. If stuck, restart: \`kubectl rollout restart deployment/coordinator -n agentex\`"
+3. If stuck, restart: \`kubectl rollout restart deployment/coordinator -n agentex\`" || true
       return 0
     fi
   fi
@@ -1974,7 +1974,7 @@ The coordinator tracks unresolved debate threads and nudges agents to synthesize
 ## Action Required
 1. Spawn an agent specifically to synthesize the oldest unresolved threads
 2. Check if \`post_debate_response\` S3 writes are working (query_debate_outcomes returns data)
-3. Consider increasing synthesis frequency in agent instructions"
+3. Consider increasing synthesis frequency in agent instructions" || true
       return 0
     fi
   fi


### PR DESCRIPTION
## Summary

Workers with `platform-specialist` specialization were crashing on startup (exit code 1) because `file_proactive_issue()` returns 1 when GitHub issue creation fails (rate limit, duplicate title, missing label), and `set -euo pipefail` caused the entire agent to exit immediately.

## Root Cause

All `file_proactive_issue()` call sites in proactive scan functions lacked `|| true`, so any failure propagated through `set -e` and killed the agent before it could do its assigned work.

## Fix

Added `|| true` to all 6 `file_proactive_issue()` call sites:
- `proactive_debugger_scan()` — PR adds functions without error handling
- `proactive_architecture_scan()` — protected files merged without god-approved
- `proactive_consensus_scan()` — debate backlog
- `proactive_coordinator_scan()` — stale assignments, heartbeat staleness, debate backlog

The function already has its own error handling (`log "WARNING: Failed to file proactive issue"`). The `|| true` simply prevents the error from propagating to the caller under `set -e`.

## Impact

This fix unblocks:
- v0.5 Criterion 3 (proactiveIssuesFound > 0 for 2+ agents) — previously stuck at 0/2 because agents crashed before the counter could be incremented
- General agent stability — proactive scan failures no longer kill workers

Closes #1901