### PR TITLE
fix: filter god-locked issues from coordinator task queue (closes #1966)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -674,10 +674,28 @@ refresh_task_queue() {
     echo "[$(date -u +%H:%M:%S)] Fetching all actionable open issues (including unlabeled)..."
     # Issue #1570: Also filter out pull_request entries — REST /issues endpoint includes PRs.
     # GraphQL gh issue list excludes PRs automatically; REST does not.
+    # Issue #1966: Also filter out god-locked issues — issues with the god-locked label are
+    # reserved for god/architecture work and must not be claimed by agents. This prevents
+    # workers from repeatedly violating the god directive by implementing locked v1.0 epics.
     numbers=$(echo "$issues_json" | jq -r '.[] |
         select(.pull_request == null) |
         select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) |
+        select(.labels | map(.name) | contains(["god-locked"]) | not) |
         .number' 2>/dev/null | head -20)
+
+    # Issue #1966: Log how many god-locked issues were excluded from the queue.
+    local god_locked_count
+    god_locked_count=$(echo "$issues_json" | jq '[.[] |
+        select(.pull_request == null) |
+        select(.labels | map(.name) | contains(["god-locked"]))] | length' 2>/dev/null || echo "0")
+    if [ "${god_locked_count:-0}" -gt 0 ]; then
+        local god_locked_nums
+        god_locked_nums=$(echo "$issues_json" | jq -r '.[] |
+            select(.pull_request == null) |
+            select(.labels | map(.name) | contains(["god-locked"])) |
+            "#\(.number)"' 2>/dev/null | tr '\n' ' ')
+        echo "[$(date -u +%H:%M:%S)] Issue #1966: Filtered $god_locked_count god-locked issue(s) from task queue: $god_locked_nums"
+    fi
 
     for num in $numbers; do
         # Issue #1384: Skip issues that already have an open PR to prevent duplicate work.


### PR DESCRIPTION
## Summary

- Adds `god-locked` label filter to `refresh_task_queue()` in coordinator.sh
- Prevents agents from repeatedly claiming v1.0 epic issues that god has locked
- Adds observability logging when god-locked issues are filtered from the queue

## Problem

The coordinator's `refresh_task_queue()` had no mechanism to honor the god directive. Workers repeatedly claimed and implemented god-locked issues (#1839, #1844, #1846, #1847, #1909), wasting circuit breaker slots and requiring manual PR closures.

## Solution

Single-line jq filter addition in the issue number extraction:
```jq
select(.labels | map(.name) | contains(["god-locked"]) | not)
```

This filters out any issue with the `god-locked` label before adding it to the task queue. The filter uses labels already fetched in `issues_json` (no extra API calls).

## Behavior

- God adds `god-locked` label to issues agents should not work on
- Coordinator silently skips those issues during every queue refresh (~2.5min)  
- Log line shows count and numbers of filtered issues for observability
- If god removes the label, the issue re-enters the queue on the next refresh

## Testing

To verify: apply `god-locked` label to any open issue and confirm it no longer appears in `coordinator-state.taskQueue` after the next refresh cycle.

Closes #1966