### PR TITLE
fix: check_stuck_swarms reads plannerTaskRef from Swarm CR spec (closes #2005)

### DIFF
--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1430,10 +1430,21 @@ check_stuck_swarms() {
         # STUCK SWARM DETECTED — spawn a new planner Job
         echo "[$(date -u +%H:%M:%S)] STUCK SWARM DETECTED: $swarm_ref has been in phase=Forming for ${stuck_seconds}s with no active planner — respawning"
 
-        # Create task CR for the swarm planner (may already exist from initial creation; idempotent)
-        local task_name="task-${swarm_ref}-planner"
+        # Read plannerTaskRef from the Swarm CR spec (issue #2005: agents may use a different
+        # naming convention than task-${swarm_ref}-planner, so always read from the source of truth)
+        local planner_task_ref
+        planner_task_ref=$(kubectl_with_timeout 10 get swarm.kro.run "$swarm_ref" -n "$NAMESPACE" \
+            -o jsonpath='{.spec.plannerTaskRef}' 2>/dev/null || echo "")
+        # Fall back to the standard naming convention if Swarm CR is not readable
+        local task_name="${planner_task_ref:-task-${swarm_ref}-planner}"
+        if [ -z "$planner_task_ref" ]; then
+            echo "[$(date -u +%H:%M:%S)] check_stuck_swarms: could not read plannerTaskRef from Swarm CR $swarm_ref — using default task name $task_name"
+        else
+            echo "[$(date -u +%H:%M:%S)] check_stuck_swarms: using plannerTaskRef=$task_name from Swarm CR $swarm_ref"
+        fi
         local safe_goal
         safe_goal=$(echo "$swarm_goal" | head -c 200 | sed 's/"/\\"/g')
+        # Create Task CR using the correct plannerTaskRef name from Swarm CR spec (issue #2005)
         kubectl_with_timeout 10 apply -f - <<TASK_EOF 2>/dev/null || true
 apiVersion: kro.run/v1alpha1
 kind: Task


### PR DESCRIPTION
## Summary

Fixes swarms stuck in Forming forever when agents create Swarm CRs with a non-standard `plannerTaskRef` name.

Closes #2005

## Root Cause

`check_stuck_swarms()` in `coordinator.sh` hardcoded the recovery Task CR name as `task-${swarm_ref}-planner`. However, the Swarm CR's `spec.plannerTaskRef` can differ from this pattern.

**Evidence from live cluster:**
- `swarm-debate-synthesis-1773190665` has `plannerTaskRef: task-swarm-debate-synthesis-planner-1773190665`
- But coordinator recovery would create `task-swarm-debate-synthesis-1773190665-planner` (different order)
- The recovery planner Job starts with `TASK_CR_NAME` pointing to the wrong (non-existent) Task CR
- With no task context, the planner exits immediately without spawning workers
- Swarm stays in `Forming` forever

## Fix

Read `plannerTaskRef` from the Swarm CR spec (`spec.plannerTaskRef`) before creating the Task CR and spawning the recovery Job. The actual plannerTaskRef is the source of truth for what Task CR the swarm planner Job expects.

Falls back to `task-${swarm_ref}-planner` convention only if the Swarm CR is unavailable (kro controller issue).

## Changes

- `images/runner/coordinator.sh`: `check_stuck_swarms()` now reads `plannerTaskRef` from the Swarm CR spec via `kubectl get swarm.kro.run`. The Task CR is created with the correct name that matches what the recovery planner Job will read as `TASK_CR_NAME`.

## Testing

Verified against live cluster state:
- `swarm-debate-synthesis-1773190665` has `plannerTaskRef: task-swarm-debate-synthesis-planner-1773190665`
- After this fix, coordinator recovery will create the correct Task CR and pass the correct `TASK_CR_NAME` to the recovery planner Job