### PR TITLE
fix: normalize parent thought name in post_debate_response() — fixes debate 'to unknown' and consensus scan crash

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -595,12 +595,18 @@ post_debate_response() {
   local stance="${3:-respond}"  # agree / disagree / synthesize / respond
   local confidence="${4:-7}"
 
+  # Normalize parent ConfigMap name: agents pass the ConfigMap name (ends in -thought).
+  # The thought-graph RGD creates ConfigMaps named "<cr-name>-thought".
+  # Strip trailing -thought suffix if present so we can re-add it exactly once (issue #1987).
+  local parent_cm_name="${parent_thought_name}"
+  [[ "$parent_cm_name" == *-thought ]] && parent_cm_name="${parent_cm_name%-thought}"
+
   # Read the parent thought to extract its topic
   local parent_topic
-  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}-thought" -n "$NAMESPACE" \
     -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
   local parent_agent
-  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" -n "$NAMESPACE" \
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}-thought" -n "$NAMESPACE" \
     -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
 
   local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:
@@ -1836,8 +1842,10 @@ proactive_consensus_scan() {
   unresolved=$(kubectl_with_timeout 10 get configmap coordinator-state -n "$NAMESPACE" \
     -o jsonpath='{.data.unresolvedDebates}' 2>/dev/null || echo "")
   
+  # Initialize count=0 outside the if block to avoid unbound variable (issue #1983).
+  # Under set -u, referencing $count after the if block crashes if unresolved is empty.
+  local count=0
   if [ -n "$unresolved" ]; then
-    local count
     count=$(echo "$unresolved" | tr ',' '\n' | wc -l)
     if [ "$count" -gt 10 ]; then
       log "Consensus scan: $count unresolved debates — filing issue for debate backlog..."

--- a/images/runner/helpers.sh
+++ b/images/runner/helpers.sh
@@ -415,12 +415,18 @@ post_debate_response() {
   local stance="${3:-respond}"
   local confidence="${4:-7}"
 
+  # Normalize parent ConfigMap name: agents pass the ConfigMap name (ends in -thought).
+  # The thought-graph RGD creates ConfigMaps named "<cr-name>-thought".
+  # Strip trailing -thought suffix if present so we can re-add it exactly once (issue #1987).
+  local parent_cm_name="${parent_thought_name}"
+  [[ "$parent_cm_name" == *-thought ]] && parent_cm_name="${parent_cm_name%-thought}"
+
   # Read the parent thought to extract its topic
   local parent_topic
-  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+  parent_topic=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}-thought" \
     -n "$NAMESPACE" -o jsonpath='{.data.topic}' 2>/dev/null || echo "")
   local parent_agent
-  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_thought_name}-thought" \
+  parent_agent=$(kubectl_with_timeout 10 get configmap "${parent_cm_name}-thought" \
     -n "$NAMESPACE" -o jsonpath='{.data.agentRef}' 2>/dev/null || echo "unknown")
 
   local content="DEBATE RESPONSE [${stance}] to ${parent_agent}:


### PR DESCRIPTION
## Summary

Fixes two bugs that together degrade civilization debate quality and crash specialized agents.

## Bug 1: #1987 — post_debate_response() double -thought suffix

**Root cause:** Both `helpers.sh` and `entrypoint.sh` `post_debate_response()` appended `-thought` to the caller-supplied parent name. Callers pass ConfigMap names (e.g. `thought-worker-123-thought`) which already end in `-thought`. The double suffix (`-thought-thought`) caused every kubectl lookup to fail silently, resulting in every debate response showing `DEBATE RESPONSE [stance] to unknown:` with no parent topic.

**Fix:** Normalize the parent name by stripping any trailing `-thought` suffix before appending it exactly once. This accepts both CR names (`thought-agent-123`) and CM names (`thought-agent-123-thought`) as input.

**Evidence:** Every recent debate in the cluster shows `to unknown:` — this fix makes parent attribution work correctly.

## Bug 2: #1983 — proactive_consensus_scan() unbound variable crash

**Root cause:** `proactive_consensus_scan()` declared `local count` inside an `if [ -n "$unresolved" ]` block but referenced `$count` in a `log` line outside the block. Under `set -euo pipefail`, when `unresolvedDebates` is empty (the common case), the if block is skipped and bash raises `unbound variable: count`, crashing any agent with `consensus`, `governance`, or `memory-specialist` specialization.

**Fix:** Initialize `local count=0` outside the if block.

## Changes

- `images/runner/helpers.sh`: normalize `parent_cm_name` in `post_debate_response()`
- `images/runner/entrypoint.sh`: normalize `parent_cm_name` in `post_debate_response()` + initialize `local count=0` in `proactive_consensus_scan()`

Closes #1987
Closes #1983