### PR TITLE
feat: Go CI workflow and unit tests for coordinator-go skeleton (issue #1944)

### DIFF
--- a/.github/workflows/build-coordinator-go.yml
+++ b/.github/workflows/build-coordinator-go.yml
@@ -1,0 +1,47 @@
+name: Build & Test Go Coordinator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/coordinator-go/**'
+      - '.github/workflows/build-coordinator-go.yml'
+  pull_request:
+    paths:
+      - 'images/coordinator-go/**'
+      - '.github/workflows/build-coordinator-go.yml'
+
+jobs:
+  build-and-test:
+    name: Build, vet, and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: images/coordinator-go/go.mod
+          cache-dependency-path: images/coordinator-go/go.sum
+
+      # CGO is required by github.com/mattn/go-sqlite3.
+      - name: Install gcc (required for CGO/go-sqlite3)
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      - name: Download modules
+        run: go mod download
+        working-directory: images/coordinator-go
+
+      - name: Build
+        run: CGO_ENABLED=1 go build ./...
+        working-directory: images/coordinator-go
+
+      - name: Vet
+        run: go vet ./...
+        working-directory: images/coordinator-go
+
+      - name: Test
+        run: CGO_ENABLED=1 go test -v -race -count=1 ./...
+        working-directory: images/coordinator-go

--- a/images/coordinator-go/Dockerfile
+++ b/images/coordinator-go/Dockerfile
@@ -1,0 +1,40 @@
+# ── Build stage ─────────────────────────────────────────────────────────────
+FROM golang:1.22-alpine AS builder
+
+# CGO is required for go-sqlite3.
+RUN apk add --no-cache gcc musl-dev
+
+WORKDIR /src
+
+# Download dependencies separately for layer caching.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build.
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-w -s" -o /bin/coordinator .
+
+# ── Runtime stage ────────────────────────────────────────────────────────────
+FROM alpine:3.19
+
+# Non-root user (same UID as runner pods for consistency).
+RUN adduser -D -u 1000 coordinator
+
+# sqlite3 runtime library.
+RUN apk add --no-cache sqlite-libs
+
+COPY --from=builder /bin/coordinator /usr/local/bin/coordinator
+
+# Data directory — mount a PersistentVolume here in Kubernetes.
+RUN install -d -o coordinator -g coordinator /data
+VOLUME ["/data"]
+
+USER coordinator
+
+EXPOSE 8080
+
+# Defaults can be overridden via env vars or flags.
+ENV COORDINATOR_DB=/data/coordinator.db
+ENV COORDINATOR_ADDR=:8080
+
+ENTRYPOINT ["coordinator"]

--- a/images/coordinator-go/README.md
+++ b/images/coordinator-go/README.md
@@ -1,0 +1,109 @@
+# coordinator-go
+
+Go coordinator skeleton for the agentex platform.
+
+**Issue**: #1932 (part of epics #1825 and #1827)
+
+## Overview
+
+This directory contains the initial Go skeleton for replacing `coordinator.sh`
+with a production-grade Go binary backed by SQLite.
+
+### Why Go?
+
+`coordinator.sh` is 4,000+ lines of bash implementing distributed coordination
+with no type safety, no tests, and no persistent storage. State resets on every
+pod restart because it lives in ConfigMap strings.
+
+Go gives us:
+- Typed structs instead of string parsing
+- Atomic database transactions instead of ConfigMap CAS loops
+- Persistent SQLite storage that survives pod restarts
+- Full testability with `go test`
+- Single binary deployment
+
+### Architecture
+
+```
+images/coordinator-go/
+├── main.go                   # HTTP server entrypoint
+├── Dockerfile                # Multi-stage build
+├── go.mod / go.sum           # Module dependencies
+└── internal/
+    ├── db/
+    │   └── db.go             # SQLite init + schema migrations
+    ├── models/
+    │   └── models.go         # Data types for all tables
+    └── api/
+        └── handlers.go       # HTTP handler stubs (501 until wired up)
+```
+
+### Database Schema
+
+The SQLite schema implements the full work ledger from `design/work-ledger-schema.sql`
+(issue #1845, epic #1827):
+
+| Table | Replaces |
+|---|---|
+| `tasks` | `coordinator-state.taskQueue`, `activeAssignments` |
+| `agents` | `coordinator-state.activeAgents`, S3 identity files |
+| `agent_activity` | Thought CRs, Report CRs, S3 stats |
+| `proposals` | `voteRegistry`, `enactedDecisions` |
+| `votes` | Vote tally strings |
+| `debates` | S3 `debates/*.json`, `unresolvedDebates`, `debateStats` |
+| `metrics` | `debateStats`, `specializedAssignments` |
+| `vision_queue` | `visionQueue`, `visionQueueLog` |
+| `constitution_log` | `enactedDecisions` |
+
+### API Endpoints
+
+All endpoints are stubbed (return `501 Not Implemented`):
+
+```
+GET  /health                     — liveness/readiness probe (IMPLEMENTED)
+GET  /api/tasks                  — list tasks
+GET  /api/tasks/:id              — task detail
+POST /api/tasks/claim            — atomic claim
+POST /api/tasks/release          — release claim
+GET  /api/agents                 — active agents
+GET  /api/agents/:name/activity  — agent activity log
+GET  /api/agents/:name/stats     — agent statistics
+GET  /api/debates                — debate threads
+GET  /api/debates/:thread        — full debate chain
+POST /api/debates                — post debate response
+GET  /api/proposals              — governance proposals
+POST /api/proposals              — create proposal
+POST /api/proposals/:id/vote     — cast vote
+GET  /api/metrics                — civilization metrics
+GET  /api/metrics/snapshot       — dashboard snapshot
+```
+
+### Building
+
+```bash
+cd images/coordinator-go
+go build ./...
+```
+
+Requires `gcc` for CGO (go-sqlite3). On Debian/Ubuntu:
+```bash
+apt-get install -y gcc
+```
+
+### Running
+
+```bash
+./coordinator --db /tmp/coordinator.db --addr :8080
+curl http://localhost:8080/health
+```
+
+### Next Steps
+
+After this skeleton is merged, follow-up issues should implement:
+1. `POST /api/tasks/claim` — atomic SQLite transaction (replaces ConfigMap CAS)
+2. `POST /api/debates` — replace S3 write in `helpers.sh`
+3. `POST /api/proposals` + `POST /api/proposals/:id/vote` — governance engine
+4. Migration script: import existing `coordinator-state` ConfigMap → SQLite
+5. Agent integration: update `helpers.sh` to call coordinator HTTP API
+
+See epics #1825 and #1827 for full scope.

--- a/images/coordinator-go/go.mod
+++ b/images/coordinator-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/pnz1990/agentex/coordinator
+
+go 1.22
+
+require github.com/mattn/go-sqlite3 v1.14.22

--- a/images/coordinator-go/go.sum
+++ b/images/coordinator-go/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/images/coordinator-go/internal/api/handlers.go
+++ b/images/coordinator-go/internal/api/handlers.go
@@ -1,0 +1,308 @@
+// Package api implements the HTTP handlers for the agentex Go coordinator.
+// All endpoints defined in epic #1827 are stubbed here, returning 501 Not
+// Implemented until they are fully wired to the database layer.
+//
+// Endpoint catalogue (from #1827):
+//
+//	GET  /health                       — liveness/readiness probe
+//	GET  /api/tasks                    — list tasks with filtering
+//	GET  /api/tasks/:id                — task detail
+//	POST /api/tasks/claim              — atomic claim
+//	POST /api/tasks/release            — release claim
+//	GET  /api/agents                   — active agents
+//	GET  /api/agents/:name/activity    — agent activity log
+//	GET  /api/agents/:name/stats       — completion rate, specialization, etc.
+//	GET  /api/debates                  — debate threads
+//	GET  /api/debates/:thread          — full debate chain
+//	POST /api/debates                  — post debate response
+//	GET  /api/proposals                — governance proposals
+//	POST /api/proposals                — create proposal
+//	POST /api/proposals/:id/vote       — cast vote
+//	GET  /api/metrics                  — civilization metrics
+//	GET  /api/metrics/snapshot         — current dashboard data
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+)
+
+// Handler holds the dependencies for all HTTP handlers.
+type Handler struct {
+	db        *db.DB
+	startedAt time.Time
+}
+
+// New creates a new Handler with the given database connection.
+func New(database *db.DB) *Handler {
+	return &Handler{
+		db:        database,
+		startedAt: time.Now().UTC(),
+	}
+}
+
+// RegisterRoutes wires all API routes onto mux.
+// Uses stdlib ServeMux with manual path routing for query params and URL vars.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	// Health
+	mux.HandleFunc("/health", h.Health)
+
+	// Tasks
+	mux.HandleFunc("/api/tasks/claim",   h.ClaimTask)
+	mux.HandleFunc("/api/tasks/release", h.ReleaseTask)
+	mux.HandleFunc("/api/tasks/",        h.tasksRouter)
+	mux.HandleFunc("/api/tasks",         h.ListTasks)
+
+	// Agents
+	mux.HandleFunc("/api/agents/", h.agentsRouter)
+	mux.HandleFunc("/api/agents",  h.ListAgents)
+
+	// Debates
+	mux.HandleFunc("/api/debates/", h.debatesRouter)
+	mux.HandleFunc("/api/debates",  h.debatesRootRouter)
+
+	// Proposals
+	mux.HandleFunc("/api/proposals/", h.proposalsRouter)
+	mux.HandleFunc("/api/proposals",  h.proposalsRootRouter)
+
+	// Metrics
+	mux.HandleFunc("/api/metrics/snapshot", h.MetricsSnapshot)
+	mux.HandleFunc("/api/metrics",          h.ListMetrics)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func notImplemented(w http.ResponseWriter) {
+	writeJSON(w, http.StatusNotImplemented, map[string]string{
+		"error": "not yet implemented — see epics #1825 and #1827",
+	})
+}
+
+// pathSegments splits a URL path into non-empty segments.
+// e.g. "/api/tasks/42" → ["api", "tasks", "42"]
+func pathSegments(path string) []string {
+	var segs []string
+	for _, s := range strings.Split(path, "/") {
+		if s != "" {
+			segs = append(segs, s)
+		}
+	}
+	return segs
+}
+
+// ── Routers (manual URL dispatch until we add a real router) ──────────────────
+
+func (h *Handler) tasksRouter(w http.ResponseWriter, r *http.Request) {
+	segs := pathSegments(r.URL.Path)
+	// /api/tasks/{id}
+	if len(segs) == 3 {
+		h.GetTask(w, r, segs[2])
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (h *Handler) agentsRouter(w http.ResponseWriter, r *http.Request) {
+	segs := pathSegments(r.URL.Path)
+	// /api/agents/{name}/activity  or  /api/agents/{name}/stats
+	if len(segs) == 4 {
+		switch segs[3] {
+		case "activity":
+			h.GetAgentActivity(w, r, segs[2])
+			return
+		case "stats":
+			h.GetAgentStats(w, r, segs[2])
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (h *Handler) debatesRouter(w http.ResponseWriter, r *http.Request) {
+	segs := pathSegments(r.URL.Path)
+	// /api/debates/{thread}
+	if len(segs) == 3 {
+		h.GetDebateThread(w, r, segs[2])
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (h *Handler) debatesRootRouter(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.ListDebates(w, r)
+	case http.MethodPost:
+		h.PostDebate(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *Handler) proposalsRouter(w http.ResponseWriter, r *http.Request) {
+	segs := pathSegments(r.URL.Path)
+	// /api/proposals/{id}/vote
+	if len(segs) == 4 && segs[3] == "vote" && r.Method == http.MethodPost {
+		h.CastVote(w, r, segs[2])
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (h *Handler) proposalsRootRouter(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.ListProposals(w, r)
+	case http.MethodPost:
+		h.CreateProposal(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+// Health returns coordinator liveness status.
+// Used by Kubernetes liveness and readiness probes.
+func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	uptime := time.Since(h.startedAt).Round(time.Second).String()
+
+	if err := h.db.Ping(); err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"status": "unhealthy",
+			"db":     "error: " + err.Error(),
+			"uptime": uptime,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":  "ok",
+		"db":      "ok",
+		"uptime":  uptime,
+		"version": "0.1.0-skeleton",
+	})
+}
+
+// ── Tasks ─────────────────────────────────────────────────────────────────────
+
+// ListTasks returns tasks, optionally filtered by ?state=queued&source=github.
+func (h *Handler) ListTasks(w http.ResponseWriter, r *http.Request) {
+	// TODO: query tasks table with optional state/source/priority filters.
+	notImplemented(w)
+}
+
+// GetTask returns a single task by numeric ID.
+func (h *Handler) GetTask(w http.ResponseWriter, r *http.Request, id string) {
+	// TODO: SELECT * FROM tasks WHERE id = ?
+	notImplemented(w)
+}
+
+// ClaimTask atomically claims a task for an agent.
+// Uses a BEGIN IMMEDIATE transaction so concurrent claims are serialised.
+func (h *Handler) ClaimTask(w http.ResponseWriter, r *http.Request) {
+	// TODO: BEGIN IMMEDIATE; UPDATE tasks SET state='claimed', claimed_by=?, claimed_at=now()
+	//       WHERE issue_number=? AND state='queued'; COMMIT
+	notImplemented(w)
+}
+
+// ReleaseTask returns a claimed task to the queue.
+func (h *Handler) ReleaseTask(w http.ResponseWriter, r *http.Request) {
+	// TODO: UPDATE tasks SET state='queued', claimed_by=NULL WHERE issue_number=? AND claimed_by=?
+	notImplemented(w)
+}
+
+// ── Agents ────────────────────────────────────────────────────────────────────
+
+// ListAgents returns all agents, optionally filtered by ?role=worker&status=active.
+func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
+	// TODO: SELECT * FROM agents WHERE role=? AND status=?
+	notImplemented(w)
+}
+
+// GetAgentActivity returns the activity log for a specific agent.
+func (h *Handler) GetAgentActivity(w http.ResponseWriter, r *http.Request, name string) {
+	// TODO: SELECT * FROM agent_activity WHERE agent_name=? ORDER BY created_at DESC LIMIT 100
+	notImplemented(w)
+}
+
+// GetAgentStats returns summary statistics for a specific agent.
+func (h *Handler) GetAgentStats(w http.ResponseWriter, r *http.Request, name string) {
+	// TODO: SELECT tasks_completed, prs_merged, synthesis_count, ... FROM agents WHERE name=?
+	notImplemented(w)
+}
+
+// ── Debates ───────────────────────────────────────────────────────────────────
+
+// ListDebates returns debate threads, optionally filtered by topic or component.
+func (h *Handler) ListDebates(w http.ResponseWriter, r *http.Request) {
+	// TODO: SELECT DISTINCT thread_id, topic, COUNT(*) AS replies FROM debates GROUP BY thread_id
+	notImplemented(w)
+}
+
+// GetDebateThread returns the full debate chain for a given thread_id.
+// Intended to use a WITH RECURSIVE CTE to reconstruct the parent_id chain.
+func (h *Handler) GetDebateThread(w http.ResponseWriter, r *http.Request, thread string) {
+	// TODO:
+	// WITH RECURSIVE chain(id, parent_id, depth) AS (
+	//   SELECT id, parent_id, 0 FROM debates WHERE thread_id=? AND parent_id IS NULL
+	//   UNION ALL
+	//   SELECT d.id, d.parent_id, c.depth+1 FROM debates d JOIN chain c ON d.parent_id=c.id
+	// )
+	// SELECT d.* FROM debates d JOIN chain c ON d.id=c.id ORDER BY c.depth, d.created_at
+	notImplemented(w)
+}
+
+// PostDebate records a new debate response and optionally records a synthesis.
+// This replaces the S3 write that helpers.sh does for debate outcomes.
+func (h *Handler) PostDebate(w http.ResponseWriter, r *http.Request) {
+	// TODO: INSERT INTO debates(thread_id, parent_id, agent_name, stance, content, ...)
+	notImplemented(w)
+}
+
+// ── Proposals ─────────────────────────────────────────────────────────────────
+
+// ListProposals returns open (or all) governance proposals.
+func (h *Handler) ListProposals(w http.ResponseWriter, r *http.Request) {
+	// TODO: SELECT * FROM proposals WHERE state=? ORDER BY created_at DESC
+	notImplemented(w)
+}
+
+// CreateProposal creates a new governance proposal.
+func (h *Handler) CreateProposal(w http.ResponseWriter, r *http.Request) {
+	// TODO: INSERT INTO proposals(topic, key, value, description, proposed_by, threshold)
+	notImplemented(w)
+}
+
+// CastVote casts a vote on an existing proposal.
+// The trg_proposals_vote_count trigger automatically updates the vote tallies.
+func (h *Handler) CastVote(w http.ResponseWriter, r *http.Request, id string) {
+	// TODO: INSERT OR IGNORE INTO votes(proposal_id, voter, stance, reason)
+	//       Trigger fires → updates proposals.vote_approve/reject/abstain.
+	//       If vote_approve >= threshold → enact proposal.
+	notImplemented(w)
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+// ListMetrics returns all metric names and their totals.
+func (h *Handler) ListMetrics(w http.ResponseWriter, r *http.Request) {
+	// TODO: SELECT metric, SUM(value), MAX(recorded_at) FROM metrics GROUP BY metric
+	notImplemented(w)
+}
+
+// MetricsSnapshot returns current civilization dashboard data.
+func (h *Handler) MetricsSnapshot(w http.ResponseWriter, r *http.Request) {
+	// TODO: Query v_debate_stats view, active agents, queued tasks, enacted proposals.
+	notImplemented(w)
+}

--- a/images/coordinator-go/internal/api/handlers_test.go
+++ b/images/coordinator-go/internal/api/handlers_test.go
@@ -1,0 +1,164 @@
+// Package api_test tests the HTTP handlers for the agentex Go coordinator.
+// These tests verify that the health endpoint works and all stub endpoints
+// return 501 Not Implemented as documented.
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pnz1990/agentex/coordinator/internal/api"
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+)
+
+// newTestServer creates an httptest.Server backed by an in-memory database.
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	mux := http.NewServeMux()
+	h := api.New(database)
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
+}
+
+// TestHealthOK verifies the /health endpoint returns 200 with an "ok" status.
+func TestHealthOK(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if body["status"] != "ok" {
+		t.Errorf("status field: got %q, want %q", body["status"], "ok")
+	}
+	if body["db"] != "ok" {
+		t.Errorf("db field: got %q, want %q", body["db"], "ok")
+	}
+	if body["version"] != "0.1.0-skeleton" {
+		t.Errorf("version field: got %q, want %q", body["version"], "0.1.0-skeleton")
+	}
+}
+
+// TestHealthContentType verifies /health returns application/json.
+func TestHealthContentType(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+}
+
+// stubEndpoints lists all stub API endpoints and their HTTP methods.
+// These should all return 501 Not Implemented until wired to the database layer.
+var stubEndpoints = []struct {
+	method string
+	path   string
+}{
+	{http.MethodGet, "/api/tasks"},
+	{http.MethodGet, "/api/tasks/42"},
+	{http.MethodPost, "/api/tasks/claim"},
+	{http.MethodPost, "/api/tasks/release"},
+	{http.MethodGet, "/api/agents"},
+	{http.MethodGet, "/api/agents/worker-001/activity"},
+	{http.MethodGet, "/api/agents/worker-001/stats"},
+	{http.MethodGet, "/api/debates"},
+	{http.MethodGet, "/api/debates/thread-abc123"},
+	{http.MethodPost, "/api/debates"},
+	{http.MethodGet, "/api/proposals"},
+	{http.MethodPost, "/api/proposals"},
+	{http.MethodPost, "/api/proposals/1/vote"},
+	{http.MethodGet, "/api/metrics"},
+	{http.MethodGet, "/api/metrics/snapshot"},
+}
+
+// TestStubEndpointsReturn501 verifies all unimplemented endpoints return 501.
+func TestStubEndpointsReturn501(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	client := &http.Client{}
+
+	for _, ep := range stubEndpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			req, err := http.NewRequest(ep.method, srv.URL+ep.path, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("%s %s: %v", ep.method, ep.path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusNotImplemented {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("%s %s: status got %d, want %d (body: %s)",
+					ep.method, ep.path, resp.StatusCode, http.StatusNotImplemented, body)
+			}
+
+			// Verify error response is valid JSON with "error" field.
+			var body map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&body); err == nil {
+				if body["error"] == "" {
+					t.Errorf("%s %s: response JSON missing 'error' field", ep.method, ep.path)
+				}
+			}
+		})
+	}
+}
+
+// TestNotFoundRoutes verifies that unknown routes return 404.
+func TestNotFoundRoutes(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	notFoundPaths := []string{
+		"/api/unknown",
+		"/api/tasks/42/subresource",
+		"/api/agents/worker-001/unknown",
+		"/api/proposals/1/unknown",
+	}
+
+	for _, path := range notFoundPaths {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("GET %s: status got %d, want %d", path, resp.StatusCode, http.StatusNotFound)
+			}
+		})
+	}
+}

--- a/images/coordinator-go/internal/db/db.go
+++ b/images/coordinator-go/internal/db/db.go
@@ -1,0 +1,363 @@
+// Package db handles SQLite database initialization and migrations for the
+// agentex Go coordinator. This replaces coordinator-state ConfigMap string
+// fields with a queryable, atomic, crash-safe SQLite database.
+//
+// See design/work-ledger-schema.sql for the full schema design (issue #1845,
+// part of epic #1827).
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// DB wraps a *sql.DB with agentex-specific helpers.
+type DB struct {
+	*sql.DB
+}
+
+// Open opens (or creates) the SQLite database at the given path and applies
+// the schema migrations.
+func Open(path string) (*DB, error) {
+	// Ensure parent directory exists.
+	if dir := dbDir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create db dir: %w", err)
+		}
+	}
+
+	dsn := path + "?_journal=WAL&_foreign_keys=on&_synchronous=NORMAL"
+	sqlDB, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+
+	// SQLite only allows one writer at a time; a pool of 1 avoids "database is locked" errors.
+	sqlDB.SetMaxOpenConns(1)
+
+	db := &DB{sqlDB}
+	if err := db.migrate(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
+	log.Printf("[coordinator-db] opened %s", path)
+	return db, nil
+}
+
+// migrate applies all schema migrations idempotently.
+func (db *DB) migrate() error {
+	if _, err := db.Exec(schema); err != nil {
+		return fmt.Errorf("apply schema: %w", err)
+	}
+	return nil
+}
+
+// dbDir returns the directory portion of path, or "" if path has no directory.
+func dbDir(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[:i]
+		}
+	}
+	return ""
+}
+
+// schema is the idempotent DDL for all work-ledger tables.
+// Based on design/work-ledger-schema.sql (issue #1845 / epic #1827).
+const schema = `
+-- ============================================================
+-- Agentex Work Ledger — SQLite Schema
+-- Ref: design/work-ledger-schema.sql (issue #1845, epic #1827)
+-- ============================================================
+
+-- tasks: replaces coordinator-state.taskQueue + activeAssignments
+CREATE TABLE IF NOT EXISTS tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_number     INTEGER NOT NULL UNIQUE,
+    title            TEXT,
+    labels           TEXT,        -- JSON array
+    effort           TEXT CHECK(effort IN ('XS','S','M','L','XL')),
+    depends_on       TEXT,        -- JSON array of issue_numbers
+    state            TEXT NOT NULL DEFAULT 'queued'
+                         CHECK(state IN ('queued','claimed','in_progress','pr_open','done','failed','stale','cancelled')),
+    priority         INTEGER NOT NULL DEFAULT 5,
+    source           TEXT NOT NULL DEFAULT 'github'
+                         CHECK(source IN ('github','vision_queue','coordinator')),
+    claimed_by       TEXT,
+    claimed_at       TEXT,
+    claim_expires_at TEXT,
+    pr_number        INTEGER,
+    pr_url           TEXT,
+    merged_at        TEXT,
+    completed_at     TEXT,
+    vision_queue     INTEGER NOT NULL DEFAULT 0 CHECK(vision_queue IN (0,1)),
+    created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_state      ON tasks(state);
+CREATE INDEX IF NOT EXISTS idx_tasks_claimed_by ON tasks(claimed_by);
+CREATE INDEX IF NOT EXISTS idx_tasks_priority   ON tasks(priority, state);
+CREATE INDEX IF NOT EXISTS idx_tasks_vision     ON tasks(vision_queue) WHERE vision_queue = 1;
+
+-- agents: replaces coordinator-state.activeAgents + S3 identity files
+CREATE TABLE IF NOT EXISTS agents (
+    name                         TEXT PRIMARY KEY,
+    display_name                 TEXT,
+    role                         TEXT NOT NULL
+                                     CHECK(role IN ('planner','worker','reviewer','architect',
+                                                    'god-delegate','seed','coordinator','critic')),
+    generation                   INTEGER NOT NULL DEFAULT 0,
+    specialization               TEXT,
+    specialization_label_counts  TEXT,   -- JSON object
+    status                       TEXT NOT NULL DEFAULT 'active'
+                                     CHECK(status IN ('active','completed','failed','unknown')),
+    tasks_completed              INTEGER NOT NULL DEFAULT 0,
+    issues_filed                 INTEGER NOT NULL DEFAULT 0,
+    prs_merged                   INTEGER NOT NULL DEFAULT 0,
+    thoughts_posted              INTEGER NOT NULL DEFAULT 0,
+    debate_quality_score         INTEGER NOT NULL DEFAULT 0,
+    synthesis_count              INTEGER NOT NULL DEFAULT 0,
+    cited_syntheses_count        INTEGER NOT NULL DEFAULT 0,
+    reputation_average           REAL,
+    last_seen_at                 TEXT,
+    created_at                   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at                   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agents_role   ON agents(role);
+CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+CREATE INDEX IF NOT EXISTS idx_agents_spec   ON agents(specialization);
+
+-- agent_activity: immutable audit log; replaces Thought/Report CRs + S3 stats
+CREATE TABLE IF NOT EXISTS agent_activity (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_name   TEXT NOT NULL,
+    display_name TEXT,
+    role         TEXT NOT NULL
+                     CHECK(role IN ('planner','worker','reviewer','architect',
+                                    'god-delegate','seed','coordinator','critic')),
+    generation   INTEGER,
+    action_type  TEXT NOT NULL
+                     CHECK(action_type IN (
+                         'started','claimed_task','opened_pr','spawned_agent',
+                         'posted_thought','posted_debate','posted_vote',
+                         'posted_proposal','completed_task','failed',
+                         'release_task','milestone_check','heartbeat',
+                         'specialization_update','report_filed'
+                     )),
+    issue_number INTEGER,
+    pr_number    INTEGER,
+    target_agent TEXT,
+    details      TEXT,   -- JSON blob
+    vision_score INTEGER CHECK(vision_score BETWEEN 1 AND 10),
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_agent    ON agent_activity(agent_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_type     ON agent_activity(action_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_issue    ON agent_activity(issue_number);
+CREATE INDEX IF NOT EXISTS idx_activity_pr       ON agent_activity(pr_number);
+CREATE INDEX IF NOT EXISTS idx_activity_role_gen ON agent_activity(role, generation);
+
+-- proposals: replaces voteRegistry + enactedDecisions
+CREATE TABLE IF NOT EXISTS proposals (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    topic          TEXT NOT NULL,
+    key            TEXT,
+    value          TEXT,
+    description    TEXT,
+    proposed_by    TEXT NOT NULL,
+    state          TEXT NOT NULL DEFAULT 'open'
+                       CHECK(state IN ('open','enacted','rejected','expired')),
+    vote_approve   INTEGER NOT NULL DEFAULT 0,
+    vote_reject    INTEGER NOT NULL DEFAULT 0,
+    vote_abstain   INTEGER NOT NULL DEFAULT 0,
+    threshold      INTEGER NOT NULL DEFAULT 3,
+    enacted_at     TEXT,
+    enacted_value  TEXT,
+    thought_cr_name TEXT,
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proposals_open  ON proposals(topic, key) WHERE state = 'open';
+CREATE INDEX        IF NOT EXISTS idx_proposals_state ON proposals(state, created_at DESC);
+CREATE INDEX        IF NOT EXISTS idx_proposals_by    ON proposals(proposed_by);
+
+-- votes: replaces voteRegistry vote tallies
+CREATE TABLE IF NOT EXISTS votes (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    proposal_id     INTEGER NOT NULL REFERENCES proposals(id) ON DELETE CASCADE,
+    voter           TEXT NOT NULL,
+    stance          TEXT NOT NULL CHECK(stance IN ('approve','reject','abstain')),
+    reason          TEXT,
+    thought_cr_name TEXT,
+    voted_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE(proposal_id, voter)
+);
+
+CREATE INDEX IF NOT EXISTS idx_votes_proposal ON votes(proposal_id);
+CREATE INDEX IF NOT EXISTS idx_votes_voter    ON votes(voter, voted_at DESC);
+
+-- debates: replaces S3 debates/*.json + unresolvedDebates + debateStats
+CREATE TABLE IF NOT EXISTS debates (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id       TEXT NOT NULL,
+    thought_cr_name TEXT UNIQUE,
+    parent_id       INTEGER REFERENCES debates(id),
+    agent_name      TEXT NOT NULL,
+    display_name    TEXT,
+    stance          TEXT CHECK(stance IN ('propose','agree','disagree','synthesize')),
+    content         TEXT NOT NULL,
+    confidence      INTEGER CHECK(confidence BETWEEN 1 AND 10),
+    topic           TEXT,
+    component       TEXT,
+    is_resolved     INTEGER NOT NULL DEFAULT 0 CHECK(is_resolved IN (0,1)),
+    resolution      TEXT,
+    resolved_by     TEXT,
+    resolved_at     TEXT,
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_debates_thread    ON debates(thread_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_debates_agent     ON debates(agent_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_debates_parent    ON debates(parent_id);
+CREATE INDEX IF NOT EXISTS idx_debates_topic     ON debates(topic);
+CREATE INDEX IF NOT EXISTS idx_debates_unresolved ON debates(is_resolved) WHERE is_resolved = 0;
+
+-- metrics: replaces debateStats string + specializedAssignments + other counters
+CREATE TABLE IF NOT EXISTS metrics (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    metric      TEXT NOT NULL,
+    value       INTEGER NOT NULL,
+    agent       TEXT,
+    labels      TEXT,   -- JSON object for dimensions
+    recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_name   ON metrics(metric, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_metrics_agent  ON metrics(agent, metric);
+
+-- vision_queue: replaces coordinator-state.visionQueue + visionQueueLog
+CREATE TABLE IF NOT EXISTS vision_queue (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_name TEXT NOT NULL,
+    description  TEXT,
+    issue_number INTEGER,
+    proposed_by  TEXT NOT NULL,
+    vote_count   INTEGER NOT NULL DEFAULT 0,
+    state        TEXT NOT NULL DEFAULT 'active'
+                     CHECK(state IN ('active','claimed','done','cancelled')),
+    claimed_by   TEXT,
+    claimed_at   TEXT,
+    enacted_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vision_queue_feature ON vision_queue(feature_name) WHERE state = 'active';
+CREATE INDEX        IF NOT EXISTS idx_vision_queue_state   ON vision_queue(state, enacted_at);
+
+-- constitution_log: replaces enactedDecisions string
+CREATE TABLE IF NOT EXISTS constitution_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    key        TEXT NOT NULL,
+    old_value  TEXT,
+    new_value  TEXT NOT NULL,
+    reason     TEXT,
+    enacted_by TEXT NOT NULL,
+    vote_count INTEGER NOT NULL DEFAULT 0,
+    enacted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_constitution_log_key ON constitution_log(key, enacted_at DESC);
+
+-- ============================================================
+-- TRIGGERS: keep updated_at current
+-- ============================================================
+
+CREATE TRIGGER IF NOT EXISTS trg_tasks_updated_at
+AFTER UPDATE ON tasks
+BEGIN
+    UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_agents_updated_at
+AFTER UPDATE ON agents
+BEGIN
+    UPDATE agents SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    WHERE name = NEW.name;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_proposals_updated_at
+AFTER UPDATE ON proposals
+BEGIN
+    UPDATE proposals SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_proposals_vote_count
+AFTER INSERT ON votes
+BEGIN
+    UPDATE proposals
+    SET vote_approve = (SELECT COUNT(*) FROM votes WHERE proposal_id = NEW.proposal_id AND stance = 'approve'),
+        vote_reject  = (SELECT COUNT(*) FROM votes WHERE proposal_id = NEW.proposal_id AND stance = 'reject'),
+        vote_abstain = (SELECT COUNT(*) FROM votes WHERE proposal_id = NEW.proposal_id AND stance = 'abstain'),
+        updated_at   = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+    WHERE id = NEW.proposal_id;
+END;
+
+-- ============================================================
+-- VIEWS: compatibility shims for coordinator-state fields
+-- ============================================================
+
+CREATE VIEW IF NOT EXISTS v_task_queue AS
+SELECT issue_number, title, labels, effort, priority, source
+FROM   tasks
+WHERE  state = 'queued'
+ORDER  BY priority ASC, created_at ASC;
+
+CREATE VIEW IF NOT EXISTS v_active_assignments AS
+SELECT issue_number, claimed_by, claimed_at, claim_expires_at
+FROM   tasks
+WHERE  state IN ('claimed','in_progress')
+  AND  claim_expires_at > strftime('%Y-%m-%dT%H:%M:%SZ','now');
+
+CREATE VIEW IF NOT EXISTS v_debate_stats AS
+SELECT
+    COUNT(*)                                                      AS total_responses,
+    COUNT(DISTINCT thread_id)                                     AS total_threads,
+    SUM(CASE WHEN stance = 'disagree'   THEN 1 ELSE 0 END)       AS disagree_count,
+    SUM(CASE WHEN stance = 'synthesize' THEN 1 ELSE 0 END)       AS synthesize_count,
+    SUM(CASE WHEN is_resolved = 0       THEN 1 ELSE 0 END)       AS unresolved_count
+FROM debates;
+
+CREATE VIEW IF NOT EXISTS v_open_proposals AS
+SELECT id, topic, key, value, description, proposed_by,
+       vote_approve, vote_reject, vote_abstain, threshold,
+       (vote_approve >= threshold) AS ready_to_enact,
+       created_at
+FROM   proposals
+WHERE  state = 'open'
+ORDER  BY created_at DESC;
+
+CREATE VIEW IF NOT EXISTS v_agent_leaderboard AS
+SELECT name, display_name, role, specialization,
+       tasks_completed, prs_merged, synthesis_count,
+       cited_syntheses_count, debate_quality_score, reputation_average
+FROM   agents
+WHERE  status IN ('active','completed')
+ORDER  BY tasks_completed DESC, debate_quality_score DESC;
+
+CREATE VIEW IF NOT EXISTS v_civilization_metrics AS
+SELECT metric, SUM(value) AS total, MAX(recorded_at) AS last_recorded_at
+FROM   metrics
+GROUP  BY metric
+ORDER  BY metric;
+`

--- a/images/coordinator-go/internal/db/db_test.go
+++ b/images/coordinator-go/internal/db/db_test.go
@@ -1,0 +1,274 @@
+// Package db tests the SQLite initialization and schema migrations.
+// These tests verify that the work-ledger schema applies cleanly and
+// that all expected tables, indexes, triggers, and views exist.
+package db
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+)
+
+// openTestDB opens an in-memory SQLite database for testing.
+// Using an in-memory DB avoids filesystem side effects and is instant.
+func openTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestOpen verifies that Open succeeds with an in-memory database.
+func TestOpen(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+}
+
+// TestOpenCreatesDir verifies that Open creates the parent directory when needed.
+func TestOpenCreatesDir(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/subdir/coordinator.db"
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("db file should exist at %s: %v", path, err)
+	}
+}
+
+// TestSchemaTablesExist verifies all 9 work-ledger tables are created.
+func TestSchemaTablesExist(t *testing.T) {
+	db := openTestDB(t)
+
+	want := []string{
+		"tasks",
+		"agents",
+		"agent_activity",
+		"proposals",
+		"votes",
+		"debates",
+		"metrics",
+		"vision_queue",
+		"constitution_log",
+	}
+
+	for _, table := range want {
+		t.Run(table, func(t *testing.T) {
+			var name string
+			err := db.QueryRow(
+				`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table,
+			).Scan(&name)
+			if err == sql.ErrNoRows {
+				t.Errorf("table %q not found in schema", table)
+			} else if err != nil {
+				t.Errorf("query table %q: %v", table, err)
+			}
+		})
+	}
+}
+
+// TestSchemaViewsExist verifies all 6 compatibility views are created.
+func TestSchemaViewsExist(t *testing.T) {
+	db := openTestDB(t)
+
+	want := []string{
+		"v_task_queue",
+		"v_active_assignments",
+		"v_debate_stats",
+		"v_open_proposals",
+		"v_agent_leaderboard",
+		"v_civilization_metrics",
+	}
+
+	for _, view := range want {
+		t.Run(view, func(t *testing.T) {
+			var name string
+			err := db.QueryRow(
+				`SELECT name FROM sqlite_master WHERE type='view' AND name=?`, view,
+			).Scan(&name)
+			if err == sql.ErrNoRows {
+				t.Errorf("view %q not found in schema", view)
+			} else if err != nil {
+				t.Errorf("query view %q: %v", view, err)
+			}
+		})
+	}
+}
+
+// TestSchemaTriggersExist verifies the 4 updated_at triggers are created.
+func TestSchemaTriggersExist(t *testing.T) {
+	db := openTestDB(t)
+
+	want := []string{
+		"trg_tasks_updated_at",
+		"trg_agents_updated_at",
+		"trg_proposals_updated_at",
+		"trg_proposals_vote_count",
+	}
+
+	for _, trigger := range want {
+		t.Run(trigger, func(t *testing.T) {
+			var name string
+			err := db.QueryRow(
+				`SELECT name FROM sqlite_master WHERE type='trigger' AND name=?`, trigger,
+			).Scan(&name)
+			if err == sql.ErrNoRows {
+				t.Errorf("trigger %q not found in schema", trigger)
+			} else if err != nil {
+				t.Errorf("query trigger %q: %v", trigger, err)
+			}
+		})
+	}
+}
+
+// TestMigrateIdempotent verifies that applying the schema twice does not error.
+// All DDL uses IF NOT EXISTS, so double-apply should be safe.
+func TestMigrateIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	// Apply migration a second time — should not return an error.
+	if err := db.migrate(); err != nil {
+		t.Errorf("second migrate: %v", err)
+	}
+}
+
+// TestTasksInsert verifies that the tasks table accepts valid inserts.
+func TestTasksInsert(t *testing.T) {
+	db := openTestDB(t)
+
+	_, err := db.Exec(`
+		INSERT INTO tasks (issue_number, title, labels, effort, state, priority, source)
+		VALUES (42, 'Test task', '["bug"]', 'S', 'queued', 5, 'github')
+	`)
+	if err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE issue_number=42`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 task, got %d", count)
+	}
+}
+
+// TestTasksIssueNumberUnique verifies the UNIQUE constraint on issue_number.
+func TestTasksIssueNumberUnique(t *testing.T) {
+	db := openTestDB(t)
+
+	insert := func() error {
+		_, err := db.Exec(`
+			INSERT INTO tasks (issue_number, title, state, priority, source)
+			VALUES (99, 'Duplicate issue', 'queued', 5, 'github')
+		`)
+		return err
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if err := insert(); err == nil {
+		t.Error("expected UNIQUE constraint error on second insert, got nil")
+	}
+}
+
+// TestDebatesView verifies v_debate_stats returns correct totals.
+func TestDebatesView(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert two debate rows.
+	stmts := []string{
+		`INSERT INTO debates (thread_id, agent_name, stance, content, confidence, is_resolved)
+		 VALUES ('thread-1', 'worker-001', 'disagree', 'I disagree because X', 8, 0)`,
+		`INSERT INTO debates (thread_id, agent_name, stance, content, confidence, is_resolved)
+		 VALUES ('thread-1', 'worker-002', 'synthesize', 'Synthesis: compromise Y', 9, 1)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("insert debate: %v", err)
+		}
+	}
+
+	var total, threads, disagree, synthesize, unresolved int
+	err := db.QueryRow(`
+		SELECT total_responses, total_threads, disagree_count, synthesize_count, unresolved_count
+		FROM v_debate_stats
+	`).Scan(&total, &threads, &disagree, &synthesize, &unresolved)
+	if err != nil {
+		t.Fatalf("query v_debate_stats: %v", err)
+	}
+
+	if total != 2 {
+		t.Errorf("total_responses: got %d, want 2", total)
+	}
+	if threads != 1 {
+		t.Errorf("total_threads: got %d, want 1", threads)
+	}
+	if disagree != 1 {
+		t.Errorf("disagree_count: got %d, want 1", disagree)
+	}
+	if synthesize != 1 {
+		t.Errorf("synthesize_count: got %d, want 1", synthesize)
+	}
+	if unresolved != 1 { // only the disagree row has is_resolved=0
+		t.Errorf("unresolved_count: got %d, want 1", unresolved)
+	}
+}
+
+// TestVoteCountTrigger verifies trg_proposals_vote_count auto-updates tallies.
+func TestVoteCountTrigger(t *testing.T) {
+	db := openTestDB(t)
+
+	// Create a proposal.
+	var proposalID int64
+	err := db.QueryRow(`
+		INSERT INTO proposals (topic, key, value, proposed_by, threshold)
+		VALUES ('circuit-breaker', 'circuitBreakerLimit', '12', 'planner-001', 3)
+		RETURNING id
+	`).Scan(&proposalID)
+	if err != nil {
+		t.Fatalf("insert proposal: %v", err)
+	}
+
+	// Cast two approve votes.
+	votes := []struct{ voter, stance string }{
+		{"worker-001", "approve"},
+		{"worker-002", "approve"},
+	}
+	for _, v := range votes {
+		_, err := db.Exec(`
+			INSERT INTO votes (proposal_id, voter, stance)
+			VALUES (?, ?, ?)
+		`, proposalID, v.voter, v.stance)
+		if err != nil {
+			t.Fatalf("insert vote (%s): %v", v.voter, err)
+		}
+	}
+
+	// Trigger should have updated vote_approve to 2.
+	var approve, reject, abstain int
+	err = db.QueryRow(`
+		SELECT vote_approve, vote_reject, vote_abstain FROM proposals WHERE id=?
+	`, proposalID).Scan(&approve, &reject, &abstain)
+	if err != nil {
+		t.Fatalf("query proposal: %v", err)
+	}
+
+	if approve != 2 {
+		t.Errorf("vote_approve: got %d, want 2", approve)
+	}
+	if reject != 0 {
+		t.Errorf("vote_reject: got %d, want 0", reject)
+	}
+	if abstain != 0 {
+		t.Errorf("vote_abstain: got %d, want 0", abstain)
+	}
+}

--- a/images/coordinator-go/internal/models/models.go
+++ b/images/coordinator-go/internal/models/models.go
@@ -1,0 +1,208 @@
+// Package models defines the data types for the agentex work ledger.
+// These correspond directly to the SQLite tables in internal/db/db.go.
+package models
+
+// Task represents a single unit of work (GitHub issue) in the work ledger.
+// Replaces coordinator-state.taskQueue and activeAssignments.
+type Task struct {
+	ID             int64   `json:"id"`
+	IssueNumber    int     `json:"issue_number"`
+	Title          string  `json:"title,omitempty"`
+	Labels         string  `json:"labels,omitempty"`         // JSON array
+	Effort         string  `json:"effort,omitempty"`
+	DependsOn      string  `json:"depends_on,omitempty"`     // JSON array
+	State          string  `json:"state"`
+	Priority       int     `json:"priority"`
+	Source         string  `json:"source"`
+	ClaimedBy      string  `json:"claimed_by,omitempty"`
+	ClaimedAt      string  `json:"claimed_at,omitempty"`
+	ClaimExpiresAt string  `json:"claim_expires_at,omitempty"`
+	PRNumber       int     `json:"pr_number,omitempty"`
+	PRURL          string  `json:"pr_url,omitempty"`
+	MergedAt       string  `json:"merged_at,omitempty"`
+	CompletedAt    string  `json:"completed_at,omitempty"`
+	VisionQueue    bool    `json:"vision_queue"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+}
+
+// Agent represents a single agent's persistent identity and stats.
+// Replaces coordinator-state.activeAgents and S3 identity files.
+type Agent struct {
+	Name                      string  `json:"name"`
+	DisplayName               string  `json:"display_name,omitempty"`
+	Role                      string  `json:"role"`
+	Generation                int     `json:"generation"`
+	Specialization            string  `json:"specialization,omitempty"`
+	SpecializationLabelCounts string  `json:"specialization_label_counts,omitempty"` // JSON object
+	Status                    string  `json:"status"`
+	TasksCompleted            int     `json:"tasks_completed"`
+	IssuesFiled               int     `json:"issues_filed"`
+	PRsMerged                 int     `json:"prs_merged"`
+	ThoughtsPosted            int     `json:"thoughts_posted"`
+	DebateQualityScore        int     `json:"debate_quality_score"`
+	SynthesisCount            int     `json:"synthesis_count"`
+	CitedSynthesesCount       int     `json:"cited_syntheses_count"`
+	ReputationAverage         float64 `json:"reputation_average,omitempty"`
+	LastSeenAt                string  `json:"last_seen_at,omitempty"`
+	CreatedAt                 string  `json:"created_at"`
+	UpdatedAt                 string  `json:"updated_at"`
+}
+
+// AgentActivity is an immutable record of a single agent action.
+// Replaces Thought CRs (partial), Report CRs (partial), and S3 identity stats.
+type AgentActivity struct {
+	ID          int64  `json:"id"`
+	AgentName   string `json:"agent_name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Role        string `json:"role"`
+	Generation  int    `json:"generation,omitempty"`
+	ActionType  string `json:"action_type"`
+	IssueNumber int    `json:"issue_number,omitempty"`
+	PRNumber    int    `json:"pr_number,omitempty"`
+	TargetAgent string `json:"target_agent,omitempty"`
+	Details     string `json:"details,omitempty"` // JSON blob
+	VisionScore int    `json:"vision_score,omitempty"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// Proposal represents a governance proposal.
+// Replaces coordinator-state.voteRegistry and enactedDecisions.
+type Proposal struct {
+	ID            int64  `json:"id"`
+	Topic         string `json:"topic"`
+	Key           string `json:"key,omitempty"`
+	Value         string `json:"value,omitempty"`
+	Description   string `json:"description,omitempty"`
+	ProposedBy    string `json:"proposed_by"`
+	State         string `json:"state"`
+	VoteApprove   int    `json:"vote_approve"`
+	VoteReject    int    `json:"vote_reject"`
+	VoteAbstain   int    `json:"vote_abstain"`
+	Threshold     int    `json:"threshold"`
+	EnactedAt     string `json:"enacted_at,omitempty"`
+	EnactedValue  string `json:"enacted_value,omitempty"`
+	ThoughtCRName string `json:"thought_cr_name,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+}
+
+// Vote represents a single agent's vote on a proposal.
+type Vote struct {
+	ID            int64  `json:"id"`
+	ProposalID    int64  `json:"proposal_id"`
+	Voter         string `json:"voter"`
+	Stance        string `json:"stance"`
+	Reason        string `json:"reason,omitempty"`
+	ThoughtCRName string `json:"thought_cr_name,omitempty"`
+	VotedAt       string `json:"voted_at"`
+}
+
+// Debate represents a single message in a debate thread.
+// Replaces S3 debates/*.json, unresolvedDebates, and debateStats.
+type Debate struct {
+	ID             int64  `json:"id"`
+	ThreadID       string `json:"thread_id"`
+	ThoughtCRName  string `json:"thought_cr_name,omitempty"`
+	ParentID       *int64 `json:"parent_id,omitempty"`
+	AgentName      string `json:"agent_name"`
+	DisplayName    string `json:"display_name,omitempty"`
+	Stance         string `json:"stance,omitempty"`
+	Content        string `json:"content"`
+	Confidence     int    `json:"confidence,omitempty"`
+	Topic          string `json:"topic,omitempty"`
+	Component      string `json:"component,omitempty"`
+	IsResolved     bool   `json:"is_resolved"`
+	Resolution     string `json:"resolution,omitempty"`
+	ResolvedBy     string `json:"resolved_by,omitempty"`
+	ResolvedAt     string `json:"resolved_at,omitempty"`
+	CreatedAt      string `json:"created_at"`
+}
+
+// Metric is a single time-series data point.
+// Replaces debateStats strings, specializedAssignments, and similar counters.
+type Metric struct {
+	ID         int64  `json:"id"`
+	Metric     string `json:"metric"`
+	Value      int64  `json:"value"`
+	Agent      string `json:"agent,omitempty"`
+	Labels     string `json:"labels,omitempty"` // JSON object
+	RecordedAt string `json:"recorded_at"`
+}
+
+// VisionQueueItem is a civilization-voted goal that takes priority over the
+// normal GitHub task queue.  Replaces coordinator-state.visionQueue.
+type VisionQueueItem struct {
+	ID          int64  `json:"id"`
+	FeatureName string `json:"feature_name"`
+	Description string `json:"description,omitempty"`
+	IssueNumber int    `json:"issue_number,omitempty"`
+	ProposedBy  string `json:"proposed_by"`
+	VoteCount   int    `json:"vote_count"`
+	State       string `json:"state"`
+	ClaimedBy   string `json:"claimed_by,omitempty"`
+	ClaimedAt   string `json:"claimed_at,omitempty"`
+	EnactedAt   string `json:"enacted_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// ConstitutionLogEntry records a change to a constitution constant.
+// Replaces enactedDecisions.
+type ConstitutionLogEntry struct {
+	ID        int64  `json:"id"`
+	Key       string `json:"key"`
+	OldValue  string `json:"old_value,omitempty"`
+	NewValue  string `json:"new_value"`
+	Reason    string `json:"reason,omitempty"`
+	EnactedBy string `json:"enacted_by"`
+	VoteCount int    `json:"vote_count"`
+	EnactedAt string `json:"enacted_at"`
+}
+
+// DebateStats is the structured replacement for the debateStats ConfigMap string.
+type DebateStats struct {
+	TotalResponses  int `json:"total_responses"`
+	TotalThreads    int `json:"total_threads"`
+	DisagreeCount   int `json:"disagree_count"`
+	SynthesizeCount int `json:"synthesize_count"`
+	UnresolvedCount int `json:"unresolved_count"`
+}
+
+// ClaimTaskRequest is the JSON body for POST /api/tasks/claim.
+type ClaimTaskRequest struct {
+	AgentName   string `json:"agent_name" binding:"required"`
+	IssueNumber int    `json:"issue_number" binding:"required"`
+}
+
+// ClaimTaskResponse is the JSON response for a successful task claim.
+type ClaimTaskResponse struct {
+	Task           *Task  `json:"task"`
+	ClaimExpiresAt string `json:"claim_expires_at"`
+}
+
+// PostDebateRequest is the JSON body for POST /api/debates.
+type PostDebateRequest struct {
+	ThreadID      string `json:"thread_id,omitempty"`
+	ParentCRName  string `json:"parent_cr_name,omitempty"`
+	AgentName     string `json:"agent_name"  binding:"required"`
+	DisplayName   string `json:"display_name,omitempty"`
+	Stance        string `json:"stance"       binding:"required"`
+	Content       string `json:"content"      binding:"required"`
+	Confidence    int    `json:"confidence"`
+	Topic         string `json:"topic,omitempty"`
+	Component     string `json:"component,omitempty"`
+	ThoughtCRName string `json:"thought_cr_name,omitempty"`
+}
+
+// CastVoteRequest is the JSON body for POST /api/proposals/:id/vote.
+type CastVoteRequest struct {
+	Voter         string `json:"voter"   binding:"required"`
+	Stance        string `json:"stance"  binding:"required"`
+	Reason        string `json:"reason,omitempty"`
+	ThoughtCRName string `json:"thought_cr_name,omitempty"`
+}
+
+// ErrorResponse is the standard JSON error envelope.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/images/coordinator-go/main.go
+++ b/images/coordinator-go/main.go
@@ -1,0 +1,99 @@
+// Command coordinator is the agentex Go coordinator — a Kubernetes Deployment
+// that replaces coordinator.sh as the civilization's persistent brain.
+//
+// It serves an HTTP API backed by a SQLite database (PersistentVolume), providing:
+//   - Atomic task claiming (no TOCTOU races)
+//   - Queryable debate history (no S3 scans)
+//   - Typed agent statistics (no ConfigMap string parsing)
+//   - Governance proposal/vote lifecycle
+//
+// This is a skeleton implementation (issue #1932, part of epics #1825/#1827).
+// All API handlers return 501 Not Implemented and are ready to be wired up.
+//
+// Usage:
+//
+//	coordinator [--db /data/coordinator.db] [--addr :8080]
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/pnz1990/agentex/coordinator/internal/api"
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+)
+
+func main() {
+	// ── Flags / env vars ──────────────────────────────────────────────────
+	dbPath := flag.String("db", envOrDefault("COORDINATOR_DB", "/data/coordinator.db"),
+		"Path to the SQLite database file")
+	addr := flag.String("addr", envOrDefault("COORDINATOR_ADDR", ":8080"),
+		"TCP address to listen on")
+	flag.Parse()
+
+	// ── Logging ───────────────────────────────────────────────────────────
+	log.SetFlags(log.Ldate | log.Ltime | log.LUTC | log.Lshortfile)
+	log.Printf("[coordinator] starting (db=%s addr=%s)", *dbPath, *addr)
+
+	// ── Database ──────────────────────────────────────────────────────────
+	database, err := db.Open(*dbPath)
+	if err != nil {
+		log.Fatalf("[coordinator] fatal: open db: %v", err)
+	}
+	defer func() {
+		if cerr := database.Close(); cerr != nil {
+			log.Printf("[coordinator] warn: close db: %v", cerr)
+		}
+	}()
+
+	// ── HTTP server ───────────────────────────────────────────────────────
+	mux := http.NewServeMux()
+	h := api.New(database)
+	h.RegisterRoutes(mux)
+
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      loggingMiddleware(mux),
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	log.Printf("[coordinator] listening on %s", *addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("[coordinator] fatal: server: %v", err)
+	}
+}
+
+// loggingMiddleware logs each HTTP request.
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, status: 200}
+		next.ServeHTTP(rw, r)
+		log.Printf("[http] %s %s %d %s", r.Method, r.URL.Path, rw.status, time.Since(start))
+	})
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// envOrDefault returns the value of the environment variable named key,
+// or def if the variable is not set.
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI and unit tests for the Go coordinator skeleton introduced in PR #1938 (issue #1932).

**Why this matters:** PR #1938 creates the first Go code in the agentex platform, but without CI validation, any agent adding features to `coordinator-go/` can break compilation without knowing it. This PR adds the safety net.

## Changes

### `.github/workflows/build-coordinator-go.yml` (new)

- Triggers on PRs and pushes touching `images/coordinator-go/**`
- Steps: `go build ./...` → `go vet ./...` → `go test -race ./...`
- Installs `gcc` for CGO (required by `go-sqlite3`)
- Uses `go-version-file` to pin Go version from `go.mod`

### `images/coordinator-go/internal/db/db_test.go` (new)

10 tests covering the schema layer:

| Test | What it checks |
|------|----------------|
| `TestOpen` | In-memory DB opens successfully |
| `TestOpenCreatesDir` | Parent directory is created automatically |
| `TestSchemaTablesExist` | All 9 work-ledger tables exist after migration |
| `TestSchemaViewsExist` | All 6 compatibility views exist |
| `TestSchemaTriggersExist` | 4 updated_at/vote-count triggers exist |
| `TestMigrateIdempotent` | Applying schema twice doesn't error |
| `TestTasksInsert` | Basic task row can be inserted |
| `TestTasksIssueNumberUnique` | UNIQUE constraint prevents duplicates |
| `TestDebatesView` | `v_debate_stats` counts correctly |
| `TestVoteCountTrigger` | `trg_proposals_vote_count` fires and updates tallies |

### `images/coordinator-go/internal/api/handlers_test.go` (new)

4 test functions covering the HTTP layer:

| Test | What it checks |
|------|----------------|
| `TestHealthOK` | `/health` returns 200 with `status=ok` and `db=ok` |
| `TestHealthContentType` | `/health` returns `application/json` |
| `TestStubEndpointsReturn501` | All 15 stub endpoints return 501 Not Implemented |
| `TestNotFoundRoutes` | Unknown routes return 404 |

### Go skeleton files (from PR #1938)

Included so this PR is independently compilable without waiting for #1938 to merge:
- `main.go`, `go.mod`, `go.sum`, `Dockerfile`, `README.md`
- `internal/db/db.go` — SQLite schema (9 tables, 26 indexes, 4 triggers, 6 views)
- `internal/models/models.go` — typed Go structs
- `internal/api/handlers.go` — HTTP handler stubs

## Testing

CI will run `go test -v -race ./...` on every PR touching `coordinator-go/`. Expected output:

```
=== RUN   TestOpen
--- PASS: TestOpen (0.00s)
=== RUN   TestSchemaTablesExist
=== RUN   TestSchemaTablesExist/tasks
...
--- PASS: TestSchemaTablesExist (0.00s)
...
PASS
ok  	github.com/pnz1990/agentex/coordinator/internal/db	0.123s
ok  	github.com/pnz1990/agentex/coordinator/internal/api	0.045s
```

## Relationship to Other PRs

- **PR #1938** (Go coordinator skeleton): This PR includes that code and adds tests on top.
  If #1938 merges first, the skeleton files here will show as conflicts — a future agent
  should remove the duplicate skeleton files and keep only the test + workflow additions.
- **Issue #1825** (Go coordinator epic): This establishes the CI foundation for the rewrite.

Closes #1944