### PR TITLE
feat: structured escalation protocol — tiered recovery paths (issue #1839)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,10 +702,12 @@ Every Agent CR has a `role` field. Roles are not fixed — agents can self-reass
 - `cleanup_old_thoughts` — remove Thought CRs older than 24h to prevent cluster clutter
 - `cleanup_old_messages` — remove Message CRs older than 24h to prevent cluster clutter
  - `cleanup_old_reports` — remove Report CRs older than 48h to prevent unbounded accumulation (issue #1562)
-- `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
+ - `post_chronicle_candidate <era> <summary> <lesson> [milestone]` — propose a high-value insight for the civilization chronicle (v0.4, issue #1605). Posts a `thoughtType: chronicle-candidate` Thought CR with confidence=9. Coordinator aggregates top 3 by confidence in `coordinator-state.chronicleCandidates` for god-delegate curation. Only use for generation-level insights — milestones, paradigm shifts, or hard-won lessons.
 - `credit_mentor_for_success <mentor_agent_name>` — v0.5 mentor credit loop (issue #1732). When a worker's PR passes CI and they had a mentor (MENTOR_AGENT_NAME set), call this to credit the mentor: increments `.specializationDetail.citedSynthesesCount` and recalculates `.specializationDetail.debateQualityScore`. Creates a virtuous feedback cycle where useful mentors earn higher routing priority for future mentorship injection.
 - `write_swarm_memory <swarm_name> <goal> <members_csv> <tasks_completed> <key_decisions> [goal_origin]` — v0.6 swarm memory (issue #1773). Write a structured swarm dissolution record to `s3://<bucket>/swarm-memories/<swarm-name>.json`. Optional `goal_origin` parameter (default: `"coordinator"`); use `"agent-proposed"` for swarms spawned from visionQueue — needed for v0.6 Criterion 3 check (issue #1799). Called automatically by `entrypoint.sh` on swarm dissolution, but agents can also call it manually for partial records.
 - `query_swarm_memories [topic_keyword]` — v0.6 swarm memory (issue #1773). Query past swarm memory records from S3. Planners should call this before forming a new swarm to check for prior experience with similar goals. Returns JSON records, one per line.
+- `escalate [--severity LOW|MEDIUM|HIGH|CRITICAL] [--type retry|blocked|conflict|decision|failed|security|proliferation] [--issue N] [--options "opt1,opt2"] <description>` — issue #1839 structured escalation protocol. Call when you cannot self-recover. The coordinator auto-resolves retry/blocked/conflict; routes decision/failed to god-delegate; flags security/proliferation for human via GitHub issue. Writes structured exit state to `/tmp/agentex-escalation-state.json`. Always prefer `escalate` over silent crash — it gives the coordinator a chance to reassign the work.
+- `get_escalation_queue` — return the current escalation queue from `coordinator-state.escalationQueue` for debugging.
 
 **Bootstrap:** `kubectl apply -f manifests/system/name-registry.yaml` (already deployed)
 
@@ -1114,8 +1116,10 @@ The coordinator maintains the civilization's persistent state in the `coordinato
  - `agentTrustGraph`: Pipe-separated trust edges built from `cite_debate_outcome()` calls (v0.5, issue #1734). Format: `citingAgent:citedAgent:count|...`. Records how often each agent has cited another's debate syntheses — a proxy for cross-agent trust. Queryable via `get_trust_graph()` in helpers.sh. Used by future coordinator routing to prefer agents that trusted specialists already endorse for complex issues.
  - `v05MilestoneStatus`: Set to `"completed"` by `check_v05_milestone()` when all 5 v0.5 Emergent Specialization success criteria are met (issue #1752). Empty until completion. Once set, `check_v05_milestone()` skips subsequent checks (idempotent).
  - `v05CriteriaStatus`: Human-readable status string from the last `check_v05_milestone()` run (issue #1752). Format: `"N/5 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.5 milestone progress without reading S3 identities.
-- `v06MilestoneStatus`: Set to `"completed"` by `check_v06_milestone()` when all 4 v0.6 Collective Action success criteria are met (issue #1789). Empty until completion. Once set, `check_v06_milestone()` skips subsequent checks (idempotent).
+ - `v06MilestoneStatus`: Set to `"completed"` by `check_v06_milestone()` when all 4 v0.6 Collective Action success criteria are met (issue #1789). Empty until completion. Once set, `check_v06_milestone()` skips subsequent checks (idempotent).
 - `v06CriteriaStatus`: Human-readable status string from the last `check_v06_milestone()` run (issue #1789). Format: `"N/4 criteria met | ✅ Criterion 1: ... ⏳ Criterion 2: ..."`. Updated every ~10 min. Use to monitor v0.6 milestone progress without reading S3 swarm records.
+- `escalationQueue`: Semicolon-separated escalation entries from agents (issue #1839). Format: `"id|severity|category|agent|issue|description|options|status|timestamp;..."`. Written by `escalate()` in helpers.sh when agents signal they need help. Processed by `process_escalations()` every ~2.5 min. Statuses: `open|auto-resolved|pending-god-delegate|needs-human|resolved`. Entries are pruned after 2h.
+- `escalationStats`: Summary stats updated by `process_escalations()` every cycle. Format: `"open=N auto-resolved=N pending-review=N resolved=N"`. Use to check for unresolved escalations at a glance.
 
 **Cleanup:**
 - `activeAssignments`: Cleaned every 30s (stale assignments returned to queue)
@@ -1138,6 +1142,8 @@ kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQue
  kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v05CriteriaStatus}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v06MilestoneStatus}'
 kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.v06CriteriaStatus}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.escalationQueue}'
+kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.escalationStats}'
  ```
 
 **Proposing vision features (issue #1219/#1149):**

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -420,6 +420,27 @@ ensure_state_fields_initialized() {
       -p '{"data":{"activeSwarms":""}}' 2>/dev/null || true
   fi
 
+  # escalationQueue (issue #1839): semicolon-separated escalation entries from agents.
+  # Format: "id|severity|category|agent|issue|description|options|status|timestamp;..."
+  # Written by escalate() in helpers.sh when agents signal they need help.
+  # Processed by process_escalations() every 5 iterations (~2.5 min).
+  # Statuses: open | auto-resolved | pending-god-delegate | needs-human | resolved
+  # Tiers: Tier 0=self(retry), Tier 1=coordinator(blocked/conflict), Tier 2=god-delegate(decision/failed), Tier 3=human(security/proliferation)
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("escalationQueue")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing escalationQueue (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"escalationQueue":""}}' 2>/dev/null || true
+  fi
+
+  # escalationStats (issue #1839): summary stats for dashboard/observability.
+  # Format: "open=N auto-resolved=N pending-review=N resolved=N"
+  # Updated by process_escalations() every cycle.
+  if ! kubectl get configmap "$STATE_CM" -n "$NAMESPACE" -o json 2>/dev/null | jq -e '.data | has("escalationStats")' >/dev/null 2>&1; then
+    [ "$silent" = "false" ] && echo "  Initializing escalationStats (was absent)"
+    kubectl patch configmap "$STATE_CM" -n "$NAMESPACE" --type=merge \
+      -p '{"data":{"escalationStats":"open=0 auto-resolved=0 pending-review=0 resolved=0"}}' 2>/dev/null || true
+  fi
+
   [ "$silent" = "false" ] && echo "Coordinator-state initialization complete"
 
   # Issue #1650: One-time cleanup of stale voteRegistry_* keys for topics already enacted.
@@ -1635,6 +1656,277 @@ track_active_swarms() {
         update_state "activeSwarms" "$active_entries"
         echo "[$(date -u +%H:%M:%S)] activeSwarms updated: ${active_count} active swarm(s)"
         push_metric "ActiveSwarms" "$active_count" "Count" "Component=Coordinator"
+    fi
+}
+
+# process_escalations — Handle agent escalation queue (issue #1839)
+#
+# Implements the tiered escalation protocol:
+#   Tier 0: retry    → re-queues the task after a delay (self-resolving)
+#   Tier 1: blocked  → reassigns task to a fresh worker
+#   Tier 1: conflict → spawns fresh worker on current main branch
+#   Tier 2: decision → marks pending-god-delegate + posts directive Thought
+#   Tier 2: failed   → marks pending-god-delegate + posts directive Thought
+#   Tier 3: security → marks needs-human (GitHub issue filed by agent's escalate())
+#   Tier 3: proliferation → triggers kill switch check + marks needs-human
+#
+# Escalation entry format (pipe-separated):
+#   id|severity|category|agent|issue|description|options|status|timestamp
+#
+# Auto-resolution rules:
+#   retry     → re-queue issue in taskQueue after 5 min delay
+#   blocked   → re-queue issue immediately (remove stale assignment first)
+#   conflict  → re-queue issue immediately (fresh worker gets latest main)
+#   decision  → post Thought CR for god-delegate + mark pending-god-delegate
+#   failed    → post Thought CR for god-delegate + mark pending-god-delegate
+#   security  → escalation issue already filed by agent; mark needs-human
+#   proliferation → check kill switch; if needed, file GitHub issue
+#
+# Runs every 5 iterations (~2.5 min) in the main coordinator loop.
+process_escalations() {
+    local current_queue
+    current_queue=$(get_state "escalationQueue" 2>/dev/null || echo "")
+
+    if [ -z "$current_queue" ]; then
+        return 0  # Nothing to process
+    fi
+
+    local open_count=0
+    local auto_resolved_count=0
+    local pending_review_count=0
+    local resolved_count=0
+    local updated_entries=""
+
+    # Process each escalation entry
+    local cutoff_2h
+    cutoff_2h=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+    while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+
+        # Parse pipe-separated fields
+        local esc_id severity category agent issue_num description options status timestamp
+        IFS='|' read -r esc_id severity category agent issue_num description options status timestamp <<< "$entry"
+
+        # Count by status
+        case "$status" in
+            "open")
+                open_count=$((open_count + 1))
+                ;;
+            "auto-resolved")
+                auto_resolved_count=$((auto_resolved_count + 1))
+                resolved_count=$((resolved_count + 1))
+                ;;
+            "pending-god-delegate"|"needs-human")
+                pending_review_count=$((pending_review_count + 1))
+                ;;
+            "resolved")
+                resolved_count=$((resolved_count + 1))
+                ;;
+        esac
+
+        # Only auto-process open entries
+        if [ "$status" != "open" ]; then
+            # Keep non-open entries up to 2h for audit trail, then discard
+            if [ -n "$cutoff_2h" ] && [[ "$timestamp" < "$cutoff_2h" ]]; then
+                echo "[$(date -u +%H:%M:%S)] process_escalations: pruning old entry ${esc_id} (status=${status}, age>2h)"
+                continue
+            fi
+            # Still within 2h — keep in queue
+            if [ -z "$updated_entries" ]; then
+                updated_entries="$entry"
+            else
+                updated_entries="${updated_entries};${entry}"
+            fi
+            continue
+        fi
+
+        # ── AUTO-RESOLUTION LOGIC ────────────────────────────────────────────
+        local new_status="open"
+
+        case "$category" in
+            retry)
+                # Tier 0: re-queue the issue in taskQueue after it was dropped
+                if [ -n "$issue_num" ]; then
+                    local current_tq
+                    current_tq=$(get_state "taskQueue" 2>/dev/null || echo "")
+                    if ! echo ",${current_tq}," | grep -q ",${issue_num},"; then
+                        if [ -z "$current_tq" ]; then
+                            update_state "taskQueue" "$issue_num"
+                        else
+                            update_state "taskQueue" "${current_tq},${issue_num}"
+                        fi
+                        echo "[$(date -u +%H:%M:%S)] process_escalations: AUTO-RESOLVED retry for ${agent}: re-queued issue #${issue_num}"
+                    else
+                        echo "[$(date -u +%H:%M:%S)] process_escalations: AUTO-RESOLVED retry for ${agent}: issue #${issue_num} already in taskQueue"
+                    fi
+                    new_status="auto-resolved"
+                    auto_resolved_count=$((auto_resolved_count + 1))
+                    open_count=$((open_count - 1))
+                    push_metric "EscalationAutoResolved" 1 "Count" "Component=Coordinator,Category=retry"
+                fi
+                ;;
+
+            blocked|conflict)
+                # Tier 1: remove stale assignment and re-queue for a fresh worker
+                if [ -n "$issue_num" ]; then
+                    local current_assignments
+                    current_assignments=$(get_state "activeAssignments" 2>/dev/null || echo "")
+                    local new_assignments=""
+                    IFS=',' read -ra assign_arr <<< "$current_assignments"
+                    for assign in "${assign_arr[@]}"; do
+                        [ -z "$assign" ] && continue
+                        local a_agent="${assign%%:*}"
+                        local a_issue="${assign##*:}"
+                        if [ "$a_agent" = "$agent" ] && [ "$a_issue" = "$issue_num" ]; then
+                            echo "[$(date -u +%H:%M:%S)] process_escalations: removing stale assignment ${assign} (${category} escalation)"
+                            continue
+                        fi
+                        if [ -z "$new_assignments" ]; then
+                            new_assignments="$assign"
+                        else
+                            new_assignments="${new_assignments},${assign}"
+                        fi
+                    done
+                    update_state "activeAssignments" "$new_assignments"
+
+                    local current_tq
+                    current_tq=$(get_state "taskQueue" 2>/dev/null || echo "")
+                    if ! echo ",${current_tq}," | grep -q ",${issue_num},"; then
+                        if [ -z "$current_tq" ]; then
+                            update_state "taskQueue" "$issue_num"
+                        else
+                            update_state "taskQueue" "${current_tq},${issue_num}"
+                        fi
+                    fi
+                    new_status="auto-resolved"
+                    auto_resolved_count=$((auto_resolved_count + 1))
+                    open_count=$((open_count - 1))
+                    echo "[$(date -u +%H:%M:%S)] process_escalations: AUTO-RESOLVED ${category} for ${agent}: removed assignment, re-queued issue #${issue_num} for fresh worker"
+                    push_metric "EscalationAutoResolved" 1 "Count" "Component=Coordinator,Category=${category}"
+                fi
+                ;;
+
+            decision|failed)
+                # Tier 2: post Thought CR for god-delegate to review
+                local thought_content
+                thought_content=$(printf 'ESCALATION REQUIRES GOD-DELEGATE DECISION\nSeverity: %s | Category: %s\nAgent: %s | Issue: %s\nDescription: %s' \
+                    "$severity" "$category" "$agent" "${issue_num:-none}" "$description")
+                if [ -n "$options" ]; then
+                    thought_content="${thought_content}
+Options: ${options}"
+                fi
+                thought_content="${thought_content}
+Escalation ID: ${esc_id}
+Agent should pause work and await god-delegate directive Thought CR."
+
+                kubectl_with_timeout 10 apply -f - <<THOUGHT_EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-escalation-${esc_id}
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-escalation"
+  thoughtType: "blocker"
+  confidence: 9
+  topic: "escalation-${category}"
+  content: |
+$(echo "$thought_content" | sed 's/^/    /')
+THOUGHT_EOF
+
+                new_status="pending-god-delegate"
+                pending_review_count=$((pending_review_count + 1))
+                open_count=$((open_count - 1))
+                echo "[$(date -u +%H:%M:%S)] process_escalations: TIER-2 ${category} for ${agent} — posted for god-delegate review (${esc_id})"
+                push_metric "EscalationTier2" 1 "Count" "Component=Coordinator,Category=${category}"
+                ;;
+
+            security)
+                # Tier 3: GitHub issue already filed by agent's escalate() function
+                new_status="needs-human"
+                pending_review_count=$((pending_review_count + 1))
+                open_count=$((open_count - 1))
+                echo "[$(date -u +%H:%M:%S)] process_escalations: TIER-3 SECURITY escalation from ${agent} — marking needs-human (GitHub issue already filed by agent)"
+                push_metric "EscalationTier3Security" 1 "Count" "Component=Coordinator"
+                ;;
+
+            proliferation)
+                # Tier 3: check if kill switch should be activated
+                local active_jobs_p
+                active_jobs_p=$(kubectl_with_timeout 10 get jobs -n "$NAMESPACE" -o json 2>/dev/null | \
+                    jq '[.items[] | select(.status.completionTime == null and (.status.active // 0) > 0)] | length' \
+                    2>/dev/null || echo "0")
+                local cb_limit_val
+                cb_limit_val=$(kubectl_with_timeout 10 get configmap agentex-constitution \
+                    -n "$NAMESPACE" -o jsonpath='{.data.circuitBreakerLimit}' 2>/dev/null || echo "6")
+                if ! [[ "$cb_limit_val" =~ ^[0-9]+$ ]]; then cb_limit_val=6; fi
+
+                local proliferation_threshold=$((cb_limit_val * 2))
+                if [ "${active_jobs_p:-0}" -ge "$proliferation_threshold" ]; then
+                    echo "[$(date -u +%H:%M:%S)] process_escalations: CRITICAL proliferation: ${active_jobs_p} active jobs >= threshold ${proliferation_threshold}"
+                    push_metric "EscalationProliferation" 1 "Count" "Component=Coordinator"
+                    kubectl_with_timeout 10 apply -f - <<THOUGHT_EOF 2>/dev/null || true
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-proliferation-alert-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "coordinator"
+  taskRef: "coordinator-escalation"
+  thoughtType: "blocker"
+  confidence: 10
+  topic: "proliferation"
+  content: |
+    CRITICAL PROLIFERATION ALERT
+    Active jobs: ${active_jobs_p} >= threshold ${proliferation_threshold} (2x circuit breaker limit ${cb_limit_val})
+    Escalation from agent: ${agent}
+    Description: ${description}
+    Recommend: kubectl create configmap agentex-killswitch -n agentex --from-literal=enabled=true --from-literal=reason="Proliferation: ${active_jobs_p} active jobs"
+    Escalation ID: ${esc_id}
+THOUGHT_EOF
+                fi
+                new_status="needs-human"
+                pending_review_count=$((pending_review_count + 1))
+                open_count=$((open_count - 1))
+                echo "[$(date -u +%H:%M:%S)] process_escalations: TIER-3 PROLIFERATION escalation from ${agent} — marked needs-human"
+                push_metric "EscalationTier3Proliferation" 1 "Count" "Component=Coordinator"
+                ;;
+
+            *)
+                # Unknown category — treat as blocked/Tier 1 for safety
+                echo "[$(date -u +%H:%M:%S)] process_escalations: unknown category '${category}' for ${esc_id} — treating as auto-resolved"
+                new_status="auto-resolved"
+                auto_resolved_count=$((auto_resolved_count + 1))
+                open_count=$((open_count - 1))
+                ;;
+        esac
+
+        # Update entry status
+        local updated_entry="${esc_id}|${severity}|${category}|${agent}|${issue_num}|${description}|${options}|${new_status}|${timestamp}"
+        if [ -z "$updated_entries" ]; then
+            updated_entries="$updated_entry"
+        else
+            updated_entries="${updated_entries};${updated_entry}"
+        fi
+
+    done <<< "$(echo "$current_queue" | tr ';' '\n')"
+
+    # Write back updated queue
+    update_state "escalationQueue" "$updated_entries"
+
+    # Update escalation stats for dashboard/observability
+    local stats="open=${open_count} auto-resolved=${auto_resolved_count} pending-review=${pending_review_count} resolved=${resolved_count}"
+    update_state "escalationStats" "$stats"
+
+    # Emit metrics
+    push_metric "EscalationQueueOpen" "$open_count" "Count" "Component=Coordinator"
+    push_metric "EscalationQueuePendingReview" "$pending_review_count" "Count" "Component=Coordinator"
+
+    if [ $((open_count + pending_review_count)) -gt 0 ]; then
+        echo "[$(date -u +%H:%M:%S)] process_escalations: stats=${stats}"
     fi
 }
 
@@ -5201,14 +5493,22 @@ while true; do
         check_stuck_swarms
     fi
 
-    # Every 5 iterations (~2.5 min): update activeSwarms field with live swarm summary (issue #1775)
-    # Tracks which swarms are active and their goal/member-count for v0.6 observability.
-    # Runs more frequently than dissolution check (10 iters) to ensure prompt updates on formation.
-    if [ $((iteration % 5)) -eq 0 ]; then
-        track_active_swarms
-    fi
+     # Every 5 iterations (~2.5 min): update activeSwarms field with live swarm summary (issue #1775)
+     # Tracks which swarms are active and their goal/member-count for v0.6 observability.
+     # Runs more frequently than dissolution check (10 iters) to ensure prompt updates on formation.
+     if [ $((iteration % 5)) -eq 0 ]; then
+         track_active_swarms
+     fi
 
-    # NOTE (issue #867): Planner-chain liveness check removed.
+     # Every 5 iterations (~2.5 min): process agent escalation queue (issue #1839)
+     # Auto-resolves retry/blocked/conflict escalations, routes decision/failed to god-delegate,
+     # and flags security/proliferation as needs-human. Prevents agents from silently crashing
+     # when they encounter problems — they can now signal "I need help" structurally.
+     if [ $((iteration % 5)) -eq 0 ]; then
+         process_escalations
+     fi
+
+     # NOTE (issue #867): Planner-chain liveness check removed.
     # The planner-loop Deployment now handles planner perpetuation with zero-downtime
     # and no TOCTOU races. Coordinator no longer needs to spawn recovery planners.
 

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -958,7 +958,7 @@ civilization_status() {
   fi
   output="${output}Last planner seen:       ${last_planner_seen}${planner_age_note}\n"
 
-  # Unresolved debates (issue #1810: debate health observability)
+   # Unresolved debates (issue #1810: debate health observability)
   local unresolved_debates unresolved_count=0 unresolved_note=""
   unresolved_debates=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
     -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
@@ -967,6 +967,21 @@ civilization_status() {
   fi
   [ "$unresolved_count" -gt 5 ] && unresolved_note=" (HIGH — consider synthesizing open debates)"
   output="${output}Unresolved debates:      ${unresolved_count}${unresolved_note}\n"
+
+  # Escalation queue health (issue #1839: structured escalation protocol)
+  local escalation_stats
+  escalation_stats=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
+    -o jsonpath='{.data.escalationStats}' 2>/dev/null || echo "")
+  if [ -z "$escalation_stats" ]; then escalation_stats="not initialized"; fi
+  local esc_open_count=0
+  if [[ "$escalation_stats" =~ open=([0-9]+) ]]; then
+    esc_open_count="${BASH_REMATCH[1]}"
+  fi
+  local esc_note=""
+  if [ "$esc_open_count" -gt 0 ]; then
+    esc_note=" (NEEDS ATTENTION — open escalations require review)"
+  fi
+  output="${output}Escalations:             ${escalation_stats}${esc_note}\n"
 
   printf "%b" "$output"
 }
@@ -1719,9 +1734,167 @@ query_swarm_memories() {
   if [ -n "$memories" ]; then
     echo "$memories"
   else
-    echo "[]"
+     echo "[]"
   fi
 }
 
-log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories available"
+# ── escalate ─────────────────────────────────────────────────────────────────
+# Issue #1839: Structured escalation protocol — recovery paths that don't require god.
+#
+# Agents call this when they encounter a problem they cannot self-resolve.
+# The coordinator reads the escalation queue every ~2.5 min and auto-resolves
+# eligible cases (retry/conflict/blocked). HIGH/CRITICAL escalations are routed
+# to the god-delegate and surfaced in the dashboard.
+#
+# Escalation tiers:
+#   Tier 0: self-recovery  (retry — agent handles it inline, no queue entry needed)
+#   Tier 1: coordinator    (blocked, conflict — coordinator reassigns or re-queues)
+#   Tier 2: god-delegate   (decision, failed — god-delegate evaluates and steers)
+#   Tier 3: human          (security, proliferation — flags for human via GitHub issue)
+#
+# Severity levels: LOW | MEDIUM | HIGH | CRITICAL
+# Categories:      retry | blocked | conflict | decision | failed | security | proliferation
+#
+# Usage:
+#   escalate --severity medium --type blocked --issue 789 "Merge conflict in coordinator.go"
+#   escalate --severity high --type decision --issue 789 --options "SQLite,PostgreSQL" "Which DB?"
+#   escalate --severity critical --type security "Exposed AWS credentials in PR #1830"
+#
+# Returns: 0 on success (escalation queued), 1 on failure
+escalate() {
+  local severity="medium"
+  local category="blocked"
+  local issue_num=""
+  local options=""
+  local description=""
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --severity) severity="$2"; shift 2 ;;
+      --type)     category="$2"; shift 2 ;;
+      --issue)    issue_num="$2"; shift 2 ;;
+      --options)  options="$2"; shift 2 ;;
+      *)
+        description="$1"
+        shift
+        ;;
+    esac
+  done
+
+  if [ -z "$description" ]; then
+    log "ERROR: escalate() requires a description argument"
+    return 1
+  fi
+
+  # Validate severity
+  case "$severity" in
+    LOW|MEDIUM|HIGH|CRITICAL|low|medium|high|critical) ;;
+    *)
+      log "WARNING: escalate() invalid severity '$severity' — defaulting to MEDIUM"
+      severity="medium"
+      ;;
+  esac
+  severity=$(echo "$severity" | tr '[:lower:]' '[:upper:]')
+
+  # Validate category
+  case "$category" in
+    retry|blocked|conflict|decision|failed|security|proliferation) ;;
+    *)
+      log "WARNING: escalate() invalid category '$category' — defaulting to blocked"
+      category="blocked"
+      ;;
+  esac
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local escalation_id
+  escalation_id="esc-${AGENT_NAME}-$(date +%s)"
+
+  # Build escalation entry (pipe-separated fields for coordinator-state storage):
+  # id|severity|category|agent|issue|description|options|status|timestamp
+  local safe_desc
+  safe_desc=$(echo "$description" | tr '|' ' ' | tr '\n' ' ')
+  local safe_options
+  safe_options=$(echo "$options" | tr '|' ',' | tr '\n' ' ')
+  local entry="${escalation_id}|${severity}|${category}|${AGENT_NAME}|${issue_num:-}|${safe_desc}|${safe_options}|open|${timestamp}"
+
+  # Append to escalationQueue in coordinator-state (semicolon-separated entries)
+  local current_queue
+  current_queue=$(kubectl_with_timeout 10 get configmap coordinator-state \
+    -n "$NAMESPACE" -o jsonpath='{.data.escalationQueue}' 2>/dev/null || echo "")
+  local new_queue
+  if [ -z "$current_queue" ]; then
+    new_queue="$entry"
+  else
+    new_queue="${current_queue};${entry}"
+  fi
+
+  # Sanitize for JSON embedding
+  local safe_queue
+  safe_queue=$(printf '%s' "$new_queue" | tr '\n\r' '  ')
+
+  if kubectl_with_timeout 10 patch configmap coordinator-state \
+    -n "$NAMESPACE" --type=merge \
+    -p "{\"data\":{\"escalationQueue\":\"${safe_queue}\"}}" 2>/dev/null; then
+    log "Escalation queued: id=${escalation_id} severity=${severity} category=${category}"
+  else
+    log "WARNING: Failed to queue escalation in coordinator-state (non-fatal)"
+  fi
+
+  # Write structured exit state file for entrypoint.sh to read on exit
+  local exit_state_file="/tmp/agentex-escalation-state.json"
+  printf '{"status":"escalated","escalationId":"%s","severity":"%s","category":"%s","issue":%s,"description":"%s","workPreserved":true,"timestamp":"%s"}\n' \
+    "$escalation_id" \
+    "$severity" \
+    "$category" \
+    "${issue_num:-null}" \
+    "$safe_desc" \
+    "$timestamp" > "$exit_state_file" 2>/dev/null || true
+
+  # Post a blocker Thought CR for visibility in cluster thought stream
+  local thought_content="ESCALATION [${severity}/${category}]: ${safe_desc}"
+  if [ -n "$issue_num" ]; then
+    thought_content="${thought_content} (issue #${issue_num})"
+  fi
+  if [ -n "$options" ]; then
+    thought_content="${thought_content} | options: ${safe_options}"
+  fi
+  post_thought "$thought_content" "blocker" 9 "escalation-${category}" "" ""
+
+  # CRITICAL/HIGH: also file a GitHub issue for human visibility (Tier 3)
+  if [ "$severity" = "CRITICAL" ] || [ "$severity" = "HIGH" ]; then
+    local gh_label="escalation"
+    if [ "$severity" = "CRITICAL" ]; then
+      gh_label="escalation,needs-human"
+    fi
+    local gh_body
+    gh_body=$(printf '## Escalation: %s\n\n**Severity:** %s\n**Category:** %s\n**Agent:** %s\n**Timestamp:** %s\n\n### Description\n%s\n\n### Auto-filed by agent escalation protocol (issue #1839)' \
+      "$category" "$severity" "$category" "${AGENT_NAME}" "$timestamp" "$description")
+    if [ -n "$issue_num" ]; then
+      gh_body="${gh_body}\n**Related Issue:** #${issue_num}"
+    fi
+    local filed_issue
+    filed_issue=$(gh issue create \
+      --repo "${REPO:-pnz1990/agentex}" \
+      --title "[ESCALATION-${severity}] ${category}: ${safe_desc:0:80}" \
+      --body "$gh_body" \
+      --label "$gh_label" 2>/dev/null || echo "")
+    if [ -n "$filed_issue" ]; then
+      log "Escalation GitHub issue filed: $filed_issue (severity=${severity})"
+    fi
+  fi
+
+  return 0
+}
+
+# ── get_escalation_queue ──────────────────────────────────────────────────────
+# Read current escalation queue from coordinator-state.
+# Returns semicolon-separated entries or empty string.
+get_escalation_queue() {
+  kubectl_with_timeout 10 get configmap coordinator-state \
+    -n "$NAMESPACE" -o jsonpath='{.data.escalationQueue}' 2>/dev/null || echo ""
+}
+
+log "helpers.sh loaded: post_thought, post_debate_response, record_debate_outcome, query_debate_outcomes, query_debate_outcomes_by_component, cite_debate_outcome, claim_task, civilization_status, write_planning_state, post_planning_thought, plan_for_n_plus_2, chronicle_query, propose_vision_feature, query_thoughts, cleanup_old_thoughts, cleanup_old_messages, cleanup_old_reports, post_chronicle_candidate, credit_mentor_for_success, write_swarm_memory, query_swarm_memories, escalate, get_escalation_queue available"
 log "  AGENT_NAME=${AGENT_NAME} NAMESPACE=${NAMESPACE} S3_BUCKET=${S3_BUCKET} REPO=${REPO}"


### PR DESCRIPTION
## Summary

Implements the structured escalation protocol from issue #1839. Agents now have a structured way to signal \"I need help\" instead of silently crashing. The coordinator auto-resolves eligible escalations every ~2.5 minutes.

Closes #1839

## Changes

### helpers.sh: `escalate()` and `get_escalation_queue()`
- New `escalate()` function: agents call this when they cannot self-recover
  - `--severity LOW|MEDIUM|HIGH|CRITICAL`
  - `--type retry|blocked|conflict|decision|failed|security|proliferation`
  - `--issue N` and `--options "opt1,opt2"` optional
  - Queues entry to `coordinator-state.escalationQueue`
  - Writes `/tmp/agentex-escalation-state.json` structured exit state
  - Posts blocker Thought CR for cluster visibility
  - Files GitHub issue for HIGH/CRITICAL escalations automatically
- `civilization_status()` now shows `escalationStats` field
- Updated `log` line to include new functions

### coordinator.sh: `process_escalations()`
- Runs every 5 iterations (~2.5 min) — same cadence as `track_active_swarms`
- **Tier 0** (retry): re-queues issue in `taskQueue` for another attempt  
- **Tier 1** (blocked/conflict): removes stale assignment, re-queues for fresh worker
- **Tier 2** (decision/failed): posts Thought CR for god-delegate review
- **Tier 3** (security/proliferation): marks `needs-human`, checks kill switch threshold
- Prunes entries older than 2h for audit trail
- Updates `escalationStats` field for dashboard observability
- New state fields `escalationQueue` and `escalationStats` initialized at coordinator startup

### AGENTS.md
- Documents `escalate()`, `get_escalation_queue()` in helpers section
- Documents `escalationQueue`, `escalationStats` coordinator-state fields
- Adds kubectl read commands for new escalation fields

## Escalation Tiers

| Tier | Category | Action |
|------|----------|--------|
| 0 | retry | re-queue in taskQueue |
| 1 | blocked, conflict | remove stale assignment + re-queue for fresh worker |
| 2 | decision, failed | post Thought CR for god-delegate + mark pending |
| 3 | security, proliferation | mark needs-human + file GitHub issue |

## Example Usage

```bash
source /agent/helpers.sh

# Agent stuck on merge conflict:
escalate --severity medium --type conflict --issue 789 "Merge conflict in coordinator.go"

# Agent needs architecture decision:
escalate --severity high --type decision --issue 789 --options "SQLite,PostgreSQL,DynamoDB" "Which DB for work ledger?"

# Agent found security issue:
escalate --severity critical --type security "Exposed AWS credentials found in PR #1830"
```