### PR TITLE
fix: prevent duplicate milestone issues during coordinator rolling updates

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -4063,12 +4063,23 @@ Begin v0.6 milestone planning. Suggest: focus on **swarm intelligence** — grou
 
 Closes #1732"
 
-        gh issue create \
-            --repo "${GITHUB_REPO}" \
-            --title "milestone: v0.5 Emergent Specialization COMPLETE — all criteria verified by coordinator" \
-            --label "enhancement,self-improvement" \
-            --body "$milestone_body" 2>/dev/null || \
-            echo "[$(date -u +%H:%M:%S)] WARNING: Could not file v0.5 completion issue (non-fatal)"
+        # Issue #2019: Pre-filing dedup check — prevent duplicate issues during concurrent
+        # coordinator instances (rolling updates). Both instances pass the ConfigMap guard
+        # before either patches it; the GitHub check provides a second barrier.
+        local existing_v05_issue
+        existing_v05_issue=$(gh issue list --repo "${GITHUB_REPO}" \
+            --search "milestone: v0.5 Emergent Specialization COMPLETE" \
+            --state open --limit 1 2>/dev/null | head -1)
+        if [ -n "$existing_v05_issue" ]; then
+            echo "[$(date -u +%H:%M:%S)] check_v05_milestone: milestone issue already exists — skipping duplicate creation (issue #2019)"
+        else
+            gh issue create \
+                --repo "${GITHUB_REPO}" \
+                --title "milestone: v0.5 Emergent Specialization COMPLETE — all criteria verified by coordinator" \
+                --label "enhancement,self-improvement" \
+                --body "$milestone_body" 2>/dev/null || \
+                echo "[$(date -u +%H:%M:%S)] WARNING: Could not file v0.5 completion issue (non-fatal)"
+        fi
 
         push_metric "MilestoneCompleted" 1 "Count" "Milestone=v0.5"
     fi
@@ -4300,12 +4311,23 @@ swarms reasoning about other swarms' work and collaborating across goal boundari
 
 Closes #1771"
 
-        gh issue create \
-            --repo "${GITHUB_REPO}" \
-            --title "milestone: v0.6 Collective Action COMPLETE — all criteria verified by coordinator" \
-            --label "enhancement,self-improvement" \
-            --body "$milestone_body" 2>/dev/null || \
-            echo "[$(date -u +%H:%M:%S)] WARNING: Could not file v0.6 completion issue (non-fatal)"
+        # Issue #2019: Pre-filing dedup check — prevent duplicate issues during concurrent
+        # coordinator instances (rolling updates). Both instances pass the ConfigMap guard
+        # before either patches it; the GitHub check provides a second barrier.
+        local existing_v06_issue
+        existing_v06_issue=$(gh issue list --repo "${GITHUB_REPO}" \
+            --search "milestone: v0.6 Collective Action COMPLETE" \
+            --state open --limit 1 2>/dev/null | head -1)
+        if [ -n "$existing_v06_issue" ]; then
+            echo "[$(date -u +%H:%M:%S)] check_v06_milestone: milestone issue already exists — skipping duplicate creation (issue #2019)"
+        else
+            gh issue create \
+                --repo "${GITHUB_REPO}" \
+                --title "milestone: v0.6 Collective Action COMPLETE — all criteria verified by coordinator" \
+                --label "enhancement,self-improvement" \
+                --body "$milestone_body" 2>/dev/null || \
+                echo "[$(date -u +%H:%M:%S)] WARNING: Could not file v0.6 completion issue (non-fatal)"
+        fi
 
         push_metric "MilestoneCompleted" 1 "Count" "Milestone=v0.6"
     fi


### PR DESCRIPTION
## Summary

Fixes coordinator filing duplicate milestone announcement issues during Deployment rolling updates.

Closes #2019

## Problem

During a coordinator Deployment rolling update, two instances run briefly in parallel. Both can pass the ConfigMap-based guard (`v05/v06MilestoneStatus != 'completed'`) before either patches the ConfigMap to `'completed'`. This causes both instances to file identical GitHub issues.

**Evidence:** Issues #2011 and #2014 were identical v0.6 milestone completion reports filed 5 minutes apart (within a single coordinator check cycle).

## Fix

Added a pre-filing GitHub search check in both `check_v05_milestone()` and `check_v06_milestone()`:

```bash
existing_v06_issue=$(gh issue list --repo "${GITHUB_REPO}" \
    --search "milestone: v0.6 Collective Action COMPLETE" \
    --state open --limit 1 2>/dev/null | head -1)
if [ -n "$existing_v06_issue" ]; then
    echo "Milestone issue already exists — skipping duplicate creation"
else
    gh issue create ...
fi
```

This provides a second deduplication barrier that covers the concurrent-coordinator window that the ConfigMap guard cannot handle.

## Changes

- `images/runner/coordinator.sh`: Added duplicate check before `gh issue create` in both `check_v05_milestone()` and `check_v06_milestone()`

## Testing

The logic is straightforward: if `gh issue list` returns any result matching the milestone title, skip creation. The existing ConfigMap guard remains as the primary check (no S3/API calls needed on every loop iteration).