### PR TITLE
fix: filter god-locked issues from coordinator task queue to prevent directive violations (issue #1966)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -679,7 +679,7 @@ refresh_task_queue() {
         select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) |
         .number' 2>/dev/null | head -20)
 
-    for num in $numbers; do
+     for num in $numbers; do
         # Issue #1384: Skip issues that already have an open PR to prevent duplicate work.
         if echo " $covered_issues " | grep -q " $num "; then
             echo "[$(date -u +%H:%M:%S)] Issue #1384: Skipping issue #$num — open PR already exists"
@@ -689,6 +689,15 @@ refresh_task_queue() {
         # Score based on labels already fetched (avoid extra API calls)
         local labels
         labels=$(echo "$issues_json" | jq -r --argjson n "$num" '.[] | select(.pull_request == null) | select(.number == $n) | [.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+        # Issue #1966: Skip issues with the "god-locked" label — these are locked by god directive
+        # and agents must not implement them. God applies this label to prevent wasted work on
+        # epics that require scaffolding (e.g., v1.0 Go rewrites). This check uses labels already
+        # fetched from the bulk issues query — no extra API calls needed.
+        if echo "$labels" | grep -q "god-locked"; then
+            echo "[$(date -u +%H:%M:%S)] Issue #1966: Skipping issue #$num — has god-locked label (directive violation prevention)"
+            continue
+        fi
 
         # Issue #1442: Accumulate label data for issueLabels cache (only for labeled issues)
         if [ -n "$labels" ]; then
@@ -4703,6 +4712,12 @@ route_tasks_by_specialization() {
         if [ -z "$issue_labels" ]; then
             issue_labels=$(gh issue view "$issue_num" --repo "${GITHUB_REPO}" \
                 --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+        fi
+
+        # Issue #1966: Skip issues with the "god-locked" label — locked by god directive.
+        if echo "$issue_labels" | grep -q "god-locked"; then
+            echo "[$(date -u +%H:%M:%S)] Issue #1966: Skipping routing for issue #$issue_num — has god-locked label"
+            continue
         fi
 
         # Find best specialized agent


### PR DESCRIPTION
## Summary

Prevents workers from repeatedly claiming and implementing locked v1.0 epics by adding
a `god-locked` label check to the coordinator's task queue refresh and routing functions.

Closes #1966

## Root Cause

The coordinator's `refresh_task_queue()` and `route_tasks_by_specialization()` fetched ALL
open GitHub issues without any filtering for god directives. The god directive 
'CRITICAL: DO NOT work on v1.0 epics' only exists as text — the coordinator had no way
to honor it.

**Observed on 2026-03-11:**
5 concurrent workers running on locked epics simultaneously:
- worker-1773190703: issue #1839 (Structured escalation protocol)
- worker-1773190713: issue #1844 (Multi-tier watchdog chain)
- worker-1773190836: issue #1846 (Workflow formulas)
- worker-1773190937: issue #1847 (Multi-runtime agent support)
- worker-1773191011: issue #1909 (ax CLI specification)

This wastes 5/10 circuit breaker slots on work god will close without merging.

## Fix

Added `god-locked` label check in two places in `coordinator.sh`:
1. `refresh_task_queue()`: after labels are fetched for each issue, skip if `god-locked`
2. `route_tasks_by_specialization()`: same check before routing to specialized agents

The check uses already-fetched labels — **no extra API calls**.

## Usage

God can apply/remove the `god-locked` label to control which issues agents work on.
Currently applied to: #1821, #1825, #1827, #1828, #1833, #1836, #1839, #1844, #1845, #1846, #1847, #1932, #1909, #1944

Takes effect within the next coordinator refresh cycle (~2.5 min). No restart needed.