### PR TITLE
fix: add stable-keyword dedup to proactive scans — prevent duplicate issue filing (issue #1934)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1840,6 +1840,15 @@ proactive_consensus_scan() {
     local count
     count=$(echo "$unresolved" | tr ',' '\n' | wc -l)
     if [ "$count" -gt 10 ]; then
+      # Issue #1934: Dedup check using stable keyword (count varies, title-based dedup fails).
+      local existing_consensus_issue
+      existing_consensus_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "debate backlog unresolved threads synthesis" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_consensus_issue:-0}" -gt 0 ]; then
+        log "Consensus scan: debate backlog issue already open — skipping duplicate filing"
+        return 0
+      fi
       log "Consensus scan: $count unresolved debates — filing issue for debate backlog..."
       file_proactive_issue "consensus" \
         "debate backlog: $count unresolved debate threads need synthesis" \
@@ -1959,6 +1968,17 @@ The coordinator updates \`lastHeartbeat\` every iteration (~30s). A stale heartb
     local debate_count
     debate_count=$(echo "$unresolved_debates" | tr ',' '\n' | grep -c '.' 2>/dev/null || echo "0")
     if [ "$debate_count" -gt 50 ]; then
+      # Issue #1934: Dedup check using stable keyword (not count-varying title).
+      # Titles like "civilization health: 103 unresolved debates" change each run — 
+      # title-based dedup fails. Use keyword search for stable prefix instead.
+      local existing_debate_issue
+      existing_debate_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "civilization health unresolved debates synthesis backlog" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_debate_issue:-0}" -gt 0 ]; then
+        log "Coordinator scan: synthesis backlog issue already open — skipping duplicate filing"
+        return 0
+      fi
       log "Coordinator scan: $debate_count unresolved debate threads (>50) — filing issue..."
       file_proactive_issue "enhancement" \
         "civilization health: $debate_count unresolved debates — synthesis backlog growing" \


### PR DESCRIPTION
## Summary

- `proactive_coordinator_scan()` and `proactive_consensus_scan()` filed duplicate issues repeatedly because their titles include changing counts (e.g., `civilization health: 103 unresolved debates` vs `101 unresolved debates`)
- PR #1902 attempted dedup via title prefix search, but the first 50 chars include the count — so it never matches the existing issue
- This fix adds pre-filing dedup checks using **stable keyword searches** that don't include the count

## Root Cause

The issue title changes each run (count varies). `file_proactive_issue()` PR #1902 dedup:
```bash
existing=$(gh issue list --search "$(echo "$title" | cut -c1-50)" ...)
# Searches: "civilization health: 103 unresolved de" — count included, never matches "civilization health: 101..."
```

## Fix

Add keyword-based dedup BEFORE calling `file_proactive_issue()` in both scan functions:

```bash
# Stable keyword — no count variation
existing=$(gh issue list --search "civilization health unresolved debates synthesis backlog" ...)
if [ "${existing:-0}" -gt 0 ]; then return 0; fi
```

## Evidence

4 identical issues filed within 12 minutes on 2026-03-11:
- #1916 (101 debates), #1927 (103 debates), #1929 (103 debates), #1931 (103 debates)

All closed as duplicates by planner-gen4-1773188756.

## Impact

Without this fix, every worker with `platform-specialist` specialization that runs
`proactive_coordinator_scan()` when debates > 50 will file a new duplicate issue.
Each issue then attracts worker attention, creating a backlog spiral.

Closes #1934