### PR TITLE
feat: workflow formula engine — ax CLI and TOML templates for repeatable agent workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1276,6 +1276,29 @@ image: agentex/runner:latest (UID 1000, non-root, PSA restricted)
                  propose_vision_feature(), query_thoughts(), cleanup_old_thoughts(), cleanup_old_messages(),
                  cleanup_old_reports(), post_chronicle_candidate(), get_trust_graph(), credit_mentor_for_success(),
                  write_swarm_memory(), query_swarm_memories()
+   - /agent/formula.sh — Sourceable workflow formula library (issue #1846)
+    Source with: source /agent/formula.sh
+      Provides: formula_list(), formula_start(), formula_current(), formula_done(), formula_skip(),
+                formula_progress(), formula_status(), formula_resume(), formula_persist(), formula_restore(),
+                formula_step_done()
+   - /usr/local/bin/ax — Agentex CLI wrapper for formulas and agent commands (issue #1846)
+    Usage examples:
+      ax formula list                   # list available formulas
+      ax formula start worker-implement # start a worker formula run
+      ax formula current                # show current step to complete
+      ax formula done claim             # mark 'claim' step done, advance
+      ax formula done                   # mark current step done
+      ax formula progress               # show ██████░░░░ progress bar
+      ax formula resume worker-12345    # successor: resume predecessor's formula
+      ax tasks --mine                   # show this agent's assigned issue
+      ax status                         # civilization health overview
+      ax thought "Found bug in X" blocker 9  # post a Thought CR
+      ax plan "did X" "do Y next" "do Z after" # write 3-step S3 plan
+   - /agent/formulas/ — TOML workflow templates (issue #1846)
+    worker-implement.toml   — 8 steps: claim → clone → implement → test → pr → release → report → spawn
+    planner-cycle.toml      — planner: read-state → triage → cleanup → spawn-workers → debate → plan → report
+    reviewer-cycle.toml     — reviewer: list-prs → select → review → feedback → insight → spawn
+    architect-improve.toml  — architect: audit → chronicle-check → identify → propose → implement → pr → debate → spawn
 ```
 
 Environment:

--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 FROM ubuntu:24.04 AS builder
 
-# Image version: 2026-03-10-r14 (issue #1830: fix tasksCompleted=0 — move increment before Report CR creation)
+# Image version: 2026-03-10-r15 (issue #1846: add ax CLI and workflow formulas)
 ARG OPENCODE_VERSION=latest
 
 # Run apt-get upgrade to pick up latest security patches for system packages (issue #858)
@@ -132,7 +132,10 @@ COPY coordinator.sh /usr/local/bin/coordinator.sh
 COPY planner-loop.sh /usr/local/bin/planner-loop.sh
 COPY identity.sh /agent/identity.sh
 COPY helpers.sh /agent/helpers.sh
-RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh /agent/helpers.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
+COPY formula.sh /agent/formula.sh
+COPY ax /usr/local/bin/ax
+COPY formulas/ /agent/formulas/
+RUN mkdir -p /agent/formulas && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh /agent/helpers.sh /agent/formula.sh /usr/local/bin/ax && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
 
 USER agentex
 WORKDIR /workspace

--- a/images/runner/ax
+++ b/images/runner/ax
@@ -1,0 +1,774 @@
+#!/usr/bin/env bash
+# ax — Agentex CLI for workflow formula management
+#
+# Issue #1846: Workflow formulas — repeatable, templated work patterns for agents
+#
+# Formulas are TOML files that define trackable steps for recurring workflows.
+# Each agent instance gets a formula "run" — a tracked execution of a formula.
+# Progress persists in /tmp/ax-formula-state.json (agent-local) and in S3
+# (for recovery by successor agents when an agent dies mid-formula).
+#
+# USAGE:
+#   ax formula list                   # list available formulas
+#   ax formula start <name>           # start a formula run
+#   ax formula current                # show current step
+#   ax formula done <step-id>         # mark step complete, advance to next
+#   ax formula progress               # show progress bar and all steps
+#   ax formula resume                 # resume a partially-completed formula
+#   ax formula skip <step-id>         # skip a step (records reason)
+#   ax formula status                 # full status of current run
+#
+# Other ax subcommands:
+#   ax tasks --mine                   # show tasks assigned to this agent
+#   ax status                         # civilization status overview
+#   ax thought <content> [type]       # post a thought CR
+#   ax plan <my-work> <n1> <n2>       # write 3-step planning state
+#   ax spawn <role>                   # spawn successor agent
+#   ax report                         # file Report CR (from /tmp/ax-report-*.json)
+#
+# FORMULA FILE FORMAT (TOML):
+#   [formula]
+#   name = "worker-implement"
+#   description = "Standard worker: claim issue, implement, open PR"
+#   version = 1
+#   role = "worker"
+#
+#   [[steps]]
+#   id = "claim"
+#   title = "Claim the issue"
+#   description = "..."
+#   verify = "..."       # optional: bash command that exits 0 if step is done
+#
+#   [[steps]]
+#   id = "implement"
+#   needs = ["claim"]    # optional: step IDs that must complete first
+#   ...
+
+set -o pipefail 2>/dev/null || true
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+AX_VERSION="1.0.0"
+FORMULA_DIR="${AX_FORMULA_DIR:-/agent/formulas}"
+STATE_FILE="${AX_STATE_FILE:-/tmp/ax-formula-state.json}"
+NAMESPACE="${NAMESPACE:-agentex}"
+AGENT_NAME="${AGENT_NAME:-unknown}"
+AGENT_ROLE="${AGENT_ROLE:-worker}"
+S3_BUCKET="${S3_BUCKET:-agentex-thoughts}"
+
+# Try to load S3 bucket from constitution if not set
+if [ "$S3_BUCKET" = "agentex-thoughts" ] && command -v kubectl >/dev/null 2>&1; then
+  _s3=$(timeout 5s kubectl get configmap agentex-constitution -n "$NAMESPACE" \
+    -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo "")
+  [ -n "$_s3" ] && S3_BUCKET="$_s3"
+fi
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+ax_log() { echo "[ax] $*" >&2; }
+ax_info() { echo "[ax] $*"; }
+ax_error() { echo "[ax ERROR] $*" >&2; }
+
+# ── TOML Parser (minimal, for formula files) ──────────────────────────────────
+# Parses the subset of TOML used in formula files.
+# Returns key=value pairs, one per line.
+# For [[steps]] arrays, prefixes with "step_N_<key>=<value>"
+#
+# Usage: toml_parse <file>
+toml_parse() {
+  local file="$1"
+  [ -f "$file" ] || { ax_error "Formula file not found: $file"; return 1; }
+
+  local section="" step_idx=-1
+
+  while IFS= read -r line; do
+    # Skip comments and empty lines
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+
+    # Section headers
+    if [[ "$line" =~ ^\[formula\] ]]; then
+      section="formula"
+      continue
+    fi
+    if [[ "$line" =~ ^\[\[steps\]\] ]]; then
+      section="steps"
+      step_idx=$((step_idx + 1))
+      continue
+    fi
+
+    # Key = value parsing
+    if [[ "$line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_-]*)[[:space:]]*=[[:space:]]*(.*) ]]; then
+      local key="${BASH_REMATCH[1]}"
+      local value="${BASH_REMATCH[2]}"
+
+      # Strip surrounding quotes
+      value=$(echo "$value" | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+
+      # Handle TOML arrays like needs = ["claim", "implement"]
+      if [[ "$value" =~ ^\[.*\]$ ]]; then
+        # Strip brackets and parse comma-separated values
+        value=$(echo "$value" | tr -d '[]' | tr -d '"' | tr -d "'" | tr ',' ' ' | tr -s ' ')
+      fi
+
+      if [ "$section" = "formula" ]; then
+        echo "formula_${key}=${value}"
+      elif [ "$section" = "steps" ] && [ $step_idx -ge 0 ]; then
+        echo "step_${step_idx}_${key}=${value}"
+      fi
+    fi
+  done < "$file"
+}
+
+# ── Formula Discovery ─────────────────────────────────────────────────────────
+formula_list() {
+  ax_info "Available formulas:"
+  ax_info ""
+
+  local found=0
+  for dir in "$FORMULA_DIR" "/workspace/repo/formulas" "$(dirname "$0")/../formulas"; do
+    [ -d "$dir" ] || continue
+    for f in "$dir"/*.toml; do
+      [ -f "$f" ] || continue
+      local name desc role
+      name=$(toml_parse "$f" 2>/dev/null | grep "^formula_name=" | cut -d= -f2-)
+      desc=$(toml_parse "$f" 2>/dev/null | grep "^formula_description=" | cut -d= -f2-)
+      role=$(toml_parse "$f" 2>/dev/null | grep "^formula_role=" | cut -d= -f2-)
+      ax_info "  ${name:-$(basename "$f" .toml)} [role=${role:-any}]"
+      ax_info "    ${desc}"
+      ax_info ""
+      found=$((found + 1))
+    done
+  done
+
+  if [ $found -eq 0 ]; then
+    ax_info "  No formulas found in: $FORMULA_DIR"
+    ax_info "  Set AX_FORMULA_DIR to your formula directory."
+  fi
+}
+
+# Find a formula file by name
+formula_find() {
+  local name="$1"
+  for dir in "$FORMULA_DIR" "/workspace/repo/formulas" "$(dirname "$0")/../formulas"; do
+    [ -d "$dir" ] || continue
+    local candidate="${dir}/${name}.toml"
+    [ -f "$candidate" ] && { echo "$candidate"; return 0; }
+  done
+  return 1
+}
+
+# ── Formula State (JSON in /tmp and S3) ───────────────────────────────────────
+# State schema:
+# {
+#   "formulaName": "worker-implement",
+#   "agentName": "worker-123",
+#   "startedAt": "2026-...",
+#   "currentStep": "implement",
+#   "completedSteps": ["claim", "clone"],
+#   "skippedSteps": {},
+#   "steps": [{"id":"...", "title":"...", "status":"pending|in_progress|completed|skipped"}]
+# }
+
+state_read() {
+  if [ -f "$STATE_FILE" ]; then
+    cat "$STATE_FILE"
+  else
+    echo ""
+  fi
+}
+
+state_write() {
+  local state="$1"
+  echo "$state" > "$STATE_FILE"
+
+  # Persist to S3 for recovery (best-effort)
+  if command -v aws >/dev/null 2>&1 && [ -n "$AGENT_NAME" ]; then
+    local s3_path="s3://${S3_BUCKET}/formulas/${AGENT_NAME}/state.json"
+    echo "$state" | aws s3 cp - "$s3_path" --content-type application/json >/dev/null 2>&1 || true
+  fi
+}
+
+state_load_from_s3() {
+  local agent="${1:-$AGENT_NAME}"
+  local s3_path="s3://${S3_BUCKET}/formulas/${agent}/state.json"
+  aws s3 cp "$s3_path" - 2>/dev/null || echo ""
+}
+
+# ── Formula Start ─────────────────────────────────────────────────────────────
+formula_start() {
+  local formula_name="$1"
+
+  # Find formula file
+  local formula_file
+  formula_file=$(formula_find "$formula_name") || {
+    ax_error "Formula '$formula_name' not found."
+    ax_error "Run 'ax formula list' to see available formulas."
+    return 1
+  }
+
+  # Parse formula
+  local parsed
+  parsed=$(toml_parse "$formula_file") || return 1
+
+  # Extract formula metadata
+  local name desc version role
+  name=$(echo "$parsed" | grep "^formula_name=" | cut -d= -f2-)
+  desc=$(echo "$parsed" | grep "^formula_description=" | cut -d= -f2-)
+  version=$(echo "$parsed" | grep "^formula_version=" | cut -d= -f2-)
+  role=$(echo "$parsed" | grep "^formula_role=" | cut -d= -f2-)
+
+  # Build steps array
+  local steps_json="[]"
+  local step_count=0
+  while true; do
+    local step_id step_title step_desc step_verify step_needs
+    step_id=$(echo "$parsed" | grep "^step_${step_count}_id=" | cut -d= -f2-)
+    [ -z "$step_id" ] && break
+
+    step_title=$(echo "$parsed" | grep "^step_${step_count}_title=" | cut -d= -f2-)
+    step_desc=$(echo "$parsed" | grep "^step_${step_count}_description=" | cut -d= -f2-)
+    step_verify=$(echo "$parsed" | grep "^step_${step_count}_verify=" | cut -d= -f2-)
+    step_needs=$(echo "$parsed" | grep "^step_${step_count}_needs=" | cut -d= -f2-)
+
+    local step_json
+    step_json=$(jq -n \
+      --arg id "$step_id" \
+      --arg title "$step_title" \
+      --arg desc "$step_desc" \
+      --arg verify "$step_verify" \
+      --arg needs "$step_needs" \
+      --arg status "pending" \
+      '{id: $id, title: $title, description: $desc, verify: $verify, needs: ($needs | split(" ") | map(select(. != ""))), status: $status}')
+
+    steps_json=$(echo "$steps_json" | jq --argjson step "$step_json" '. + [$step]')
+    step_count=$((step_count + 1))
+  done
+
+  # Build initial state
+  local first_step_id
+  first_step_id=$(echo "$steps_json" | jq -r '.[0].id // ""')
+
+  local state
+  state=$(jq -n \
+    --arg formulaName "$name" \
+    --arg description "$desc" \
+    --arg version "${version:-1}" \
+    --arg role "${role:-any}" \
+    --arg agentName "$AGENT_NAME" \
+    --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg currentStep "$first_step_id" \
+    --argjson steps "$steps_json" \
+    '{
+      formulaName: $formulaName,
+      description: $description,
+      version: $version,
+      role: $role,
+      agentName: $agentName,
+      startedAt: $startedAt,
+      currentStep: $currentStep,
+      completedSteps: [],
+      skippedSteps: {},
+      steps: $steps
+    }')
+
+  state_write "$state"
+
+  ax_info "Started formula: ${name} v${version:-1}"
+  ax_info "Role: ${role:-any}"
+  ax_info "Agent: ${AGENT_NAME}"
+  ax_info ""
+  ax_info "First step: ${first_step_id}"
+  ax_info ""
+  formula_progress_display "$state"
+}
+
+# ── Formula Current Step ──────────────────────────────────────────────────────
+formula_current() {
+  local state
+  state=$(state_read)
+
+  if [ -z "$state" ]; then
+    ax_error "No active formula. Run 'ax formula start <name>' to begin."
+    return 1
+  fi
+
+  local current_step formula_name
+  current_step=$(echo "$state" | jq -r '.currentStep // ""')
+  formula_name=$(echo "$state" | jq -r '.formulaName // ""')
+
+  if [ -z "$current_step" ]; then
+    ax_info "Formula '${formula_name}' is complete! All steps finished."
+    return 0
+  fi
+
+  local step_info
+  step_info=$(echo "$state" | jq --arg id "$current_step" '.steps[] | select(.id == $id)')
+
+  local step_title step_desc step_verify total completed
+  step_title=$(echo "$step_info" | jq -r '.title // ""')
+  step_desc=$(echo "$step_info" | jq -r '.description // ""')
+  step_verify=$(echo "$step_info" | jq -r '.verify // ""')
+  total=$(echo "$state" | jq '.steps | length')
+  completed=$(echo "$state" | jq '.completedSteps | length')
+
+  ax_info "Formula: ${formula_name} [${completed}/${total} steps done]"
+  ax_info ""
+  ax_info "→ Current step: ${current_step}"
+  ax_info "  Title: ${step_title}"
+  ax_info "  Description: ${step_desc}"
+  if [ -n "$step_verify" ]; then
+    ax_info "  Verify: ${step_verify}"
+  fi
+}
+
+# ── Formula Mark Step Done ────────────────────────────────────────────────────
+formula_done() {
+  local step_id="$1"
+  local notes="${2:-}"
+
+  local state
+  state=$(state_read)
+
+  if [ -z "$state" ]; then
+    ax_error "No active formula. Run 'ax formula start <name>' to begin."
+    return 1
+  fi
+
+  local current_step
+  current_step=$(echo "$state" | jq -r '.currentStep // ""')
+
+  # Default to current step if not specified
+  [ -z "$step_id" ] && step_id="$current_step"
+
+  # Verify the step exists
+  local step_exists
+  step_exists=$(echo "$state" | jq --arg id "$step_id" '.steps[] | select(.id == $id) | .id' 2>/dev/null)
+  if [ -z "$step_exists" ]; then
+    ax_error "Step '$step_id' not found in formula."
+    return 1
+  fi
+
+  # Run verify command if present
+  local step_verify
+  step_verify=$(echo "$state" | jq -r --arg id "$step_id" '.steps[] | select(.id == $id) | .verify // ""')
+  if [ -n "$step_verify" ]; then
+    ax_log "Running verify: $step_verify"
+    if ! bash -c "$step_verify" 2>/dev/null; then
+      ax_error "Verify command failed for step '$step_id'."
+      ax_error "Verify: $step_verify"
+      ax_error "Fix the issue and retry, or use 'ax formula skip $step_id' to skip verification."
+      return 1
+    fi
+    ax_log "Verify passed ✓"
+  fi
+
+  # Mark step complete and advance
+  local completed_at
+  completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Update state: mark step completed
+  state=$(echo "$state" | jq \
+    --arg id "$step_id" \
+    --arg ts "$completed_at" \
+    --arg notes "$notes" \
+    '
+    .completedSteps += [$id] |
+    .steps = [.steps[] | if .id == $id then .status = "completed" | .completedAt = $ts | .notes = $notes else . end]
+    ')
+
+  # Find the next step to work on (first step whose needs are all completed)
+  local completed_steps
+  completed_steps=$(echo "$state" | jq -r '[.completedSteps[]]')
+  local skipped_steps
+  skipped_steps=$(echo "$state" | jq -r '[.skippedSteps | keys[]]')
+  local done_steps
+  done_steps=$(echo "$state" | jq -r '[(.completedSteps + (.skippedSteps | keys))[] ]')
+
+  local next_step=""
+  next_step=$(echo "$state" | jq -r \
+    --argjson done "$done_steps" \
+    '.steps[] | select(.status == "pending") | select(
+      (.needs | length == 0) or
+      (.needs | all(. as $need | $done | index($need) != null))
+    ) | .id' | head -1)
+
+  state=$(echo "$state" | jq --arg next "$next_step" '.currentStep = $next')
+
+  state_write "$state"
+
+  local total completed_count
+  total=$(echo "$state" | jq '.steps | length')
+  completed_count=$(echo "$state" | jq '.completedSteps | length')
+
+  ax_info "✓ Step '${step_id}' completed"
+
+  if [ -z "$next_step" ]; then
+    ax_info ""
+    ax_info "🎉 Formula '$(echo "$state" | jq -r '.formulaName')' COMPLETE!"
+    ax_info "All ${total} steps finished."
+    _formula_complete_hook "$state"
+  else
+    ax_info "→ Next step: ${next_step} [${completed_count}/${total} done]"
+    local next_title
+    next_title=$(echo "$state" | jq -r --arg id "$next_step" '.steps[] | select(.id == $id) | .title')
+    ax_info "  ${next_title}"
+  fi
+}
+
+# Hook called when formula completes — saves completion record to S3
+_formula_complete_hook() {
+  local state="$1"
+  local formula_name
+  formula_name=$(echo "$state" | jq -r '.formulaName // "unknown"')
+  local completed_at
+  completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Write completion record to S3
+  local completion_json
+  completion_json=$(echo "$state" | jq --arg ts "$completed_at" '. + {completedAt: $ts, status: "completed"}')
+
+  if command -v aws >/dev/null 2>&1; then
+    local s3_path="s3://${S3_BUCKET}/formulas/${AGENT_NAME}/completed/${formula_name}-${completed_at}.json"
+    echo "$completion_json" | aws s3 cp - "$s3_path" --content-type application/json >/dev/null 2>&1 || true
+    ax_log "Formula completion saved to S3: ${s3_path}"
+  fi
+
+  # Clean up local state
+  rm -f "$STATE_FILE" 2>/dev/null || true
+}
+
+# ── Formula Skip Step ─────────────────────────────────────────────────────────
+formula_skip() {
+  local step_id="$1"
+  local reason="${2:-no reason given}"
+
+  local state
+  state=$(state_read)
+
+  if [ -z "$state" ]; then
+    ax_error "No active formula."
+    return 1
+  fi
+
+  local step_exists
+  step_exists=$(echo "$state" | jq --arg id "$step_id" '.steps[] | select(.id == $id) | .id' 2>/dev/null)
+  if [ -z "$step_exists" ]; then
+    ax_error "Step '$step_id' not found."
+    return 1
+  fi
+
+  local skipped_at
+  skipped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  state=$(echo "$state" | jq \
+    --arg id "$step_id" \
+    --arg ts "$skipped_at" \
+    --arg reason "$reason" \
+    '
+    .skippedSteps[$id] = {at: $ts, reason: $reason} |
+    .steps = [.steps[] | if .id == $id then .status = "skipped" | .skippedAt = $ts | .skipReason = $reason else . end]
+    ')
+
+  # Advance to next eligible step
+  local done_steps
+  done_steps=$(echo "$state" | jq -r '[(.completedSteps + (.skippedSteps | keys))[] ]')
+  local next_step=""
+  next_step=$(echo "$state" | jq -r \
+    --argjson done "$done_steps" \
+    '.steps[] | select(.status == "pending") | select(
+      (.needs | length == 0) or
+      (.needs | all(. as $need | $done | index($need) != null))
+    ) | .id' | head -1)
+
+  state=$(echo "$state" | jq --arg next "$next_step" '.currentStep = $next')
+  state_write "$state"
+
+  ax_info "⏭ Step '${step_id}' skipped (${reason})"
+  [ -n "$next_step" ] && ax_info "→ Next step: ${next_step}"
+}
+
+# ── Formula Resume (for successor agents) ─────────────────────────────────────
+formula_resume() {
+  local predecessor="${1:-}"
+
+  # Try to load state from S3 if no local state
+  local state
+  state=$(state_read)
+
+  if [ -z "$state" ] && [ -n "$predecessor" ]; then
+    ax_info "Loading formula state from predecessor: ${predecessor}"
+    state=$(state_load_from_s3 "$predecessor")
+    if [ -n "$state" ]; then
+      # Update agent name in resumed state
+      state=$(echo "$state" | jq --arg agent "$AGENT_NAME" '.agentName = $agent | .resumedBy = $agent | .resumedAt = now | todate')
+      state_write "$state"
+      ax_info "Resumed formula from predecessor ${predecessor}"
+    fi
+  fi
+
+  if [ -z "$state" ]; then
+    ax_error "No formula state to resume."
+    ax_error "Usage: ax formula resume [predecessor-agent-name]"
+    return 1
+  fi
+
+  ax_info "Resumed formula: $(echo "$state" | jq -r '.formulaName')"
+  ax_info "Original agent: $(echo "$state" | jq -r '.agentName')"
+  formula_progress_display "$state"
+}
+
+# ── Formula Progress Display ──────────────────────────────────────────────────
+formula_progress_display() {
+  local state="${1:-$(state_read)}"
+
+  if [ -z "$state" ]; then
+    ax_error "No active formula."
+    return 1
+  fi
+
+  local formula_name current_step total completed_count
+  formula_name=$(echo "$state" | jq -r '.formulaName // "unknown"')
+  current_step=$(echo "$state" | jq -r '.currentStep // ""')
+  total=$(echo "$state" | jq '.steps | length')
+  completed_count=$(echo "$state" | jq '.completedSteps | length')
+
+  # Progress bar
+  local bar_width=20
+  local filled=$(( (completed_count * bar_width) / total ))
+  local bar=""
+  local i=0
+  while [ $i -lt $bar_width ]; do
+    if [ $i -lt $filled ]; then bar="${bar}█"; else bar="${bar}░"; fi
+    i=$((i + 1))
+  done
+
+  ax_info "Formula: ${formula_name}"
+  ax_info "Progress: ${bar} ${completed_count}/${total} steps"
+  ax_info ""
+
+  # Print all steps with status
+  echo "$state" | jq -r '.steps[] | "\(.status) \(.id) \(.title)"' | while read -r status id title; do
+    local marker
+    case "$status" in
+      "completed") marker="✓" ;;
+      "skipped")   marker="⏭" ;;
+      "in_progress") marker="→" ;;
+      *)
+        if [ "$id" = "$current_step" ]; then
+          marker="→"
+        else
+          marker="○"
+        fi
+        ;;
+    esac
+    ax_info "  ${marker} [${id}] ${title}"
+  done
+}
+
+formula_progress() {
+  formula_progress_display
+}
+
+formula_status() {
+  local state
+  state=$(state_read)
+
+  if [ -z "$state" ]; then
+    ax_error "No active formula."
+    return 1
+  fi
+
+  echo "$state" | jq .
+}
+
+# ── Other ax subcommands ───────────────────────────────────────────────────────
+
+ax_tasks() {
+  local mine=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --mine) mine=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  if $mine; then
+    ax_info "Tasks assigned to ${AGENT_NAME}:"
+    timeout 10s kubectl get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.activeAssignments}' 2>/dev/null | \
+      tr ',' '\n' | grep "^${AGENT_NAME}:" | while read -r entry; do
+        local issue="${entry#*:}"
+        ax_info "  Issue #${issue}"
+      done
+  else
+    ax_info "Task queue:"
+    timeout 10s kubectl get configmap coordinator-state -n "$NAMESPACE" \
+      -o jsonpath='{.data.taskQueue}' 2>/dev/null | tr ',' '\n' | while read -r issue; do
+        [ -n "$issue" ] && ax_info "  Issue #${issue}"
+      done
+  fi
+}
+
+ax_status() {
+  # Source helpers.sh for civilization_status
+  if [ -f /agent/helpers.sh ]; then
+    # shellcheck source=/dev/null
+    source /agent/helpers.sh 2>/dev/null && civilization_status
+  else
+    ax_info "Civilization status (basic):"
+    ax_info "  Coordinator queue: $(timeout 10s kubectl get configmap coordinator-state -n "$NAMESPACE" -o jsonpath='{.data.taskQueue}' 2>/dev/null)"
+    ax_info "  Active assignments: $(timeout 10s kubectl get configmap coordinator-state -n "$NAMESPACE" -o jsonpath='{.data.activeAssignments}' 2>/dev/null)"
+  fi
+}
+
+ax_thought() {
+  local content="$1"
+  local type="${2:-insight}"
+  local confidence="${3:-8}"
+
+  if [ -z "$content" ]; then
+    ax_error "Usage: ax thought <content> [type] [confidence]"
+    return 1
+  fi
+
+  if [ -f /agent/helpers.sh ]; then
+    # shellcheck source=/dev/null
+    source /agent/helpers.sh 2>/dev/null && post_thought "$content" "$type" "$confidence"
+  else
+    timeout 10s kubectl apply -f - <<EOF >/dev/null
+apiVersion: kro.run/v1alpha1
+kind: Thought
+metadata:
+  name: thought-${AGENT_NAME}-$(date +%s)
+  namespace: ${NAMESPACE}
+spec:
+  agentRef: "${AGENT_NAME}"
+  taskRef: "${TASK_CR_NAME:-}"
+  thoughtType: "${type}"
+  confidence: ${confidence}
+  content: |
+$(echo "$content" | sed 's/^/    /')
+EOF
+    ax_log "Posted thought: type=${type}"
+  fi
+}
+
+ax_plan() {
+  local my_work="$1"
+  local n1="$2"
+  local n2="$3"
+  local blockers="${4:-none}"
+
+  if [ -z "$my_work" ] || [ -z "$n1" ] || [ -z "$n2" ]; then
+    ax_error "Usage: ax plan <my-work> <n1-priority> <n2-priority> [blockers]"
+    return 1
+  fi
+
+  if [ -f /agent/helpers.sh ]; then
+    # shellcheck source=/dev/null
+    source /agent/helpers.sh 2>/dev/null && plan_for_n_plus_2 "$my_work" "$n1" "$n2" "$blockers"
+  else
+    ax_error "helpers.sh not found — cannot write planning state"
+    return 1
+  fi
+}
+
+# ── Help ───────────────────────────────────────────────────────────────────────
+ax_help() {
+  cat <<'EOF'
+ax — Agentex CLI v${AX_VERSION}
+
+USAGE:
+  ax <command> [args...]
+
+FORMULA COMMANDS:
+  ax formula list                 List available formulas
+  ax formula start <name>         Start a formula run (creates local state)
+  ax formula current              Show current step description
+  ax formula done [step-id]       Mark current/named step complete, advance
+  ax formula progress             Show progress bar and all steps
+  ax formula resume [predecessor] Resume a formula (from S3 if predecessor given)
+  ax formula skip <step-id>       Skip a step with optional reason
+  ax formula status               Print full formula state as JSON
+
+TASK COMMANDS:
+  ax tasks                        Show task queue
+  ax tasks --mine                 Show tasks assigned to this agent
+
+AGENT COMMANDS:
+  ax status                       Civilization status overview
+  ax thought <content> [type]     Post a Thought CR (type: insight/blocker/debate)
+  ax plan <work> <n1> <n2>        Write 3-step planning state to S3 + thought
+
+ENVIRONMENT:
+  AX_FORMULA_DIR   Directory containing formula TOML files (default: /agent/formulas)
+  AX_STATE_FILE    Path for local formula state JSON (default: /tmp/ax-formula-state.json)
+  AGENT_NAME       This agent's name (default: unknown)
+  NAMESPACE        Kubernetes namespace (default: agentex)
+  S3_BUCKET        S3 bucket for state persistence (default: agentex-thoughts)
+
+FORMULA FILES:
+  Formulas are TOML files with a [formula] section and [[steps]] arrays.
+  See /agent/formulas/*.toml for examples.
+
+EXAMPLES:
+  # Start the standard worker formula
+  ax formula start worker-implement
+
+  # See what you need to do next
+  ax formula current
+
+  # After claiming issue #789:
+  ax formula done claim
+
+  # After implementing:
+  ax formula done implement
+
+  # After opening PR:
+  ax formula done pr
+
+  # Check overall progress
+  ax formula progress
+
+EOF
+}
+
+# ── Main Dispatcher ────────────────────────────────────────────────────────────
+main() {
+  local cmd="${1:-help}"
+  shift || true
+
+  case "$cmd" in
+    formula)
+      local subcmd="${1:-list}"
+      shift || true
+      case "$subcmd" in
+        list)     formula_list ;;
+        start)    formula_start "$@" ;;
+        current)  formula_current ;;
+        done)     formula_done "$@" ;;
+        progress) formula_progress ;;
+        resume)   formula_resume "$@" ;;
+        skip)     formula_skip "$@" ;;
+        status)   formula_status ;;
+        *)
+          ax_error "Unknown formula subcommand: $subcmd"
+          ax_help
+          return 1
+          ;;
+      esac
+      ;;
+    tasks)     ax_tasks "$@" ;;
+    status)    ax_status ;;
+    thought)   ax_thought "$@" ;;
+    plan)      ax_plan "$@" ;;
+    version)   ax_info "ax version ${AX_VERSION}" ;;
+    help|--help|-h) ax_help ;;
+    *)
+      ax_error "Unknown command: $cmd"
+      ax_help
+      return 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/images/runner/formula.sh
+++ b/images/runner/formula.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# formula.sh — Sourceable workflow formula library for agentex agents
+#
+# Issue #1846: Workflow formulas — repeatable, templated work patterns for agents
+#
+# This file provides formula_* functions that can be sourced directly.
+# It delegates to the 'ax' CLI for the actual formula engine logic.
+#
+# WHY TWO FILES?
+# - /usr/local/bin/ax — standalone CLI (call as: ax formula start worker-implement)
+# - /agent/formula.sh — sourceable library (source then call: formula_start worker-implement)
+#
+# Both use the same state file and formula directory.
+# Agents can use whichever interface fits their context:
+#   - OpenCode bash tool: source /agent/formula.sh && formula_start worker-implement
+#   - Direct shell: ax formula start worker-implement
+#
+# USAGE:
+#   source /agent/formula.sh
+#   formula_list                         # list available formulas
+#   formula_start worker-implement       # start a formula
+#   formula_current                      # show current step
+#   formula_done claim                   # mark step done, advance
+#   formula_skip thought "not blocked"   # skip an optional step
+#   formula_progress                     # show progress bar
+#   formula_persist                      # save state to S3
+#   formula_restore worker-123456        # restore from predecessor
+
+# ── Initialization ─────────────────────────────────────────────────────────────
+_AX_BIN="${_AX_BIN:-/usr/local/bin/ax}"
+FORMULA_DIR="${AX_FORMULA_DIR:-/agent/formulas}"
+FORMULA_STATE_FILE="${AX_STATE_FILE:-/tmp/ax-formula-state.json}"
+
+_formula_lib_log() { echo "[formula] $*" >&2; }
+
+# ── Wrapper functions ──────────────────────────────────────────────────────────
+
+formula_list() {
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula list
+  else
+    echo "Available formulas in ${FORMULA_DIR}:" >&2
+    for f in "${FORMULA_DIR}"/*.toml; do
+      [ -f "$f" ] && echo "  $(basename "$f" .toml)" >&2
+    done
+  fi
+}
+
+formula_start() {
+  local name="${1:-}"
+  [ -z "$name" ] && { _formula_lib_log "Usage: formula_start <formula-name>"; return 1; }
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula start "$name"
+  else
+    _formula_lib_log "ax binary not found at $_AX_BIN"
+    return 1
+  fi
+}
+
+formula_current() {
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula current
+  else
+    _formula_lib_log "ax binary not found at $_AX_BIN"
+    return 1
+  fi
+}
+
+formula_done() {
+  local step="${1:-}"
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula done "$step"
+  else
+    _formula_lib_log "ax binary not found at $_AX_BIN"
+    return 1
+  fi
+}
+
+formula_skip() {
+  local step="${1:-}"
+  local reason="${2:-no reason given}"
+  [ -z "$step" ] && { _formula_lib_log "Usage: formula_skip <step-id> [reason]"; return 1; }
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula skip "$step" "$reason"
+  else
+    _formula_lib_log "ax binary not found at $_AX_BIN"
+    return 1
+  fi
+}
+
+formula_progress() {
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula progress
+  else
+    if [ -f "$FORMULA_STATE_FILE" ]; then
+      jq -r '"Formula: \(.formulaName)\nCurrent: \(.currentStep)\nDone: \(.completedSteps | join(", "))"' \
+        "$FORMULA_STATE_FILE" 2>/dev/null || cat "$FORMULA_STATE_FILE"
+    else
+      _formula_lib_log "No active formula"
+      return 1
+    fi
+  fi
+}
+
+formula_status() {
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula status
+  else
+    [ -f "$FORMULA_STATE_FILE" ] && cat "$FORMULA_STATE_FILE" || { _formula_lib_log "No active formula"; return 1; }
+  fi
+}
+
+formula_resume() {
+  local predecessor="${1:-}"
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula resume "$predecessor"
+  else
+    _formula_lib_log "ax binary not found at $_AX_BIN"
+    return 1
+  fi
+}
+
+# Persist formula state to S3 for recovery by successors
+# (ax handles this automatically on state_write, but this provides an explicit call)
+formula_persist() {
+  if [ ! -f "$FORMULA_STATE_FILE" ]; then
+    _formula_lib_log "No active formula state to persist"
+    return 0
+  fi
+  local s3_bucket
+  s3_bucket="${S3_BUCKET:-$(kubectl get configmap agentex-constitution -n "${NAMESPACE:-agentex}" \
+    -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo 'agentex-thoughts')}"
+  local s3_key="formulas/${AGENT_NAME:-unknown}/state.json"
+  aws s3 cp "$FORMULA_STATE_FILE" "s3://${s3_bucket}/${s3_key}" \
+    --content-type application/json 2>/dev/null \
+    && _formula_lib_log "Formula state persisted to s3://${s3_bucket}/${s3_key}" \
+    || _formula_lib_log "WARNING: Failed to persist formula state to S3"
+}
+
+# Restore formula state from a predecessor agent
+formula_restore() {
+  local predecessor="${1:-}"
+  [ -z "$predecessor" ] && { _formula_lib_log "Usage: formula_restore <predecessor-agent-name>"; return 1; }
+  if [ -x "$_AX_BIN" ]; then
+    "$_AX_BIN" formula resume "$predecessor"
+  else
+    local s3_bucket
+    s3_bucket="${S3_BUCKET:-$(kubectl get configmap agentex-constitution -n "${NAMESPACE:-agentex}" \
+      -o jsonpath='{.data.s3Bucket}' 2>/dev/null || echo 'agentex-thoughts')}"
+    local s3_key="formulas/${predecessor}/state.json"
+    if aws s3 cp "s3://${s3_bucket}/${s3_key}" "$FORMULA_STATE_FILE" 2>/dev/null; then
+      _formula_lib_log "Restored formula state from predecessor: $predecessor"
+      formula_progress
+    else
+      _formula_lib_log "No formula state found for predecessor: $predecessor"
+      return 1
+    fi
+  fi
+}
+
+# Check if a step is done (for conditional logic)
+formula_step_done() {
+  local step_id="$1"
+  [ -f "$FORMULA_STATE_FILE" ] || return 1
+  local status
+  status=$(jq -r --arg s "$step_id" '.completedSteps | index($s) != null' "$FORMULA_STATE_FILE" 2>/dev/null)
+  [ "$status" = "true" ]
+}

--- a/images/runner/formulas/architect-improve.toml
+++ b/images/runner/formulas/architect-improve.toml
@@ -1,0 +1,56 @@
+# Workflow Formula: architect-improve
+# Architect: structural analysis, RGD improvements, system design
+# Part of issue #1846 — Workflow Formulas
+
+[formula]
+name = "architect-improve"
+description = "Architect: audit system structure, propose improvements, implement structural changes"
+version = 1
+role = "architect"
+
+[[steps]]
+id = "audit"
+title = "Audit current architecture"
+description = "Read manifests/rgds/*.yaml, images/runner/entrypoint.sh, AGENTS.md for structural issues"
+
+[[steps]]
+id = "chronicle-check"
+title = "Check chronicle and debate history"
+description = "Query civilization memory for known issues: source /agent/helpers.sh && chronicle_query 'architecture'; query_debate_outcomes_by_component 'entrypoint.sh'"
+needs = ["audit"]
+
+[[steps]]
+id = "identify-issue"
+title = "Identify structural improvement"
+description = "Find ONE structural/architectural issue to improve. Search for existing issues first: gh issue list --repo pnz1990/agentex --state open --search '<keyword>' --limit 10"
+needs = ["chronicle-check"]
+
+[[steps]]
+id = "propose"
+title = "Propose improvement via governance"
+description = "Post proposal Thought CR for collective review: source /agent/helpers.sh && post_thought '#proposal-<topic> ...' proposal 8"
+needs = ["identify-issue"]
+
+[[steps]]
+id = "implement"
+title = "Implement the structural change"
+description = "Create branch, implement change, test thoroughly. Structural changes require extra care."
+needs = ["propose"]
+
+[[steps]]
+id = "pr"
+title = "Open a pull request"
+description = "Push branch, open PR. For protected files, add constitution-aligned label: gh pr create --title '...' --body '...Closes #N...'"
+needs = ["implement"]
+
+[[steps]]
+id = "debate"
+title = "Post debate insight"
+description = "Invite peer debate on your structural change: source /agent/helpers.sh && post_thought 'Structural change: ... Evidence: ... Counter-arguments welcome.' insight 9"
+needs = ["pr"]
+
+[[steps]]
+id = "spawn"
+title = "Spawn successor"
+description = "Continue architect work: spawn_task_and_agent task-architect-N architect-N architect 'Continue structural improvements' '...' M 0 ''"
+needs = ["debate"]

--- a/images/runner/formulas/planner-cycle.toml
+++ b/images/runner/formulas/planner-cycle.toml
@@ -1,0 +1,56 @@
+# Workflow Formula: planner-cycle
+# Standard planner: audit, triage, spawn workers
+# Part of issue #1846 — Workflow Formulas
+
+[formula]
+name = "planner-cycle"
+description = "Standard planner: audit, triage, spawn workers, participate in governance"
+version = 1
+role = "planner"
+
+[[steps]]
+id = "read-state"
+title = "Read civilization state"
+description = "Check system health: source /agent/helpers.sh && civilization_status; kubectl get configmap coordinator-state -n agentex -o jsonpath='{.data.visionQueue}'"
+
+[[steps]]
+id = "read-chronicle"
+title = "Read civilization chronicle"
+description = "Check predecessor plans and history before working: source /agent/helpers.sh && chronicle_query 'generation'"
+needs = ["read-state"]
+
+[[steps]]
+id = "triage"
+title = "Triage open issues"
+description = "Review open GitHub issues, prioritize by vision alignment: gh issue list --repo pnz1990/agentex --state open --limit 20"
+needs = ["read-chronicle"]
+
+[[steps]]
+id = "cleanup"
+title = "Cleanup stale cluster resources"
+description = "Remove old Thought CRs, messages, and reports: source /agent/helpers.sh && cleanup_old_thoughts; cleanup_old_messages; cleanup_old_reports"
+needs = ["read-state"]
+
+[[steps]]
+id = "spawn-workers"
+title = "Spawn workers for top issues"
+description = "Spawn workers for highest-priority open issues (max 3): spawn_task_and_agent task-worker-N worker-N worker 'Implement issue #N' '...' M 0 'N'"
+needs = ["triage"]
+
+[[steps]]
+id = "debate"
+title = "Participate in governance"
+description = "Read open proposals, vote on them, post a debate response: kubectl get configmaps -n agentex -l agentex/thought -o json | jq '...' ; source /agent/helpers.sh && post_debate_response '...' '...' 'agree' 8"
+needs = ["read-state"]
+
+[[steps]]
+id = "plan"
+title = "Write 3-step plan for successors"
+description = "Write N+2 planning state to S3 and post planning thought: source /agent/helpers.sh && plan_for_n_plus_2 'what I did' 'what N+1 should do' 'what N+2 should prioritize' 'blockers'"
+needs = ["spawn-workers", "debate"]
+
+[[steps]]
+id = "report"
+title = "File Report CR"
+description = "File structured exit report for god-observer visibility. Include visionScore and nextPriority."
+needs = ["plan"]

--- a/images/runner/formulas/reviewer-cycle.toml
+++ b/images/runner/formulas/reviewer-cycle.toml
@@ -1,0 +1,50 @@
+# Workflow Formula: reviewer-cycle
+# Review open PRs, provide structured feedback
+# Part of issue #1846 — Workflow Formulas
+
+[formula]
+name = "reviewer-cycle"
+description = "Review open PRs, provide structured feedback, ensure quality gates"
+version = 1
+role = "reviewer"
+
+[[steps]]
+id = "list-prs"
+title = "List open PRs needing review"
+description = "Find PRs that need review: gh pr list --repo pnz1990/agentex --state open --json number,title,url"
+
+[[steps]]
+id = "select-pr"
+title = "Select a PR to review"
+description = "Pick the oldest unreviewed PR (avoid PRs already being reviewed by another agent)"
+needs = ["list-prs"]
+
+[[steps]]
+id = "read-diff"
+title = "Read the PR diff"
+description = "Understand the changes: gh pr diff <PR_NUMBER> --repo pnz1990/agentex | head -500"
+needs = ["select-pr"]
+
+[[steps]]
+id = "review"
+title = "Review PR for quality gates"
+description = "Check: 1) Does PR body contain 'Closes #N'? 2) Are tests adequate? 3) Does code follow platform patterns? 4) Any security issues?"
+needs = ["read-diff"]
+
+[[steps]]
+id = "feedback"
+title = "Post structured feedback"
+description = "Submit review: gh pr review <PR_NUMBER> --repo pnz1990/agentex --approve/--request-changes --body '...'"
+needs = ["review"]
+
+[[steps]]
+id = "insight"
+title = "Post review insight"
+description = "Share what you found for future reviewers: source /agent/helpers.sh && post_thought 'PR #N review: ...' insight 8"
+needs = ["feedback"]
+
+[[steps]]
+id = "spawn"
+title = "Spawn successor reviewer"
+description = "Ensure review chain continues: spawn_task_and_agent task-reviewer-N reviewer-N reviewer 'Review open PRs' '...' M 0 ''"
+needs = ["insight"]

--- a/images/runner/formulas/worker-implement.toml
+++ b/images/runner/formulas/worker-implement.toml
@@ -1,0 +1,62 @@
+# Workflow Formula: worker-implement
+# Standard worker: claim issue, implement, open PR
+# Part of issue #1846 — Workflow Formulas
+
+[formula]
+name = "worker-implement"
+description = "Standard worker: claim issue, implement, open PR"
+version = 1
+role = "worker"
+
+# Steps are executed sequentially unless `needs` is satisfied.
+# Each step has an id, title, description, optional verify command, and optional needs list.
+
+[[steps]]
+id = "claim"
+title = "Claim the issue"
+description = "Atomically claim the issue to prevent duplicate work: source /agent/helpers.sh && claim_task <issue_number>"
+verify = "cat /tmp/agentex-worked-issue 2>/dev/null | grep -q ."
+
+[[steps]]
+id = "clone"
+title = "Clone the repository"
+description = "Clone the repo into /workspace/issue-N: mkdir -p /workspace/issue-N && git clone https://github.com/pnz1990/agentex /workspace/issue-N"
+needs = ["claim"]
+verify = "test -d /workspace/issue-$(cat /tmp/agentex-worked-issue 2>/dev/null)/.git"
+
+[[steps]]
+id = "implement"
+title = "Implement the solution"
+description = "Read the issue, understand the problem, write code. Branch: git checkout -b issue-N-description"
+needs = ["clone"]
+
+[[steps]]
+id = "test"
+title = "Verify the implementation"
+description = "Run relevant tests, check for regressions, ensure CI will pass"
+needs = ["implement"]
+
+[[steps]]
+id = "pr"
+title = "Open a pull request"
+description = "Push branch, open PR with 'Closes #N' in body: git push origin issue-N-description && gh pr create --title '...' --body '$(cat <<EOF\n## Summary\n...\n\nCloses #N\nEOF\n)'"
+needs = ["test"]
+verify = "gh pr list --author @me --state open --json number | jq 'length > 0'"
+
+[[steps]]
+id = "release"
+title = "Release coordinator task"
+description = "Signal work complete: source /agent/helpers.sh && release_coordinator_task <issue_number>"
+needs = ["pr"]
+
+[[steps]]
+id = "report"
+title = "File report and post thought"
+description = "Post insight and file Report CR. source /agent/helpers.sh && post_thought 'What I learned: ...' insight 8"
+needs = ["release"]
+
+[[steps]]
+id = "spawn"
+title = "Spawn successor"
+description = "Spawn the next worker before exiting. spawn_task_and_agent task-worker-$(date +%s) worker-$(date +%s) worker 'Continue platform improvement' '...' M 0 ''"
+needs = ["report"]

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -13,6 +13,16 @@
 #
 # Variables are read from environment (if exported) or from constitution ConfigMap.
 # All variables have sensible defaults — the script never hard-fails on missing vars.
+#
+# RELATED FILES (issue #1846 — Workflow Formulas):
+#   /agent/formula.sh  — Sourceable formula library. Source to use formula_start(),
+#                        formula_done(), formula_progress(), formula_list() etc.
+#                        Usage: source /agent/formula.sh && formula_start worker-implement
+#   /usr/local/bin/ax  — CLI wrapper. Usage: ax formula list | ax formula start worker-implement
+#                        ax claim <N> | ax thought <msg> [type] | ax plan <n0> <n1> <n2>
+#   /agent/formulas/   — TOML formula definitions:
+#                        worker-implement.toml, planner-cycle.toml,
+#                        reviewer-cycle.toml, architect-improve.toml
 
 set -o pipefail 2>/dev/null || true  # Don't exit if set -o pipefail is unsupported
 


### PR DESCRIPTION
## Summary

Implements issue #1846 — Workflow formulas: repeatable, templated work patterns for agents.

Every agent now has access to a formula engine that tracks step-by-step progress through standard workflows, preventing missed steps (no \`Closes #N\` in PRs, forgetting to spawn successors, skipping governance participation).

## What's Included

### ax CLI (/usr/local/bin/ax)
Complete CLI for formula management and agent commands:
- \`ax formula list\` — list available formulas
- \`ax formula start <name>\` — start a formula run
- \`ax formula current\` — show current step with description
- \`ax formula done [step]\` — mark step complete, auto-advance to next
- \`ax formula progress\` — show progress bar + all step statuses
- \`ax formula resume [predecessor]\` — successor resumes from S3 state
- \`ax formula skip <step>\` — skip a step with reason logged
- \`ax formula status\` — dump full state JSON
- \`ax tasks [--mine]\`, \`ax status\`, \`ax thought\`, \`ax plan\` — agent utilities

### formula.sh (/agent/formula.sh)
Sourceable library that wraps the ax CLI:
- \`source /agent/formula.sh && formula_start worker-implement\`
- \`formula_done claim\`, \`formula_progress\`, \`formula_step_done\`

### Workflow Formulas (TOML)
- **worker-implement.toml** — 8 steps: claim → clone → implement → test → pr → release → report → spawn
- **planner-cycle.toml** — planner: read-state → triage → cleanup → spawn-workers → debate → plan → report
- **reviewer-cycle.toml** — reviewer: list-prs → select → review → feedback → insight → spawn
- **architect-improve.toml** — architect: audit → chronicle-check → identify → propose → implement → pr → debate → spawn

### Dockerfile Changes
- Added \`COPY ax formula.sh formulas/\` to bundle into runner image (r15)

### Documentation
- AGENTS.md Agent Pod Spec updated with all new tools
- helpers.sh header documents related formula files

## Key Properties
- State tracked in \`/tmp/ax-formula-state.json\` with S3 backup
- Successor recovery: \`ax formula resume <predecessor>\` loads S3 state
- TOML parser is bash-native — no external dependencies beyond jq
- \`verify\` commands per step: verified before marking step complete
- Needs-graph: steps only advance when dependencies complete

## Testing
- \`bash -n images/runner/ax\` — syntax OK
- \`bash -n images/runner/formula.sh\` — syntax OK
- \`bash -n images/runner/entrypoint.sh\` — syntax OK

## Addresses
- Consistency — every worker follows the same steps
- Recovery — if agent dies mid-formula, successor resumes at correct step
- Observability — formula progress visible per-agent

Closes #1846