### PR TITLE
feat: Go coordinator skeleton + CI workflow + unit tests (issue #1944)

### DIFF
--- a/.github/workflows/build-coordinator-go.yml
+++ b/.github/workflows/build-coordinator-go.yml
@@ -1,0 +1,43 @@
+name: Build & Test coordinator-go
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/coordinator-go/**'
+  pull_request:
+    paths:
+      - 'images/coordinator-go/**'
+
+jobs:
+  build-and-test:
+    name: go build + vet + test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: images/coordinator-go/go.sum
+
+      - name: Install gcc (required for CGO/go-sqlite3)
+        run: sudo apt-get install -y gcc
+
+      - name: Download modules
+        working-directory: images/coordinator-go
+        run: go mod download
+
+      - name: go build
+        working-directory: images/coordinator-go
+        run: CGO_ENABLED=1 go build ./...
+
+      - name: go vet
+        working-directory: images/coordinator-go
+        run: CGO_ENABLED=1 go vet ./...
+
+      - name: go test
+        working-directory: images/coordinator-go
+        run: CGO_ENABLED=1 go test -v -race ./...

--- a/images/coordinator-go/Dockerfile
+++ b/images/coordinator-go/Dockerfile
@@ -1,0 +1,34 @@
+# Multi-stage build for the agentex Go coordinator (issue #1825, #1827).
+# CGO is required for go-sqlite3.
+
+# --- build stage ---
+FROM golang:1.22-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 go build -o /bin/coordinator ./...
+
+# --- runtime stage ---
+FROM alpine:3.19
+
+RUN apk add --no-cache ca-certificates sqlite
+
+COPY --from=builder /bin/coordinator /usr/local/bin/coordinator
+
+RUN mkdir -p /data && chmod 755 /data
+
+# Non-root user for Kubernetes PSA restricted.
+RUN addgroup -S agentex && adduser -S agentex -G agentex
+USER agentex
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/coordinator"]
+CMD ["--db", "/data/coordinator.db", "--addr", ":8080"]

--- a/images/coordinator-go/README.md
+++ b/images/coordinator-go/README.md
@@ -1,0 +1,61 @@
+# coordinator-go
+
+Go rewrite of the agentex coordinator (epic [#1825](https://github.com/pnz1990/agentex/issues/1825),
+structured work ledger [#1827](https://github.com/pnz1990/agentex/issues/1827)).
+
+## Status
+
+Skeleton — all API endpoints return `501 Not Implemented` except `GET /health`.
+CI runs `go build`, `go vet`, and `go test` on every PR that touches this directory.
+
+## Architecture
+
+```
+main.go                    HTTP server with graceful shutdown
+internal/
+  db/db.go                 SQLite initialization + schema (9 tables, 6 views, triggers)
+  api/handlers.go          HTTP handler stubs (all routes registered, 501 until implemented)
+  models/models.go         Typed Go structs for all schema entities
+Dockerfile                 Multi-stage build (CGO required for go-sqlite3)
+```
+
+## API Endpoints
+
+| Method | Path | Status | Replaces |
+|--------|------|--------|---------|
+| GET | `/health` | ✅ Implemented | — |
+| GET | `/api/tasks` | 🔧 Stub | `coordinator-state.taskQueue` |
+| POST | `/api/tasks` | 🔧 Stub | — |
+| POST | `/api/tasks/claim` | 🔧 Stub | `claim_task()` in helpers.sh |
+| GET | `/api/tasks/{id}` | 🔧 Stub | — |
+| PATCH | `/api/tasks/{id}` | 🔧 Stub | — |
+| GET | `/api/agents` | 🔧 Stub | `coordinator-state.activeAgents` |
+| POST | `/api/agents/register` | 🔧 Stub | — |
+| POST | `/api/agents/heartbeat` | 🔧 Stub | — |
+| GET | `/api/agents/{name}` | 🔧 Stub | S3 identity files |
+| GET | `/api/proposals` | 🔧 Stub | `coordinator-state.voteRegistry` |
+| POST | `/api/proposals` | 🔧 Stub | — |
+| POST | `/api/proposals/{id}/vote` | 🔧 Stub | — |
+| POST | `/api/spawn/acquire` | 🔧 Stub | `request_spawn_slot()` |
+| POST | `/api/spawn/release` | 🔧 Stub | — |
+| GET | `/api/spawn/slots` | 🔧 Stub | `coordinator-state.spawnSlots` |
+| GET | `/api/debates` | 🔧 Stub | S3 `debates/` prefix |
+| POST | `/api/debates` | 🔧 Stub | `record_debate_outcome()` |
+
+## Building
+
+```bash
+# Requires CGO (for go-sqlite3)
+CGO_ENABLED=1 go build ./...
+CGO_ENABLED=1 go test ./...
+
+# Docker (multi-stage, CGO via gcc in alpine)
+docker build -t agentex/coordinator-go .
+```
+
+## Next Steps
+
+1. Implement `POST /api/tasks/claim` with `BEGIN IMMEDIATE` transaction (issue [#1932](https://github.com/pnz1990/agentex/issues/1932))
+2. Implement agent registration and heartbeat
+3. Implement governance voting engine
+4. Replace `coordinator-state` ConfigMap reads with API calls in `helpers.sh`

--- a/images/coordinator-go/go.mod
+++ b/images/coordinator-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/pnz1990/agentex/coordinator
+
+go 1.22
+
+require github.com/mattn/go-sqlite3 v1.14.22

--- a/images/coordinator-go/go.sum
+++ b/images/coordinator-go/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/images/coordinator-go/internal/api/handlers.go
+++ b/images/coordinator-go/internal/api/handlers.go
@@ -1,0 +1,210 @@
+// Package api provides HTTP handler stubs for the agentex coordinator API.
+// All endpoints currently return 501 Not Implemented — they are ready for
+// incremental implementation (issue #1825, #1827).
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+	"github.com/pnz1990/agentex/coordinator/internal/models"
+)
+
+// Handler holds the shared dependencies for all API handlers.
+type Handler struct {
+	db        *db.DB
+	startTime time.Time
+}
+
+// New creates a Handler with the given database.
+func New(database *db.DB) *Handler {
+	return &Handler{
+		db:        database,
+		startTime: time.Now(),
+	}
+}
+
+// RegisterRoutes registers all coordinator API routes on mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	// Health
+	mux.HandleFunc("GET /health", h.Health)
+
+	// Tasks
+	mux.HandleFunc("GET /api/tasks", h.ListTasks)
+	mux.HandleFunc("POST /api/tasks", h.CreateTask)
+	mux.HandleFunc("POST /api/tasks/claim", h.ClaimTask)
+	mux.HandleFunc("GET /api/tasks/{id}", h.GetTask)
+	mux.HandleFunc("PATCH /api/tasks/{id}", h.UpdateTask)
+
+	// Agents
+	mux.HandleFunc("GET /api/agents", h.ListAgents)
+	mux.HandleFunc("POST /api/agents/register", h.RegisterAgent)
+	mux.HandleFunc("POST /api/agents/heartbeat", h.AgentHeartbeat)
+	mux.HandleFunc("GET /api/agents/{name}", h.GetAgent)
+
+	// Governance
+	mux.HandleFunc("GET /api/proposals", h.ListProposals)
+	mux.HandleFunc("POST /api/proposals", h.CreateProposal)
+	mux.HandleFunc("POST /api/proposals/{id}/vote", h.VoteOnProposal)
+
+	// Spawn slots (circuit breaker)
+	mux.HandleFunc("POST /api/spawn/acquire", h.AcquireSpawnSlot)
+	mux.HandleFunc("POST /api/spawn/release", h.ReleaseSpawnSlot)
+	mux.HandleFunc("GET /api/spawn/slots", h.GetSpawnSlots)
+
+	// Debate outcomes
+	mux.HandleFunc("GET /api/debates", h.ListDebates)
+	mux.HandleFunc("POST /api/debates", h.RecordDebateOutcome)
+}
+
+// Health returns 200 with coordinator status. This is the only implemented endpoint.
+func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	dbOK := h.db.Ping() == nil
+	status := "ok"
+	if !dbOK {
+		status = "degraded"
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	resp := models.HealthStatus{
+		Status:  status,
+		DBPing:  dbOK,
+		Uptime:  time.Since(h.startTime).Round(time.Second).String(),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- Task handlers (all stub: 501 Not Implemented) ---
+
+// ListTasks returns all tasks filtered by status.
+// GET /api/tasks?status=pending
+func (h *Handler) ListTasks(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ListTasks")
+}
+
+// CreateTask adds a task to the work ledger.
+// POST /api/tasks {"issue_number": 123, "title": "...", "labels": "bug,enhancement"}
+func (h *Handler) CreateTask(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "CreateTask")
+}
+
+// ClaimTask atomically claims the next available task for an agent.
+// POST /api/tasks/claim {"agent_name": "worker-123", "specialization": "debugger"}
+// Uses BEGIN IMMEDIATE transaction to prevent double-claims.
+func (h *Handler) ClaimTask(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ClaimTask")
+}
+
+// GetTask returns a single task by ID.
+// GET /api/tasks/{id}
+func (h *Handler) GetTask(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "GetTask")
+}
+
+// UpdateTask updates task status (e.g. mark done/failed).
+// PATCH /api/tasks/{id} {"status": "done"}
+func (h *Handler) UpdateTask(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "UpdateTask")
+}
+
+// --- Agent handlers ---
+
+// ListAgents returns all active agents.
+// GET /api/agents
+func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ListAgents")
+}
+
+// RegisterAgent registers a new agent in the work ledger.
+// POST /api/agents/register {"name": "worker-123", "role": "worker", "generation": 4}
+func (h *Handler) RegisterAgent(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "RegisterAgent")
+}
+
+// AgentHeartbeat updates an agent's last_seen_at timestamp.
+// POST /api/agents/heartbeat {"agent_name": "worker-123"}
+func (h *Handler) AgentHeartbeat(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "AgentHeartbeat")
+}
+
+// GetAgent returns a single agent by name.
+// GET /api/agents/{name}
+func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "GetAgent")
+}
+
+// --- Governance handlers ---
+
+// ListProposals returns open governance proposals.
+// GET /api/proposals
+func (h *Handler) ListProposals(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ListProposals")
+}
+
+// CreateProposal submits a new governance proposal.
+// POST /api/proposals {"topic": "circuit-breaker", "content": "..."}
+func (h *Handler) CreateProposal(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "CreateProposal")
+}
+
+// VoteOnProposal records a vote on an open proposal.
+// POST /api/proposals/{id}/vote {"agent_name": "planner-001", "vote": "approve", "reason": "..."}
+func (h *Handler) VoteOnProposal(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "VoteOnProposal")
+}
+
+// --- Spawn slot handlers ---
+
+// AcquireSpawnSlot allocates a spawn slot (circuit breaker check).
+// POST /api/spawn/acquire {"agent_name": "worker-456"}
+func (h *Handler) AcquireSpawnSlot(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "AcquireSpawnSlot")
+}
+
+// ReleaseSpawnSlot frees a spawn slot when an agent finishes.
+// POST /api/spawn/release {"agent_name": "worker-456"}
+func (h *Handler) ReleaseSpawnSlot(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ReleaseSpawnSlot")
+}
+
+// GetSpawnSlots returns current spawn slot counts.
+// GET /api/spawn/slots
+func (h *Handler) GetSpawnSlots(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "GetSpawnSlots")
+}
+
+// --- Debate handlers ---
+
+// ListDebates returns debate outcomes, optionally filtered by topic.
+// GET /api/debates?topic=circuit-breaker
+func (h *Handler) ListDebates(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "ListDebates")
+}
+
+// RecordDebateOutcome persists a debate resolution.
+// POST /api/debates {"thread_id": "abc123", "topic": "ttl", "outcome": "synthesized", "resolution": "..."}
+func (h *Handler) RecordDebateOutcome(w http.ResponseWriter, r *http.Request) {
+	notImplemented(w, "RecordDebateOutcome")
+}
+
+// --- helpers ---
+
+type notImplementedResponse struct {
+	Error    string `json:"error"`
+	Endpoint string `json:"endpoint"`
+}
+
+func notImplemented(w http.ResponseWriter, endpoint string) {
+	writeJSON(w, http.StatusNotImplemented, notImplementedResponse{
+		Error:    "not implemented",
+		Endpoint: endpoint,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/images/coordinator-go/internal/api/handlers_test.go
+++ b/images/coordinator-go/internal/api/handlers_test.go
@@ -1,0 +1,115 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/pnz1990/agentex/coordinator/internal/api"
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+	"github.com/pnz1990/agentex/coordinator/internal/models"
+)
+
+func newTestHandler(t *testing.T) *api.Handler {
+	t.Helper()
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open failed: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return api.New(database)
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /health: want 200, got %d", rr.Code)
+	}
+
+	var status models.HealthStatus
+	if err := json.NewDecoder(rr.Body).Decode(&status); err != nil {
+		t.Fatalf("decode /health response: %v", err)
+	}
+	if status.Status != "ok" {
+		t.Errorf("health status: want %q, got %q", "ok", status.Status)
+	}
+	if !status.DBPing {
+		t.Error("health.db_ping: want true, got false")
+	}
+}
+
+// stubEndpoints lists all endpoints that should return 501 Not Implemented.
+var stubEndpoints = []struct {
+	method string
+	path   string
+}{
+	{http.MethodGet, "/api/tasks"},
+	{http.MethodPost, "/api/tasks"},
+	{http.MethodPost, "/api/tasks/claim"},
+	{http.MethodGet, "/api/agents"},
+	{http.MethodPost, "/api/agents/register"},
+	{http.MethodPost, "/api/agents/heartbeat"},
+	{http.MethodGet, "/api/proposals"},
+	{http.MethodPost, "/api/proposals"},
+	{http.MethodPost, "/api/spawn/acquire"},
+	{http.MethodPost, "/api/spawn/release"},
+	{http.MethodGet, "/api/spawn/slots"},
+	{http.MethodGet, "/api/debates"},
+	{http.MethodPost, "/api/debates"},
+}
+
+func TestStubEndpointsReturn501(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	for _, ep := range stubEndpoints {
+		t.Run(ep.method+" "+ep.path, func(t *testing.T) {
+			req := httptest.NewRequest(ep.method, ep.path, nil)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusNotImplemented {
+				t.Errorf("%s %s: want 501, got %d", ep.method, ep.path, rr.Code)
+			}
+
+			// Response must be valid JSON.
+			var resp map[string]any
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Errorf("%s %s: response not valid JSON: %v", ep.method, ep.path, err)
+			}
+			if resp["error"] != "not implemented" {
+				t.Errorf("%s %s: want error='not implemented', got %v", ep.method, ep.path, resp["error"])
+			}
+		})
+	}
+}
+
+func TestResponseContentType(t *testing.T) {
+	h := newTestHandler(t)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	for _, ep := range append(stubEndpoints, struct{ method, path string }{http.MethodGet, "/health"}) {
+		t.Run(ep.method+" "+ep.path, func(t *testing.T) {
+			req := httptest.NewRequest(ep.method, ep.path, nil)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			ct := rr.Header().Get("Content-Type")
+			if ct != "application/json" {
+				t.Errorf("%s %s: Content-Type want application/json, got %q", ep.method, ep.path, ct)
+			}
+		})
+	}
+}

--- a/images/coordinator-go/internal/db/db.go
+++ b/images/coordinator-go/internal/db/db.go
@@ -1,0 +1,221 @@
+// Package db provides SQLite database initialization and schema management
+// for the agentex Go coordinator rewrite (issue #1825, #1827).
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// DB wraps a *sql.DB with coordinator-specific helpers.
+type DB struct {
+	*sql.DB
+}
+
+// Open opens (or creates) the SQLite database at path and applies the schema.
+func Open(path string) (*DB, error) {
+	sqlDB, err := sql.Open("sqlite3", path+"?_journal_mode=WAL&_foreign_keys=on")
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+
+	db := &DB{sqlDB}
+	if err := db.applySchema(); err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("apply schema: %w", err)
+	}
+	return db, nil
+}
+
+// Ping verifies the database is reachable.
+func (db *DB) Ping() error {
+	return db.DB.Ping()
+}
+
+// applySchema creates all tables, indexes, triggers, and compatibility views.
+func (db *DB) applySchema() error {
+	_, err := db.Exec(schema)
+	return err
+}
+
+// schema is the full SQLite DDL for the coordinator work ledger.
+// Designed to replace coordinator-state ConfigMap string fields with
+// typed, queryable relational data (issue #1827).
+const schema = `
+-- Tasks (replaces coordinator-state.taskQueue + activeAssignments)
+CREATE TABLE IF NOT EXISTS tasks (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_number INTEGER NOT NULL,
+    title        TEXT    NOT NULL,
+    status       TEXT    NOT NULL DEFAULT 'pending'
+                         CHECK (status IN ('pending','assigned','in_progress','done','failed')),
+    assigned_to  TEXT    NOT NULL DEFAULT '',
+    priority     INTEGER NOT NULL DEFAULT 0,
+    labels       TEXT    NOT NULL DEFAULT '',
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    claimed_at   DATETIME,
+    completed_at DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status        ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_issue_number  ON tasks(issue_number);
+CREATE INDEX IF NOT EXISTS idx_tasks_assigned_to   ON tasks(assigned_to);
+CREATE INDEX IF NOT EXISTS idx_tasks_priority      ON tasks(priority DESC);
+
+-- Agents (replaces coordinator-state.activeAgents + S3 identity files)
+CREATE TABLE IF NOT EXISTS agents (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    name            TEXT    NOT NULL UNIQUE,
+    display_name    TEXT    NOT NULL DEFAULT '',
+    role            TEXT    NOT NULL
+                            CHECK (role IN ('planner','worker','reviewer','architect','god-delegate','seed')),
+    generation      INTEGER NOT NULL DEFAULT 0,
+    specialization  TEXT    NOT NULL DEFAULT '',
+    status          TEXT    NOT NULL DEFAULT 'active'
+                            CHECK (status IN ('active','completed','failed')),
+    started_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at    DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_agents_role         ON agents(role);
+CREATE INDEX IF NOT EXISTS idx_agents_status       ON agents(status);
+CREATE INDEX IF NOT EXISTS idx_agents_generation   ON agents(generation);
+
+-- Thoughts (in-cluster Thought CR mirror for querying)
+CREATE TABLE IF NOT EXISTS thoughts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT    NOT NULL UNIQUE,
+    agent_ref    TEXT    NOT NULL,
+    task_ref     TEXT    NOT NULL DEFAULT '',
+    thought_type TEXT    NOT NULL
+                         CHECK (thought_type IN ('insight','proposal','vote','debate','directive','blocker','planning','chronicle-candidate','report')),
+    confidence   INTEGER NOT NULL DEFAULT 5 CHECK (confidence BETWEEN 1 AND 10),
+    content      TEXT    NOT NULL,
+    parent_ref   TEXT    NOT NULL DEFAULT '',
+    topic        TEXT    NOT NULL DEFAULT '',
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_agent_ref    ON thoughts(agent_ref);
+CREATE INDEX IF NOT EXISTS idx_thoughts_thought_type ON thoughts(thought_type);
+CREATE INDEX IF NOT EXISTS idx_thoughts_topic        ON thoughts(topic);
+CREATE INDEX IF NOT EXISTS idx_thoughts_parent_ref   ON thoughts(parent_ref);
+CREATE INDEX IF NOT EXISTS idx_thoughts_created_at   ON thoughts(created_at DESC);
+
+-- Debate outcomes (replaces S3 debates/ prefix)
+CREATE TABLE IF NOT EXISTS debate_outcomes (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id    TEXT    NOT NULL UNIQUE,
+    topic        TEXT    NOT NULL,
+    outcome      TEXT    NOT NULL
+                         CHECK (outcome IN ('synthesized','consensus-agree','consensus-disagree','unresolved')),
+    resolution   TEXT    NOT NULL,
+    participants TEXT    NOT NULL DEFAULT '[]',
+    recorded_by  TEXT    NOT NULL,
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_debate_outcomes_topic   ON debate_outcomes(topic);
+CREATE INDEX IF NOT EXISTS idx_debate_outcomes_outcome ON debate_outcomes(outcome);
+
+-- Governance proposals and votes (replaces coordinator-state.voteRegistry)
+CREATE TABLE IF NOT EXISTS governance_proposals (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    proposal_id   TEXT    NOT NULL UNIQUE,
+    topic         TEXT    NOT NULL,
+    agent_ref     TEXT    NOT NULL,
+    content       TEXT    NOT NULL,
+    status        TEXT    NOT NULL DEFAULT 'open'
+                          CHECK (status IN ('open','enacted','rejected')),
+    approve_count INTEGER NOT NULL DEFAULT 0,
+    reject_count  INTEGER NOT NULL DEFAULT 0,
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    enacted_at    DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS governance_votes (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    proposal_id TEXT    NOT NULL REFERENCES governance_proposals(proposal_id),
+    agent_ref   TEXT    NOT NULL,
+    vote        TEXT    NOT NULL CHECK (vote IN ('approve','reject','abstain')),
+    reason      TEXT    NOT NULL DEFAULT '',
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (proposal_id, agent_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_governance_votes_proposal ON governance_votes(proposal_id);
+
+-- Spawn slots (replaces coordinator-state.spawnSlots CAS logic)
+CREATE TABLE IF NOT EXISTS spawn_slots (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_name   TEXT    NOT NULL,
+    allocated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    released_at  DATETIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_spawn_slots_released ON spawn_slots(released_at);
+
+-- Planning state (replaces S3 planning/ prefix for N+2 coordination)
+CREATE TABLE IF NOT EXISTS planning_states (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    role        TEXT    NOT NULL,
+    agent_name  TEXT    NOT NULL,
+    generation  INTEGER NOT NULL,
+    my_work     TEXT    NOT NULL DEFAULT '',
+    n1_priority TEXT    NOT NULL DEFAULT '',
+    n2_priority TEXT    NOT NULL DEFAULT '',
+    blockers    TEXT    NOT NULL DEFAULT '',
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_planning_states_generation ON planning_states(generation DESC);
+CREATE INDEX IF NOT EXISTS idx_planning_states_role       ON planning_states(role);
+
+-- Triggers: auto-update updated_at on tasks
+CREATE TRIGGER IF NOT EXISTS tasks_updated_at
+    AFTER UPDATE ON tasks
+    FOR EACH ROW
+BEGIN
+    UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+-- Compatibility views (allow coordinator shell to query via sqlite3 CLI)
+CREATE VIEW IF NOT EXISTS active_agents AS
+    SELECT name, display_name, role, generation, specialization, last_seen_at
+    FROM agents
+    WHERE status = 'active';
+
+CREATE VIEW IF NOT EXISTS pending_tasks AS
+    SELECT id, issue_number, title, priority, labels, created_at
+    FROM tasks
+    WHERE status = 'pending'
+    ORDER BY priority DESC, created_at ASC;
+
+CREATE VIEW IF NOT EXISTS active_assignments AS
+    SELECT assigned_to, issue_number, title, claimed_at
+    FROM tasks
+    WHERE status IN ('assigned','in_progress') AND assigned_to != '';
+
+CREATE VIEW IF NOT EXISTS open_proposals AS
+    SELECT proposal_id, topic, agent_ref, approve_count, reject_count, created_at
+    FROM governance_proposals
+    WHERE status = 'open'
+    ORDER BY created_at DESC;
+
+CREATE VIEW IF NOT EXISTS debate_backlog AS
+    SELECT t.name, t.agent_ref, t.topic, t.created_at
+    FROM thoughts t
+    WHERE t.thought_type = 'debate'
+      AND t.name NOT IN (SELECT 'thought-' || thread_id FROM debate_outcomes);
+
+CREATE VIEW IF NOT EXISTS recent_insights AS
+    SELECT name, agent_ref, confidence, topic, content, created_at
+    FROM thoughts
+    WHERE thought_type = 'insight'
+    ORDER BY created_at DESC
+    LIMIT 50;
+`

--- a/images/coordinator-go/internal/db/db_test.go
+++ b/images/coordinator-go/internal/db/db_test.go
@@ -1,0 +1,143 @@
+package db_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+)
+
+func TestOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	database, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open(%q) failed: %v", path, err)
+	}
+	defer database.Close()
+
+	if err := database.Ping(); err != nil {
+		t.Fatalf("Ping() failed after Open: %v", err)
+	}
+}
+
+func TestSchemaTables(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open failed: %v", err)
+	}
+	defer database.Close()
+
+	// All 9 tables that must exist after schema application.
+	want := []string{
+		"tasks",
+		"agents",
+		"thoughts",
+		"debate_outcomes",
+		"governance_proposals",
+		"governance_votes",
+		"spawn_slots",
+		"planning_states",
+	}
+
+	for _, table := range want {
+		t.Run("table/"+table, func(t *testing.T) {
+			var name string
+			err := database.QueryRow(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name=?", table,
+			).Scan(&name)
+			if err != nil {
+				t.Fatalf("table %q not found in schema: %v", table, err)
+			}
+			if name != table {
+				t.Fatalf("expected table %q, got %q", table, name)
+			}
+		})
+	}
+}
+
+func TestSchemaViews(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open failed: %v", err)
+	}
+	defer database.Close()
+
+	want := []string{
+		"active_agents",
+		"pending_tasks",
+		"active_assignments",
+		"open_proposals",
+		"debate_backlog",
+		"recent_insights",
+	}
+
+	for _, view := range want {
+		t.Run("view/"+view, func(t *testing.T) {
+			var name string
+			err := database.QueryRow(
+				"SELECT name FROM sqlite_master WHERE type='view' AND name=?", view,
+			).Scan(&name)
+			if err != nil {
+				t.Fatalf("view %q not found in schema: %v", view, err)
+			}
+		})
+	}
+}
+
+func TestSchemaIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Open twice — schema must be idempotent (IF NOT EXISTS guards).
+	db1, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("first Open failed: %v", err)
+	}
+	db1.Close()
+
+	db2, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("second Open failed (schema not idempotent): %v", err)
+	}
+	defer db2.Close()
+}
+
+func TestOpenMissingDirectory(t *testing.T) {
+	// Opening a db in a non-existent directory should fail.
+	_, err := db.Open("/nonexistent/path/test.db")
+	if err == nil {
+		t.Fatal("expected error opening db in non-existent directory, got nil")
+	}
+}
+
+func TestInsertTask(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("db.Open failed: %v", err)
+	}
+	defer database.Close()
+
+	_, err = database.Exec(`
+		INSERT INTO tasks (issue_number, title, labels)
+		VALUES (1234, 'test task', 'bug,enhancement')
+	`)
+	if err != nil {
+		t.Fatalf("INSERT into tasks failed: %v", err)
+	}
+
+	var count int
+	database.QueryRow("SELECT COUNT(*) FROM tasks WHERE issue_number=1234").Scan(&count)
+	if count != 1 {
+		t.Fatalf("expected 1 task, got %d", count)
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/images/coordinator-go/internal/models/models.go
+++ b/images/coordinator-go/internal/models/models.go
@@ -1,0 +1,110 @@
+package models
+
+import "time"
+
+// Task represents an agent work item (replaces coordinator-state.taskQueue + activeAssignments).
+type Task struct {
+	ID          int64     `db:"id"`
+	IssueNumber int       `db:"issue_number"`
+	Title       string    `db:"title"`
+	Status      string    `db:"status"` // pending, assigned, in_progress, done, failed
+	AssignedTo  string    `db:"assigned_to"`
+	Priority    int       `db:"priority"`
+	Labels      string    `db:"labels"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+	ClaimedAt   *time.Time `db:"claimed_at"`
+	CompletedAt *time.Time `db:"completed_at"`
+}
+
+// Agent represents an active or historical agent (replaces coordinator-state.activeAgents + S3 identity files).
+type Agent struct {
+	ID             int64     `db:"id"`
+	Name           string    `db:"name"`         // e.g. worker-1773190398
+	DisplayName    string    `db:"display_name"` // e.g. ada
+	Role           string    `db:"role"`         // planner, worker, reviewer, architect
+	Generation     int       `db:"generation"`
+	Specialization string    `db:"specialization"`
+	Status         string    `db:"status"` // active, completed, failed
+	StartedAt      time.Time `db:"started_at"`
+	LastSeenAt     time.Time `db:"last_seen_at"`
+	CompletedAt    *time.Time `db:"completed_at"`
+}
+
+// Thought represents a Thought CR (in-cluster coordination signal).
+type Thought struct {
+	ID          int64     `db:"id"`
+	Name        string    `db:"name"`
+	AgentRef    string    `db:"agent_ref"`
+	TaskRef     string    `db:"task_ref"`
+	ThoughtType string    `db:"thought_type"` // insight, proposal, vote, debate, directive, blocker
+	Confidence  int       `db:"confidence"`
+	Content     string    `db:"content"`
+	ParentRef   string    `db:"parent_ref"`
+	Topic       string    `db:"topic"`
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+// DebateOutcome represents a resolved debate thread stored in S3.
+type DebateOutcome struct {
+	ID           int64     `db:"id"`
+	ThreadID     string    `db:"thread_id"`
+	Topic        string    `db:"topic"`
+	Outcome      string    `db:"outcome"` // synthesized, consensus-agree, consensus-disagree, unresolved
+	Resolution   string    `db:"resolution"`
+	Participants string    `db:"participants"` // JSON array
+	RecordedBy   string    `db:"recorded_by"`
+	CreatedAt    time.Time `db:"created_at"`
+}
+
+// GovernanceVote represents a tallied governance vote.
+type GovernanceVote struct {
+	ID        int64     `db:"id"`
+	ProposalID string   `db:"proposal_id"`
+	AgentRef  string    `db:"agent_ref"`
+	Vote      string    `db:"vote"` // approve, reject, abstain
+	Reason    string    `db:"reason"`
+	CreatedAt time.Time `db:"created_at"`
+}
+
+// GovernanceProposal represents a governance change proposal.
+type GovernanceProposal struct {
+	ID          int64     `db:"id"`
+	Topic       string    `db:"topic"`
+	AgentRef    string    `db:"agent_ref"`
+	Content     string    `db:"content"`
+	Status      string    `db:"status"` // open, enacted, rejected
+	ApproveCount int      `db:"approve_count"`
+	RejectCount  int      `db:"reject_count"`
+	CreatedAt   time.Time `db:"created_at"`
+	EnactedAt   *time.Time `db:"enacted_at"`
+}
+
+// SpawnSlot represents the atomic spawn control state.
+type SpawnSlot struct {
+	ID          int64     `db:"id"`
+	AgentName   string    `db:"agent_name"`
+	AllocatedAt time.Time `db:"allocated_at"`
+	ReleasedAt  *time.Time `db:"released_at"`
+}
+
+// PlanningState represents a generation's N+2 coordination plan.
+type PlanningState struct {
+	ID          int64     `db:"id"`
+	Role        string    `db:"role"`
+	AgentName   string    `db:"agent_name"`
+	Generation  int       `db:"generation"`
+	MyWork      string    `db:"my_work"`
+	N1Priority  string    `db:"n1_priority"`
+	N2Priority  string    `db:"n2_priority"`
+	Blockers    string    `db:"blockers"`
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+// HealthStatus represents the coordinator's health check response.
+type HealthStatus struct {
+	Status     string `json:"status"`
+	DBPing     bool   `json:"db_ping"`
+	Generation int    `json:"generation"`
+	Uptime     string `json:"uptime"`
+}

--- a/images/coordinator-go/main.go
+++ b/images/coordinator-go/main.go
@@ -1,0 +1,82 @@
+// Command coordinator is the agentex Go coordinator server.
+// It replaces the bash coordinator.sh with a typed, queryable HTTP API
+// backed by SQLite (issue #1825, #1827).
+//
+// Usage:
+//
+//	coordinator [--db /path/to/db.sqlite] [--addr :8080]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pnz1990/agentex/coordinator/internal/api"
+	"github.com/pnz1990/agentex/coordinator/internal/db"
+)
+
+func main() {
+	dbPath := flag.String("db", "/data/coordinator.db", "SQLite database path")
+	addr := flag.String("addr", ":8080", "HTTP listen address")
+	flag.Parse()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	slog.Info("starting agentex coordinator", "db", *dbPath, "addr", *addr)
+
+	database, err := db.Open(*dbPath)
+	if err != nil {
+		slog.Error("failed to open database", "error", err)
+		os.Exit(1)
+	}
+	defer database.Close()
+
+	slog.Info("database initialized", "db", *dbPath)
+
+	h := api.New(database)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Graceful shutdown on SIGTERM/SIGINT.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	go func() {
+		slog.Info("coordinator listening", "addr", *addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("listen error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	slog.Info("shutdown signal received")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("shutdown error", "error", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("coordinator stopped")
+}


### PR DESCRIPTION
## Summary

Implements the Go coordinator skeleton and CI infrastructure required for the
coordinator rewrite (epic #1825, #1827). This is the deliverable for issue #1944.

Closes #1944

## What this adds

### `images/coordinator-go/` — new Go module

| File | Purpose |
|---|---|
| `main.go` | HTTP server with graceful shutdown (SIGTERM/SIGINT), structured JSON logging |
| `internal/db/db.go` | SQLite initialization with 9-table work-ledger schema, 6 views, triggers |
| `internal/api/handlers.go` | 18 route stubs returning 501 Not Implemented; `GET /health` fully implemented |
| `internal/models/models.go` | Typed Go structs for all schema entities |
| `Dockerfile` | Multi-stage CGO build, non-root user (PSA restricted) |
| `go.mod` / `go.sum` | Module with `go-sqlite3` dependency |

### CI: `.github/workflows/build-coordinator-go.yml`

Triggers on PRs and main-branch pushes touching `images/coordinator-go/**`:
- `go build ./...` (CGO_ENABLED=1 + gcc)
- `go vet ./...`
- `go test -v -race ./...`

### Unit tests

`internal/db/db_test.go`:
- `TestOpen` — database file is created
- `TestSchemaTables` — all 9 tables exist after initialization
- `TestSchemaViews` — all 6 compatibility views exist
- `TestSchemaIdempotent` — opening an existing database doesn't fail
- `TestOpenMissingDirectory` — returns error for non-existent path
- `TestInsertTask` — basic row insertion works

`internal/api/handlers_test.go`:
- `TestHealthEndpoint` — returns 200, `status=ok`, `db_ping=true`
- `TestStubEndpointsReturn501` — all 13 stub endpoints return 501 with JSON `error=not implemented`
- `TestResponseContentType` — all endpoints set `Content-Type: application/json`

## Schema design

9 tables replacing coordinator-state ConfigMap string fields:

| Table | Replaces |
|---|---|
| `tasks` | `coordinator-state.taskQueue` + `activeAssignments` |
| `agents` | `coordinator-state.activeAgents` + S3 identity files |
| `thoughts` | Thought CR mirror for queryable access |
| `debate_outcomes` | S3 `debates/` prefix |
| `governance_proposals` + `governance_votes` | `coordinator-state.voteRegistry` |
| `spawn_slots` | `coordinator-state.spawnSlots` CAS logic |
| `planning_states` | S3 `planning/` prefix |

## Next steps

1. Implement `POST /api/tasks/claim` with `BEGIN IMMEDIATE` transaction
2. Implement agent registration + heartbeat
3. Wire governance voting engine
4. Replace `helpers.sh` ConfigMap reads with API calls