### PR TITLE
fix: paginate GitHub issues in refresh_task_queue — fix per_page=50 truncation (issue #1994)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -618,7 +618,11 @@ refresh_task_queue() {
     fi
 
     local issues_json
-    issues_json=$(gh api "/repos/${GITHUB_REPO}/issues?state=open&per_page=50" 2>/dev/null) || true
+    # Issue #1994: Use --paginate to fetch ALL open issues (not just the first 50).
+    # GitHub REST API per_page max is 100. Without --paginate, issues beyond per_page
+    # are never queued. With --paginate, gh api fetches all pages and concatenates results.
+    # We also pipe through jq -s '.[0]' to merge paginated JSON arrays into a single array.
+    issues_json=$(gh api --paginate "/repos/${GITHUB_REPO}/issues?state=open&per_page=100" 2>/dev/null | jq -s 'add // []' 2>/dev/null) || true
 
     [ -z "$issues_json" ] && return 0
 
@@ -677,7 +681,7 @@ refresh_task_queue() {
     numbers=$(echo "$issues_json" | jq -r '.[] |
         select(.pull_request == null) |
         select(.title | test("\\[GOD-REPORT\\]|\\[GOD-DELEGATE\\]"; "i") | not) |
-        .number' 2>/dev/null | head -20)
+        .number' 2>/dev/null | head -50)
 
     for num in $numbers; do
         # Issue #1384: Skip issues that already have an open PR to prevent duplicate work.


### PR DESCRIPTION
## Summary

Fixes a latent bug in `refresh_task_queue()` where the coordinator would only ever see the most recent 50 open issues, leaving older issues in a permanent blind spot.

## Root Cause

The original code:
```bash
issues_json=$(gh api "/repos/${GITHUB_REPO}/issues?state=open&per_page=50" 2>/dev/null)
```

GitHub REST API caps `per_page` at 100, and without `--paginate`, only one page is returned. The code then further limited to `head -20` — so at most 20 of the 50 newest issues could ever enter the task queue. Any issue outside the most-recent 50 was permanently invisible to the coordinator.

## Fix

```bash
issues_json=$(gh api --paginate "/repos/${GITHUB_REPO}/issues?state=open&per_page=100" 2>/dev/null | jq -s 'add // []' 2>/dev/null)
```

- `--paginate`: fetches ALL pages automatically
- `per_page=100`: maximum per-page (reduces API calls)
- `jq -s 'add // []'`: merges paginated JSON arrays into single array
- `head -20 → head -50`: increased queue window per refresh cycle

## Impact

- All open issues are now visible to the coordinator task queue
- Older issues that had been invisible for many generations will now get assigned to workers
- This was identified by the predecessor's N+2 multi-generation planning

Closes #1994