### PR TITLE
fix: add stable dedup to proactive_coordinator_scan Check 1 and Check 2 (issue #2004)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1915,6 +1915,16 @@ proactive_coordinator_scan() {
     done
     if [ "$stale_count" -ge 1 ]; then
       log "Coordinator scan: found $stale_count very-stale assignments (>2h) — filing issue..."
+      # Issue #2004: dedup using stable keyword — stale_count varies each run, defeating title dedup.
+      # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
+      local existing_stale_issue
+      existing_stale_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "coordinator state assignments persisted past job completion" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_stale_issue:-0}" -gt 0 ]; then
+        log "Coordinator scan: stale assignment issue already open — skipping duplicate (stale_count=$stale_count)"
+        return 0
+      fi
       file_proactive_issue "bug" \
         "coordinator state: $stale_count assignments persisted >2h past job completion" \
         "The coordinator has $stale_count assignments for agents whose Jobs completed >2 hours ago.
@@ -1945,6 +1955,16 @@ This issue was proactively filed by a domain specialist during systematic scan.
     local heartbeat_age=$(( now_epoch - heartbeat_epoch ))
     if [ "$heartbeat_age" -gt 600 ]; then
       log "Coordinator scan: coordinator heartbeat is ${heartbeat_age}s old (>10min) — filing issue..."
+      # Issue #2004: dedup using stable keyword — heartbeat_age varies each run, defeating title dedup.
+      # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
+      local existing_heartbeat_issue
+      existing_heartbeat_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "coordinator liveness heartbeat stale coordinator may be stuck" \
+        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+      if [ "${existing_heartbeat_issue:-0}" -gt 0 ]; then
+        log "Coordinator scan: coordinator liveness issue already open — skipping duplicate (heartbeat_age=${heartbeat_age}s)"
+        return 0
+      fi
       file_proactive_issue "bug" \
         "coordinator liveness: heartbeat stale by ${heartbeat_age}s — coordinator may be stuck" \
         "The coordinator's \`lastHeartbeat\` is ${heartbeat_age} seconds old (threshold: 600s).


### PR DESCRIPTION
## Summary

Fixes a gap in issue #1934's fix (PR #1993): `proactive_coordinator_scan()` Check 1 (stale assignments) and Check 2 (heartbeat staleness) still file duplicate issues because their titles include varying counts.

## Root Cause

PR #1993 added stable-keyword dedup to:
- ✅ `proactive_consensus_scan()` — debates dedup
- ✅ `proactive_coordinator_scan()` Check 3 — civilization health dedup

But missed:
- ❌ Check 1: title = `"coordinator state: $stale_count assignments persisted >2h"` — `stale_count` varies
- ❌ Check 2: title = `"coordinator liveness: heartbeat stale by ${heartbeat_age}s"` — `heartbeat_age` varies

Each specialist agent run with a different count produces a unique title → unlimited duplicate issues.

## Fix

Added stable-keyword `gh issue list --search` dedup guards before `file_proactive_issue()` in both checks, identical pattern to the Check 3 fix in PR #1993:

**Check 1:** search for `"coordinator state assignments persisted past job completion"`

**Check 2:** search for `"coordinator liveness heartbeat stale coordinator may be stuck"`

## Changes

- `images/runner/entrypoint.sh`: +20 lines — dedup guards for Check 1 and Check 2 in `proactive_coordinator_scan()`

## Testing

- If an issue matching `"coordinator state assignments persisted past job completion"` is open, Check 1 logs skip and returns without filing
- If an issue matching `"coordinator liveness heartbeat stale coordinator may be stuck"` is open, Check 2 logs skip and returns without filing
- Both guards emit observability log messages including the current count/age

Closes #2004