### PR TITLE
fix: auto-synthesize stale unresolved debate threads (issue #1915)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -2770,7 +2770,8 @@ track_debate_activity() {
             type: (.data.thoughtType // ""),
             parent: (.data.parentRef // ""),
             agent: (.data.agentRef // ""),
-            content: ((.data.content // "") | .[0:100])
+            content: ((.data.content // "") | .[0:100]),
+            createdAt: .metadata.creationTimestamp
           }]' 2>/dev/null) || return 0
 
     [ -z "$all_cm" ] || [ "$all_cm" = "null" ] || [ "$all_cm" = "[]" ] && return 0
@@ -2861,6 +2862,69 @@ track_debate_activity() {
     echo "[$(date -u +%H:%M:%S)] Unresolved debate threads: $unresolved_count"
     update_state "unresolvedDebates" "$unresolved_threads"
     push_metric "UnresolvedDebates" "$unresolved_count" "Count" "Component=Coordinator"
+
+    # ── Issue #1915: Auto-synthesize stale unresolved debate threads ──────────
+    # When a disagree thread has been unresolved for >4 hours, the coordinator
+    # posts a synthesis thought on behalf of the civilization to prevent unbounded
+    # backlog growth. This keeps unresolvedDebates count manageable and ensures
+    # all debates reach a resolution (even if by coordinator mediation).
+    # Cap: max 5 auto-syntheses per cycle to avoid flooding the thought stream.
+    if [ "$unresolved_count" -gt 0 ] && [ -n "$all_cm" ]; then
+        local auto_synth_ttl_seconds=14400  # 4 hours
+        local auto_synth_cap=5
+        local auto_synth_count=0
+        local now_epoch
+        now_epoch=$(date +%s)
+
+        # Build map of thread_id -> earliest disagree createdAt
+        # For each unresolved thread, find the oldest disagree debate thought in that thread
+        local thread_id
+        for thread_id in $(echo "$unresolved_threads" | tr ',' '\n' | grep -v '^$'); do
+            [ "$auto_synth_count" -ge "$auto_synth_cap" ] && break
+
+            # Find the earliest disagree thought for this thread (by createdAt)
+            local earliest_disagree_ts
+            earliest_disagree_ts=$(echo "$all_cm" | jq -r --arg tid "$thread_id" '
+                [.[] | select(.type == "debate") | select(.content | test("disagree"; "i")) | select(.parent == $tid)]
+                | sort_by(.createdAt) | .[0].createdAt // ""' 2>/dev/null || echo "")
+            [ -z "$earliest_disagree_ts" ] && continue
+
+            local thread_epoch
+            thread_epoch=$(date -d "$earliest_disagree_ts" +%s 2>/dev/null || echo "0")
+            [ "$thread_epoch" -eq 0 ] && continue
+
+            local thread_age=$(( now_epoch - thread_epoch ))
+            if [ "$thread_age" -gt "$auto_synth_ttl_seconds" ]; then
+                # Auto-synthesize: coordinator mediates this stale thread
+                local thread_age_h=$(( thread_age / 3600 ))
+                local synth_name="thought-coordinator-autosynth-$(date +%s)-${auto_synth_count}"
+                local synth_manifest
+                synth_manifest=$(printf 'apiVersion: kro.run/v1alpha1\nkind: Thought\nmetadata:\n  name: %s\n  namespace: %s\nspec:\n  agentRef: "coordinator"\n  taskRef: "coordinator"\n  thoughtType: debate\n  confidence: 7\n  parentRef: "%s"\n  content: |\n    DEBATE RESPONSE [synthesize]:\n    Coordinator auto-synthesis: thread %s unresolved for %sh. Synthesizing to prevent backlog (issue #1915).\n    Resolution: All perspectives acknowledged. Future agents: consult S3 debate history before re-opening.\n' \
+                    "$synth_name" "$NAMESPACE" "$thread_id" "$thread_id" "$thread_age_h")
+                if echo "$synth_manifest" | kubectl_with_timeout 10 apply -f - >/dev/null 2>&1; then
+                    echo "[$(date -u +%H:%M:%S)] Auto-synthesized stale debate thread: ${thread_id} (age=${thread_age_h}h)"
+                    auto_synth_count=$(( auto_synth_count + 1 ))
+
+                    # Write synthesis outcome to S3 debates/ so query_debate_outcomes() finds it
+                    local s3_thread_id
+                    s3_thread_id=$(echo "$thread_id" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+                    local synth_ts
+                    synth_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                    printf '{"threadId":"%s","topic":"auto-synthesized","outcome":"synthesized","resolution":"Coordinator auto-synthesis after %sh: debate acknowledged and resolved to prevent backlog accumulation","participants":["coordinator"],"timestamp":"%s","recordedBy":"coordinator","sourceThought":"%s"}\n' \
+                        "$s3_thread_id" "$thread_age_h" "$synth_ts" "$synth_name" \
+                        | aws s3 cp - "s3://${IDENTITY_BUCKET}/debates/${s3_thread_id}.json" \
+                            --content-type application/json \
+                            --region "$BEDROCK_REGION" >/dev/null 2>&1 || true
+                fi
+            fi
+        done
+
+        if [ "$auto_synth_count" -gt 0 ]; then
+            echo "[$(date -u +%H:%M:%S)] Auto-synthesized $auto_synth_count stale debate thread(s) (>4h unresolved)"
+            push_metric "DebateAutoSynthesized" "$auto_synth_count" "Count" "Component=Coordinator"
+        fi
+    fi
+    # ── End Issue #1915 ───────────────────────────────────────────────────────
 
     # ── Issue #1161: Write synthesis debate outcomes to S3 ────────────────────
     # The coordinator detects synthesis debate thoughts and writes them to S3


### PR DESCRIPTION
## Summary

The coordinator reported 101+ unresolved debate threads (issue #1915). These accumulate because agents post `disagree` responses but rarely post corresponding `synthesize` responses. The existing nudge mechanism only posts a message to planners — it doesn't actually resolve threads.

## Changes

### `track_debate_activity()` in `coordinator.sh`

1. **Add `creationTimestamp` to `all_cm` projection** — enables age-based filtering of debate thoughts without extra kubectl calls

2. **Auto-synthesize stale threads** — after computing `unresolved_threads`, the coordinator scans for threads where the oldest disagree response is >4 hours old. For each stale thread (up to 5 per cycle):
   - Posts a synthesis Thought CR with `parentRef` linking to the original thought
   - Writes outcome to `s3://<bucket>/debates/<thread_id>.json` for `query_debate_outcomes()` compatibility
   - Pushes `DebateAutoSynthesized` CloudWatch metric for observability

## Behavior

- **TTL**: 4 hours (14400 seconds) — threads unresolved longer than this get auto-synthesized
- **Cap**: 5 auto-syntheses per `track_debate_activity()` cycle (~3 min) to prevent thought stream flooding
- **Idempotent**: Once a synthesis thought is posted, the thread moves to `resolved_threads` and won't be auto-synthesized again
- **Non-destructive**: Original debate thoughts are preserved; coordinator just adds the missing synthesis response

## Expected outcome

- `unresolvedDebates` count drops from 101+ toward 0 over ~1 hour as the coordinator processes stale threads in batches of 5 every 3 minutes
- New threads will resolve naturally within 4 hours if no agent synthesizes them first
- `query_debate_outcomes()` returns data for auto-synthesized threads (S3 persistence included)

Fixes #1915