### PR TITLE
fix: use stable keyword dedup in proactive scan to prevent duplicate issues

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1840,6 +1840,17 @@ proactive_consensus_scan() {
     local count
     count=$(echo "$unresolved" | tr ',' '\n' | wc -l)
     if [ "$count" -gt 10 ]; then
+      # Issue #1934: Dedup check using stable keyword (not count-varying title).
+      # The count in the title changes every run, defeating dedup if we search by title.
+      # Use a stable keyword that identifies this issue type regardless of count.
+      local existing_debate_issue
+      existing_debate_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "debate backlog unresolved debate threads" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_debate_issue:-0}" -gt 0 ]; then
+        log "Consensus scan: debate backlog issue already open — skipping duplicate filing (issue #1934)"
+        return 0
+      fi
       log "Consensus scan: $count unresolved debates — filing issue for debate backlog..."
       file_proactive_issue "consensus" \
         "debate backlog: $count unresolved debate threads need synthesis" \
@@ -1959,6 +1970,18 @@ The coordinator updates \`lastHeartbeat\` every iteration (~30s). A stale heartb
     local debate_count
     debate_count=$(echo "$unresolved_debates" | tr ',' '\n' | grep -c '.' 2>/dev/null || echo "0")
     if [ "$debate_count" -gt 50 ]; then
+      # Issue #1934: Dedup check using stable keyword (not count-varying title).
+      # Searching by title includes the count (e.g. "86 unresolved debates") which changes
+      # every run, so a new issue is filed even when one is already open. Use a stable
+      # keyword that identifies this issue type regardless of current count.
+      local existing_synthesis_issue
+      existing_synthesis_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "civilization health unresolved debates synthesis backlog" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_synthesis_issue:-0}" -gt 0 ]; then
+        log "Coordinator scan: synthesis backlog issue already open — skipping duplicate filing (issue #1934)"
+        return 0
+      fi
       log "Coordinator scan: $debate_count unresolved debate threads (>50) — filing issue..."
       file_proactive_issue "enhancement" \
         "civilization health: $debate_count unresolved debates — synthesis backlog growing" \


### PR DESCRIPTION
## Summary

Both `proactive_consensus_scan()` and `proactive_coordinator_scan()` filed duplicate GitHub issues because the unresolved-debate count was embedded in the issue title. Since the count changes every run, the `gh issue list --search` by title never found the existing open issue.

Evidence: Issues #1969, #1971, #1976, #1977 were all filed within minutes of each other — all identical except for the count in the title.

## Root Cause

The dedup search used the full title prefix which included the count:
- `"civilization health: 86 unresolved debates"` 
- Next run: `"civilization health: 85 unresolved debates"` → different title → new issue filed

## Fix

Before filing each issue type, check for any open issue with a **stable keyword** that uniquely identifies the issue type regardless of the current count:

- `proactive_consensus_scan()`: search `"debate backlog unresolved debate threads"`
- `proactive_coordinator_scan()` Check 3: search `"civilization health unresolved debates synthesis backlog"`

If an open issue already exists, log a skip message and return early.

## Changes

- `images/runner/entrypoint.sh`: Added stable-keyword dedup checks in both scan functions (23 lines added)

Closes #1934