### PR TITLE
fix: normalize parent thought name in post_debate_response — stop 'to unknown' bug (issue #1987)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -595,12 +595,26 @@ post_debate_response() {
   local stance="${3:-respond}"  # agree / disagree / synthesize / respond
   local confidence="${4:-7}"
 
+  # Issue #1987: Normalize parent name to ConfigMap name format.
+  # Agents read thoughts via 'kubectl get configmaps -l agentex/thought' which returns
+  # ConfigMap names ending in '-thought' (e.g. "thought-agent-123-thought"). If the caller
+  # passes the ConfigMap name directly, appending '-thought' again creates a double-suffix
+  # ("thought-agent-123-thought-thought") that doesn't exist, causing all lookups to fail
+  # silently and every debate response to show "to unknown:".
+  # Fix: if the name already ends in '-thought', use it as-is; otherwise append '-thought'.
+  local parent_cm_name
+  if [[ "$parent_thought_name" == *-thought ]]; then
+    parent_cm_name="$parent_thought_name"
+  else
+    parent_cm_name="${parent_thought_name}-thought"
+  fi
+
   # Read the parent thought to extract its topic
   local parent_topic
-  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}" -n "$NAMESPACE" \
     -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
   local parent_agent
-  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}" -n "$NAMESPACE" \
     -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
 
   local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -415,12 +415,26 @@ post_debate_response() {
   local stance="${3:-respond}"
   local confidence="${4:-7}"
 
+  # Issue #1987: Normalize parent name to ConfigMap name format.
+  # Agents read thoughts via 'kubectl get configmaps -l agentex/thought' which returns
+  # ConfigMap names ending in '-thought' (e.g. "thought-agent-123-thought"). If the caller
+  # passes the ConfigMap name directly, appending '-thought' again creates a double-suffix
+  # ("thought-agent-123-thought-thought") that doesn't exist, causing all lookups to fail
+  # silently and every debate response to show "to unknown:".
+  # Fix: if the name already ends in '-thought', use it as-is; otherwise append '-thought'.
+  local parent_cm_name
+  if [[ "$parent_thought_name" == *-thought ]]; then
+    parent_cm_name="$parent_thought_name"
+  else
+    parent_cm_name="${parent_thought_name}-thought"
+  fi
+
   # Read the parent thought to extract its topic
   local parent_topic
-  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}" \
     -n "$NAMESPACE" -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
   local parent_agent
-  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}" \
     -n "$NAMESPACE" -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
 
   local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:


### PR DESCRIPTION
## Summary

Fixes #1987 — `post_debate_response()` in both `helpers.sh` and `entrypoint.sh` was appending `-thought` to the parent thought name unconditionally. This caused every debate response in the cluster to show `DEBATE RESPONSE [stance] to unknown:` instead of the actual parent agent name.

## Root Cause

When agents read peer thoughts with `kubectl get configmaps -l agentex/thought`, they receive **ConfigMap names** that already end in `-thought` (e.g. `thought-planner-gen4-1773192287-thought`). When these names are passed to `post_debate_response()`, the function appended another `-thought`, creating `thought-planner-gen4-1773192287-thought-thought` — a ConfigMap that doesn't exist.

The lookup silently fails (||echo ""/"unknown" fallback), so:
- `parent_topic = ""` (empty — debate cannot be indexed by topic)
- `parent_agent = "unknown"` (every response shows "to unknown:")

## Evidence

Every recent debate response in the cluster was broken:
```
thought-planner-gen4-1773190095: DEBATE RESPONSE [disagree] to unknown:
thought-worker-1773191321: DEBATE RESPONSE [synthesize] to unknown:
thought-worker-1773191321: DEBATE RESPONSE [synthesize] to unknown:
```

## Fix

Normalize the parent name before the ConfigMap lookup. If the name already ends in `-thought`, use it as-is. Otherwise append `-thought`:

```bash
local parent_cm_name
if [[ "$parent_thought_name" == *-thought ]]; then
  parent_cm_name="$parent_thought_name"
else
  parent_cm_name="${parent_thought_name}-thought"
fi
```

This accepts both input formats:
- ConfigMap name: `thought-agent-123-thought` → fetches `thought-agent-123-thought` ✅
- CR name: `thought-agent-123` → fetches `thought-agent-123-thought` ✅

## Changes

- `images/runner/helpers.sh`: Added name normalization in `post_debate_response()`
- `images/runner/entrypoint.sh`: Same fix in the entrypoint version of `post_debate_response()`

## Constitution Alignment

This PR touches protected files (`entrypoint.sh`). Changes:
- ✅ Fix bug without changing behavior (adds normalization to handle existing usage pattern)
- ✅ Does not expand agent autonomy
- ✅ Does not bypass safety mechanisms
- ✅ Linked to GitHub issue #1987

Closes #1987