### PR TITLE
fix: use bracket notation for slash-containing jsonpath annotation key (issue #2003)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1413,9 +1413,10 @@ check_stuck_swarms() {
         fi
 
         # Check if we recently respawned this swarm (annotation check to prevent loop)
+        # Issue #2003: Use bracket notation for annotation key with slash — dot notation returns empty
         local last_respawn_ts
         last_respawn_ts=$(kubectl_with_timeout 10 get configmap "$swarm_name" -n "$NAMESPACE" \
-            -o jsonpath='{.metadata.annotations.agentex/last-stuck-respawn}' 2>/dev/null || echo "")
+            -o jsonpath='{.metadata.annotations['\''agentex/last-stuck-respawn'\'']}' 2>/dev/null || echo "")
         if [ -n "$last_respawn_ts" ]; then
             local last_respawn_epoch time_since_respawn
             last_respawn_epoch=$(date -d "$last_respawn_ts" +%s 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

Fixes the stuck-swarm throttle check that was never enforcing the 5-minute cooldown between respawns.

## Problem

`check_stuck_swarms()` in coordinator.sh used kubectl jsonpath **dot notation** to read an annotation with a forward slash in its key:

```bash
-o jsonpath='{.metadata.annotations.agentex/last-stuck-respawn}'
```

Kubernetes jsonpath requires **bracket notation** for keys containing special characters like `/`. Dot notation always returns empty string, so `[ -n "$last_respawn_ts" ]` was always false — the 5-minute throttle was never enforced.

## Impact

Without throttling, a stuck swarm in `Forming` phase could be respawned on **every coordinator loop iteration** (every ~30 seconds) with no rate limiting. This causes unnecessary job creation and coordinator log spam.

## Fix

```bash
# Before (broken — always returns empty):
-o jsonpath='{.metadata.annotations.agentex/last-stuck-respawn}'

# After (correct):
-o jsonpath='{.metadata.annotations['\''agentex/last-stuck-respawn'\'']}'
```

## Changes

- Single-line fix in `images/runner/coordinator.sh` (non-protected file)
- Adds inline comment explaining the bracket notation requirement

Closes #2003