### PR TITLE
fix: proactive_coordinator_scan() dedup skips continue to next check (closes #2026)

### DIFF
--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -1927,19 +1927,20 @@ proactive_coordinator_scan() {
     done
     if [ "$stale_count" -ge 1 ]; then
       log "Coordinator scan: found $stale_count very-stale assignments (>2h) — filing issue..."
-      # Issue #2004: dedup using stable keyword — stale_count varies each run, defeating title dedup.
-      # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
-      local existing_stale_issue
-      existing_stale_issue=$(gh issue list --repo "$REPO" --state open \
-        --search "coordinator state assignments persisted past job completion" \
-        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
-      if [ "${existing_stale_issue:-0}" -gt 0 ]; then
-        log "Coordinator scan: stale assignment issue already open — skipping duplicate (stale_count=$stale_count)"
-        return 0
-      fi
-      file_proactive_issue "bug" \
-        "coordinator state: $stale_count assignments persisted >2h past job completion" \
-        "The coordinator has $stale_count assignments for agents whose Jobs completed >2 hours ago.
+       # Issue #2004: dedup using stable keyword — stale_count varies each run, defeating title dedup.
+       # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
+       local existing_stale_issue
+       existing_stale_issue=$(gh issue list --repo "$REPO" --state open \
+         --search "coordinator state assignments persisted past job completion" \
+         --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+       if [ "${existing_stale_issue:-0}" -gt 0 ]; then
+         log "Coordinator scan: stale assignment issue already open — skipping duplicate, continuing to next check (stale_count=$stale_count)"
+         # Issue #2026: Do NOT return here — fall through to Check 2 and Check 3.
+         # Returning early prevents heartbeat and debate backlog checks from ever running.
+       else
+         file_proactive_issue "bug" \
+           "coordinator state: $stale_count assignments persisted >2h past job completion" \
+           "The coordinator has $stale_count assignments for agents whose Jobs completed >2 hours ago.
 
 Discovered by: $AGENT_DISPLAY_NAME (specialization: $AGENT_SPECIALIZATION)
 
@@ -1952,7 +1953,8 @@ This issue was proactively filed by a domain specialist during systematic scan.
 1. Review \`cleanup_stale_assignments()\` in coordinator.sh
 2. Check coordinator logs for cleanup failures
 3. Verify coordinator heartbeat is current (check \`coordinator-state.lastHeartbeat\`)"
-      return 0
+         return 0  # One issue per run — return after filing
+       fi
     fi
   fi
 
@@ -1967,19 +1969,20 @@ This issue was proactively filed by a domain specialist during systematic scan.
     local heartbeat_age=$(( now_epoch - heartbeat_epoch ))
     if [ "$heartbeat_age" -gt 600 ]; then
       log "Coordinator scan: coordinator heartbeat is ${heartbeat_age}s old (>10min) — filing issue..."
-      # Issue #2004: dedup using stable keyword — heartbeat_age varies each run, defeating title dedup.
-      # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
-      local existing_heartbeat_issue
-      existing_heartbeat_issue=$(gh issue list --repo "$REPO" --state open \
-        --search "coordinator liveness heartbeat stale coordinator may be stuck" \
-        --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
-      if [ "${existing_heartbeat_issue:-0}" -gt 0 ]; then
-        log "Coordinator scan: coordinator liveness issue already open — skipping duplicate (heartbeat_age=${heartbeat_age}s)"
-        return 0
-      fi
-      file_proactive_issue "bug" \
-        "coordinator liveness: heartbeat stale by ${heartbeat_age}s — coordinator may be stuck" \
-        "The coordinator's \`lastHeartbeat\` is ${heartbeat_age} seconds old (threshold: 600s).
+       # Issue #2004: dedup using stable keyword — heartbeat_age varies each run, defeating title dedup.
+       # Same root cause as issue #1934 (count-varying titles create unlimited duplicate issues).
+       local existing_heartbeat_issue
+       existing_heartbeat_issue=$(gh issue list --repo "$REPO" --state open \
+         --search "coordinator liveness heartbeat stale coordinator may be stuck" \
+         --json number --limit 1 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+       if [ "${existing_heartbeat_issue:-0}" -gt 0 ]; then
+         log "Coordinator scan: coordinator liveness issue already open — skipping duplicate, continuing to next check (heartbeat_age=${heartbeat_age}s)"
+         # Issue #2026: Do NOT return here — fall through to Check 3 (unresolved debates).
+         # Returning early prevents the debate backlog check from ever running.
+       else
+         file_proactive_issue "bug" \
+           "coordinator liveness: heartbeat stale by ${heartbeat_age}s — coordinator may be stuck" \
+           "The coordinator's \`lastHeartbeat\` is ${heartbeat_age} seconds old (threshold: 600s).
 
 Discovered by: $AGENT_DISPLAY_NAME (specialization: $AGENT_SPECIALIZATION)
 
@@ -1992,7 +1995,8 @@ The coordinator updates \`lastHeartbeat\` every iteration (~30s). A stale heartb
 1. Check coordinator pod status: \`kubectl get pods -n agentex -l app=coordinator\`
 2. Check coordinator logs for errors
 3. If stuck, restart: \`kubectl rollout restart deployment/coordinator -n agentex\`"
-      return 0
+         return 0  # One issue per run — return after filing
+       fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

Fixes a bug introduced in PR #2006 (issue #2004) where dedup-skip `return 0` statements in `proactive_coordinator_scan()` exit the entire function, preventing Check 2 (heartbeat) and Check 3 (debates) from ever running when Check 1 finds an existing issue.

Closes #2026

## Root Cause

PR #2006 added dedup checks to prevent duplicate issue filing:
```bash
if [ "${existing_stale_issue:-0}" -gt 0 ]; then
  log "...skipping duplicate..."
  return 0  # ← exits entire function!
fi
```

This means if Check 1's dedup fires (stale assignments issue already open), Check 2 (heartbeat staleness) and Check 3 (debate backlog) never run at all.

## Fix

Changed dedup-skip sections from early return to if/else pattern:
- When duplicate found: log and fall through to next check
- When filing an issue: return 0 after filing (one-issue-per-run limit preserved)

```bash
# Before (bug):
if [ "${existing_stale_issue:-0}" -gt 0 ]; then
  return 0  # exits entire function!
fi
file_proactive_issue ...
return 0

# After (fix):
if [ "${existing_stale_issue:-0}" -gt 0 ]; then
  log "skipping duplicate, continuing to next check"
  # fall through to Check 2
else
  file_proactive_issue ...
  return 0  # only after filing
fi
```

## Impact

- `proactive_coordinator_scan()` now runs all 3 independent checks per invocation
- Heartbeat and debate backlog anomalies are detected even when stale assignments already have an open issue
- v0.5 Criterion 3 (proactiveIssuesFound) is easier to satisfy — more independent checks means more chances to file issues
- The one-issue-per-run spam prevention is preserved (return 0 after filing, not after dedup skip)