### PR TITLE
fix: file_proactive_issue() crashes agents under set -euo pipefail

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1989,6 +1989,9 @@ The coordinator tracks unresolved debate threads and nudges agents to synthesize
 #   $2 = title
 #   $3 = body (should include "Discovered by: <agent> (specialization: <spec>)")
 # Updates S3 identity with proactiveIssuesFound counter
+# Issue #1901: Returns 0 on deduplication (issue already exists) so callers
+#              with || true can continue gracefully. Returns 1 only on internal errors.
+# Issue #1898: Deduplication prevents duplicate issues from concurrent agents.
 file_proactive_issue() {
   local label="${1:-bug}"
   local title="${2:-}"
@@ -1997,6 +2000,17 @@ file_proactive_issue() {
   if [ -z "$title" ]; then
     log "file_proactive_issue: title is required"
     return 1
+  fi
+
+  # Deduplication check (issue #1898, #1901): search for an open issue with same title.
+  # Concurrent agents hitting the same threshold all try to file; the first succeeds,
+  # subsequent ones must skip rather than error (which would crash under set -euo pipefail).
+  local existing_count
+  existing_count=$(gh issue list --repo "$REPO" --state open \
+    --search "\"$title\"" --limit 5 --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+  if [ "${existing_count:-0}" -gt 0 ]; then
+    log "file_proactive_issue: duplicate detected — open issue with title already exists, skipping"
+    return 0
   fi
   
   # File the issue
@@ -2022,8 +2036,8 @@ file_proactive_issue() {
     
     return 0
   else
-    log "WARNING: Failed to file proactive issue"
-    return 1
+    log "WARNING: Failed to file proactive issue — continuing without crash (issue #1901)"
+    return 0
   fi
 }
 


### PR DESCRIPTION
## Summary

Under `set -euo pipefail`, `file_proactive_issue()` returns 1 on any GitHub API failure (rate limiting, label missing, network error). Because the function is called directly from `proactive_coordinator_scan()` without a `|| true` guard, the shell exits when the function returns non-zero — crashing the entire agent process.

This caused 5+ workers to crash simultaneously when `unresolvedDebates > 50`:
```
[23:53:58] Coordinator scan: 102 unresolved debate threads (>50) — filing issue...
[23:54:01] WARNING: Failed to file proactive issue
EXIT trap: cleaning up Agent CR worker-NNN (exit_code=1)
```

## Fix

Two-part defense-in-depth fix:

1. **Deduplication check** (addresses #1898): Before filing, search for an open issue with the same title. If one exists, log and return 0. Concurrent agents hitting the same threshold can now gracefully skip without race conditions.

2. **Failure mode** (addresses #1901 root cause): Change the failure path from `return 1` to `return 0` with a warning log. Proactive issue filing is best-effort — it should never crash an agent. The function now always returns 0 (success or graceful skip), and only returns 1 for the `title is required` validation error (which is a programming error, not a runtime error).

## Impact

- Eliminates simultaneous worker crashes when `unresolvedDebates > 50`
- Prevents duplicate proactive issues from concurrent agents  
- Workers with `platform-specialist`, `coordinator-specialist`, and other specializations will no longer crash on startup when anomaly thresholds are exceeded

Closes #1901
Partially addresses #1898

## Changes

- `images/runner/entrypoint.sh`: Added deduplication check + changed failure `return 1` → `return 0` in `file_proactive_issue()`