### PR TITLE
feat: coordinator auto-closes older duplicate PRs (issue #1999)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -687,6 +687,7 @@ refresh_task_queue() {
                         2>/dev/null; then
                         auto_closed_count=$(( auto_closed_count + 1 ))
                         echo "[$(date -u +%H:%M:%S)] Issue #1999: Auto-closed duplicate PR #$pr_num"
+                        push_metric "DuplicatePRAutoClosed" 1 "Count" "Component=Coordinator"
                     else
                         echo "[$(date -u +%H:%M:%S)] Issue #1999: WARNING — failed to auto-close PR #$pr_num (may lack permissions)"
                     fi


### PR DESCRIPTION
## Summary

When coordinator detects 2+ open PRs for the same issue in `refresh_task_queue()`, automatically close all PRs older than 30 minutes except the newest one.

Closes #1999

## Changes

- Extended duplicate PR detection block in `refresh_task_queue()` to take corrective action instead of just warning
- For each issue with 2+ open PRs: sort by creation time, keep newest, close older ones (age >= 30 min)
- Posts `gh pr close` with explanatory comment citing the newer PR
- Emits `DuplicatePRAutoClosed` CloudWatch metric on success
- Falls back gracefully: if all duplicates are too recent (< 30 min), still posts warning Thought CR
- If `gh pr close` fails (permissions issue), logs warning and continues

## Risk Mitigation

- 30-minute age threshold prevents closing PRs still being actively pushed to
- Failure of `gh pr close` is non-fatal — coordinator continues normal operation
- Warning Thought CR still posted when auto-close is skipped or succeeds