### PR TITLE
fix: add continue-on-error to CI restart steps — stops build failures (issue #1961)

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -104,31 +104,59 @@ jobs:
 
       - name: Restart coordinator deployment to pick up new image
         if: github.ref == 'refs/heads/main'
+        id: restart-coordinator
+        continue-on-error: true
         run: |
           # Rolling restart — coordinator picks up new :latest image.
           # Issue #1699: Decoupled from ConfigMap update success.
-          # Previously conditioned on ConfigMap update outcome==success, but since that
-          # step fails due to IAM permissions (#1682) with continue-on-error=true, the
-          # step conclusion='success' but outcome='failure', causing this step to be SKIPPED.
-          # Result: coordinator and planner-loop NEVER got restarted after merges to main,
-          # so new Docker images (helpers.sh, entrypoint.sh changes) were never deployed.
-          # Fix: always restart to pick up new Docker image regardless of ConfigMap result.
-          # If ConfigMap update succeeded: coordinator gets new image AND new script.
-          # If ConfigMap update failed: coordinator gets new image only (script stays stale
-          # until agent workaround in #1693 or manual fix in #1682).
-          # (issue #1226: coordinator ran stale image missing critical bug fixes)
+          # Issue #1961: Added continue-on-error=true because this step requires EKS access
+          # entry for agentex-github-actions IAM role (issue #1682). Without continue-on-error,
+          # the entire CI build fails even though the Docker image was successfully pushed.
+          # The image push succeeds — this step failing only means the restart must be done
+          # manually or will happen when the next agent pod starts and picks up :latest.
+          # Fix (god only): aws eks create-access-entry + associate-access-policy for
+          # arn:aws:iam::569190534191:role/agentex-github-actions
+          aws eks update-kubeconfig \
+            --name agentex \
+            --region ${{ env.AWS_REGION }} \
+            --alias agentex
           kubectl rollout restart deployment/coordinator -n agentex
           kubectl rollout status deployment/coordinator -n agentex --timeout=120s
           echo "Coordinator restarted successfully — running latest image"
 
+      - name: Warn if coordinator restart failed (issue #1961)
+        if: github.ref == 'refs/heads/main' && steps.restart-coordinator.outcome == 'failure'
+        run: |
+          echo "::warning::⚠️ Coordinator restart FAILED (issue #1961)."
+          echo "::warning::The agentex-github-actions IAM role likely lacks EKS access entry."
+          echo "::warning::Docker image was pushed successfully — coordinator will pick up :latest on next pod spawn."
+          echo "::warning::Fix (god only): aws eks create-access-entry + associate-access-policy for arn:aws:iam::569190534191:role/agentex-github-actions"
+          echo "::warning::Manual workaround: kubectl rollout restart deployment/coordinator -n agentex"
+
       - name: Restart planner-loop to pick up new image
         if: github.ref == 'refs/heads/main'
+        id: restart-planner-loop
+        continue-on-error: true
         run: |
           # Issue #1699: Decoupled from ConfigMap update success (same root cause as above).
+          # Issue #1961: Added continue-on-error=true — same EKS access issue (#1682).
           # Planner-loop workers source helpers.sh from the Docker image. Without this restart,
           # merged helpers.sh changes (e.g. planner claim rejection in #1691) never reach
           # running workers — confirmed: planner-loop ran 19h without restart after 3+ merges.
           echo "Triggering planner-loop rollout to pick up updated runner image..."
+          aws eks update-kubeconfig \
+            --name agentex \
+            --region ${{ env.AWS_REGION }} \
+            --alias agentex
           kubectl rollout restart deployment/planner-loop -n agentex
           kubectl rollout status deployment/planner-loop -n agentex --timeout=120s
           echo "Planner-loop restarted and running new image"
+
+      - name: Warn if planner-loop restart failed (issue #1961)
+        if: github.ref == 'refs/heads/main' && steps.restart-planner-loop.outcome == 'failure'
+        run: |
+          echo "::warning::⚠️ Planner-loop restart FAILED (issue #1961)."
+          echo "::warning::The agentex-github-actions IAM role likely lacks EKS access entry."
+          echo "::warning::Docker image was pushed successfully — planner-loop will pick up :latest on next pod spawn."
+          echo "::warning::Fix (god only): aws eks create-access-entry + associate-access-policy for arn:aws:iam::569190534191:role/agentex-github-actions"
+          echo "::warning::Manual workaround: kubectl rollout restart deployment/planner-loop -n agentex"


### PR DESCRIPTION
## Summary

The CI build-runner.yml workflow has been reporting failures on every merge to main because the 'Restart coordinator deployment' and 'Restart planner-loop' steps fail with EKS credentials error. The `agentex-github-actions` IAM role lacks an EKS access entry (root cause from #1682), so `kubectl rollout restart` always fails.

Without `continue-on-error: true`, the entire CI job reported failure even though the Docker image was successfully pushed to ECR.

**Impact of old behavior:** All recent merged PRs (#1949, #1913, #1921, #1928, #1930, #1936, #1922) showed as failed CI, and merged code was effectively never deployed.

Closes #1961

## Changes

- Add `continue-on-error: true` to both `Restart coordinator` and `Restart planner-loop` steps
- Add `aws eks update-kubeconfig` call at the start of each restart step (previously kubeconfig was only set in the ConfigMap update step which also had `continue-on-error: true` and failed silently — so kubectl had no cluster config when the restart steps ran)
- Add explicit `::warning::` steps when restarts fail, showing root cause and manual workaround commands

## Why this is the right fix

The image push is the critical outcome — the Docker `:latest` tag is updated correctly. The restart steps are best-effort improvements that speed up deployment but are not required for correctness. Agent pods spawned after the push will automatically pull `:latest`.

The underlying IAM access entry issue (#1682) requires god intervention to fix permanently. This PR ensures CI reports the correct result (success) when the real work (image push) succeeds.