### PR TITLE
fix: use kubectl replace for coordinator-script ConfigMap sync (issue #2016)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -2798,27 +2798,30 @@ sync_coordinator_configmap_if_stale() {
     log "WARNING: sync_coordinator_configmap: could not record sync timestamp/SHA. Proceeding anyway."
   fi
 
-  # Update the ConfigMap from git main (no annotation — coordinator.sh is too large for annotations)
+  # Update the ConfigMap from git main using kubectl replace (issue #2016: kubectl apply fails
+  # because it saves the full manifest in a last-applied-configuration annotation, pushing
+  # the ~290KB coordinator.sh ConfigMap over the 262144 byte annotation size limit).
+  # kubectl replace updates the ConfigMap directly without creating annotations.
   if kubectl_with_timeout 30 create configmap coordinator-script \
       --from-file=coordinator.sh="${coordinator_file}" \
       -n "$NAMESPACE" --dry-run=client -o yaml 2>/dev/null | \
-      kubectl_with_timeout 30 apply --validate=false -f - 2>&1; then
+      kubectl_with_timeout 30 replace -f - 2>&1; then
     log "✓ sync_coordinator_configmap: coordinator-script ConfigMap updated (SHA: ${git_sha:0:12})"
 
     # Restart deployment to pick up new ConfigMap
     if kubectl_with_timeout 30 rollout restart deployment coordinator -n "$NAMESPACE" 2>&1; then
       log "✓ sync_coordinator_configmap: coordinator deployment restarted to load updated script"
-      post_thought "Auto-synced coordinator-script ConfigMap (issues #1682/#1695/#1943): git SHA drift detected (${cm_sha:0:12} → ${git_sha:0:12}). Updated ConfigMap and restarted coordinator deployment." "insight" 8
+      post_thought "Auto-synced coordinator-script ConfigMap (issues #1682/#1695/#1943/#2016): git SHA drift detected (${cm_sha:0:12} → ${git_sha:0:12}). Updated ConfigMap and restarted coordinator deployment." "insight" 8
     else
       log "WARNING: sync_coordinator_configmap: ConfigMap updated but deployment restart failed"
-      post_thought "Auto-synced coordinator-script ConfigMap (issues #1682/#1695/#1943): updated ConfigMap (SHA: ${git_sha:0:12}) but deployment restart FAILED. Manual restart may be needed: kubectl rollout restart deployment coordinator -n agentex" "blocker" 8
+      post_thought "Auto-synced coordinator-script ConfigMap (issues #1682/#1695/#1943/#2016): updated ConfigMap (SHA: ${git_sha:0:12}) but deployment restart FAILED. Manual restart may be needed: kubectl rollout restart deployment coordinator -n agentex" "blocker" 8
     fi
   else
-    log "ERROR: sync_coordinator_configmap: failed to apply ConfigMap"
+    log "ERROR: sync_coordinator_configmap: failed to replace ConfigMap"
     # Revert the SHA we recorded so next planner will retry
     kubectl_with_timeout 10 patch configmap coordinator-state -n "$NAMESPACE" \
       --type=merge -p "{\"data\":{\"lastCoordinatorScriptSHA\":\"${cm_sha}\"}}" 2>/dev/null || true
-    post_thought "coordinator-script ConfigMap drift detected (issues #1682/#1695/#1943): SHA mismatch (cm=${cm_sha:0:12} vs git=${git_sha:0:12}). Auto-update FAILED. Manual fix: kubectl create configmap coordinator-script --from-file=coordinator.sh=images/runner/coordinator.sh -n agentex --dry-run=client -o yaml | kubectl apply --validate=false -f -" "blocker" 9
+    post_thought "coordinator-script ConfigMap drift detected (issues #1682/#1695/#1943/#2016): SHA mismatch (cm=${cm_sha:0:12} vs git=${git_sha:0:12}). Auto-update FAILED (kubectl replace). Manual fix: kubectl create configmap coordinator-script --from-file=coordinator.sh=images/runner/coordinator.sh -n agentex --dry-run=client -o yaml | kubectl replace -f -" "blocker" 9
   fi
 }
 


### PR DESCRIPTION
## Summary

Fix `sync_coordinator_configmap_if_stale()` in `entrypoint.sh` to use `kubectl replace` instead of `kubectl apply --validate=false` when updating the coordinator-script ConfigMap.

## Root Cause

`kubectl apply` saves the full manifest in a `kubectl.kubernetes.io/last-applied-configuration` annotation. The coordinator.sh file is ~290KB. Adding this annotation to a ~290KB ConfigMap pushes the total object size over the 262144 byte annotation size limit enforced by the Kubernetes API server (even with `--validate=false`). This caused `sync_coordinator_configmap_if_stale()` to **always fail**, meaning:

- coordinator-script ConfigMap SHA drift persisted indefinitely
- All merged improvements to coordinator.sh were silently ignored by the running coordinator
- Every planner reported a blocker thought about auto-update failing

## Fix

Replace `kubectl apply --validate=false` with `kubectl replace`:

```bash
# Before (broken):
kubectl_with_timeout 30 apply --validate=false -f -

# After (fixed):
kubectl_with_timeout 30 replace -f -
```

`kubectl replace` updates the ConfigMap directly without storing a last-applied annotation, so large ConfigMaps (like coordinator.sh) work correctly.

## Testing

The fix can be verified by running the coordinator sync manually:
```bash
kubectl create configmap coordinator-script \
  --from-file=coordinator.sh=images/runner/coordinator.sh \
  -n agentex --dry-run=client -o yaml | kubectl replace -f -
```
This succeeds where `kubectl apply` fails.

## Protected File Note

This change touches `images/runner/entrypoint.sh` (protected file).

Constitution alignment checklist:
- ✅ Fixes bug without changing behavior — behavior is identical, just the kubectl command changed
- ✅ Does not expand agent autonomy or bypass safety mechanisms  
- ✅ Cites relevant issue (#2016) with root cause analysis
- ✅ No new capabilities added; existing sync logic unchanged

Closes #2016

Ready for god review - constitution alignment verified

Constitution alignment checklist:
- [x] Fixes bug without changing behavior (kubectl replace does the same update as apply, without the annotation)
- [x] Cites relevant constitution/vision sections in PR description (references issue #2016, #1682, #1695, #1943)
- [x] Linked to GitHub issue #2016
- [x] Does not expand agent autonomy or bypass safety mechanisms