### PR TITLE
fix: batch S3 download in check_v05_milestone() — replace 50 sequential aws s3 cp calls with single aws s3 sync

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -3782,10 +3782,14 @@ check_v05_milestone() {
     local criteria_met=0
     local criteria_report=""
 
-    # ── Criteria 1, 3, 4: Single S3 download loop (issue #1764) ─────────────
-    # All three criteria use the same identity files — download each file once
-    # and extract all three metrics in a single pass. This reduces S3 API calls
-    # from 150 (3 loops × 50 files) to 50 (1 loop × 50 files).
+    # ── Criteria 1, 3, 4: Batch S3 download (issue #1896) ───────────────────
+    # All three criteria use the same identity files — download all files once
+    # via a single aws s3 sync call and extract all three metrics in a single pass.
+    #
+    # Issue #1764: Reduced from 3 loops × 50 files to 1 loop × 50 files.
+    # Issue #1896: Reduced further from 50 sequential aws s3 cp calls (~100s) to
+    #   1 batch aws s3 sync call (~5-10s) by downloading to a temp directory.
+    #   This mirrors the fix applied to check_v06_milestone() in issue #1920.
     #
     # Issue #1808: Sort by modification date DESCENDING (newest first) to ensure recent
     # worker identities are sampled. Without this, alphabetical S3 ordering returns
@@ -3797,14 +3801,28 @@ check_v05_milestone() {
         --region "$BEDROCK_REGION" 2>/dev/null | \
         sort -k1,2 -r | awk '{print $4}' | grep '\.json$' | grep -v '^$' | head -50 || echo "")
 
+    # Batch-download identity files to a temp directory (1 sync call vs 50 sequential cp calls)
+    local identity_tmp_dir
+    identity_tmp_dir=$(mktemp -d 2>/dev/null || echo "/tmp/v05-identities-$$")
+    mkdir -p "$identity_tmp_dir"
+
+    if [ -n "$identity_files" ]; then
+        aws s3 sync "s3://${IDENTITY_BUCKET}/identities/" "$identity_tmp_dir/" \
+            --region "$BEDROCK_REGION" \
+            --quiet 2>/dev/null || true
+    fi
+    echo "[$(date -u +%H:%M:%S)] v0.5 identity sync complete: $(ls "$identity_tmp_dir/" 2>/dev/null | wc -l) files downloaded"
+
     local promoted_count=0
     local proactive_count=0
     local mentor_credit_count=0
 
+    # Process files in newest-first order (sorted from S3 listing above)
     for ifile in $identity_files; do
+        local local_identity_path="$identity_tmp_dir/$ifile"
+        [ ! -f "$local_identity_path" ] && continue
         local ijson
-        ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - \
-            --region "$BEDROCK_REGION" 2>/dev/null || echo "")
+        ijson=$(cat "$local_identity_path" 2>/dev/null || echo "")
         [ -z "$ijson" ] && continue
 
         # Criterion 1: promotedRole
@@ -3822,6 +3840,9 @@ check_v05_milestone() {
         mc=$(echo "$ijson" | jq -r '(.specializationDetail.mentorCredits // []) | length' 2>/dev/null || echo "0")
         [ "$mc" -gt 0 ] 2>/dev/null && mentor_credit_count=$((mentor_credit_count + 1))
     done
+
+    # Cleanup temp dir
+    rm -rf "$identity_tmp_dir" 2>/dev/null || true
 
     # ── Criterion 1: 3+ agents with promotedRole ─────────────────────────────
     if [ "$promoted_count" -ge 3 ]; then


### PR DESCRIPTION
## Summary

Fixes the coordinator blocking issue where `check_v05_milestone()` downloaded 50 identity files from S3 sequentially, blocking the coordinator main loop for 90+ seconds every 10 minutes.

## Root Cause

`check_v05_milestone()` used `aws s3 cp` in a loop for each of the 50 identity files (inherited from issue #1764 single-loop optimization). Each call takes ~1-2 seconds, making the total ~100 seconds — 3+ full coordinator iterations.

## Fix

Replaced the per-file `aws s3 cp` loop with a single `aws s3 sync` to a temp directory, then process local files with `cat`. This mirrors the exact fix already applied to `check_v06_milestone()` in issue #1920.

```bash
# Before (50 sequential network calls ~100s):
for ifile in $identity_files; do
    ijson=$(aws s3 cp "s3://${IDENTITY_BUCKET}/identities/${ifile}" - ...)

# After (1 batch sync ~5-10s):
aws s3 sync "s3://${IDENTITY_BUCKET}/identities/" "$identity_tmp_dir/" ...
for ifile in $identity_files; do
    ijson=$(cat "$identity_tmp_dir/$ifile" ...)
```

## Impact

- **Before**: 90+ second block every 10 minutes, losing 3 coordinator iterations
- **After**: ~5-10 second batch download, negligible coordinator impact
- No functional change — same identity files processed in the same newest-first order

## Testing

The pattern is identical to the already-merged `check_v06_milestone()` fix (issue #1920), which has been running in production.

Closes #1896