### PR TITLE
feat: gradual bash migration — Go binaries in runner image with feature flags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Docker build context filter
+# The runner Dockerfile builds from repo root to access Go source files.
+# Exclude everything that's not needed for the build.
+
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# Documentation
+*.md
+!AGENTS.md
+LICENSE
+
+# Kubernetes manifests (not needed in image)
+manifests/
+chart/
+kro/
+
+# Build artifacts
+bin/
+agent
+coordinator
+
+# Local dev
+.god-notes.md
+.env
+*.log
+
+# Node modules (npm install happens inside Docker)
+node_modules/
+
+# Test fixtures only needed at Go test time, not in Docker
+**/*_test.go

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -5,9 +5,19 @@ on:
     branches: [main]
     paths:
       - 'images/runner/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'roles/**'
   pull_request:
     paths:
       - 'images/runner/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'roles/**'
 
 env:
   AWS_REGION: us-west-2
@@ -36,10 +46,13 @@ jobs:
 
       - name: Build image
         run: |
+          # Build context is repo root (not images/runner/) because the Dockerfile
+          # has a Go build stage that needs access to go.mod, cmd/, internal/, roles/
           docker build \
             -t $ECR_REGISTRY/$ECR_REPO:${{ github.sha }} \
             -t $ECR_REGISTRY/$ECR_REPO:latest \
-            images/runner/
+            -f images/runner/Dockerfile \
+            .
 
       - name: Scan with Trivy
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -8,7 +8,10 @@ on:
       - 'go.sum'
       - 'cmd/**'
       - 'internal/**'
+      - 'roles/**'
       - 'Makefile'
+      - 'images/runner/Dockerfile'
+      - 'images/coordinator-go/Dockerfile'
       - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
@@ -16,7 +19,10 @@ on:
       - 'go.sum'
       - 'cmd/**'
       - 'internal/**'
+      - 'roles/**'
       - 'Makefile'
+      - 'images/runner/Dockerfile'
+      - 'images/coordinator-go/Dockerfile'
       - '.github/workflows/go-ci.yml'
 
 jobs:
@@ -49,8 +55,14 @@ jobs:
           go-version: '1.25'
           cache: true
 
+      - name: Build agent binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/agent ./cmd/agent/
+
       - name: Build coordinator binary
         run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/coordinator ./cmd/coordinator/
 
-      - name: Build Docker image
+      - name: Build coordinator-go Docker image
         run: docker build -t agentex/coordinator-go:test -f images/coordinator-go/Dockerfile .
+
+      - name: Build runner Docker image (Go stage only)
+        run: docker build --target go-builder -t agentex/runner-go-builder:test -f images/runner/Dockerfile .

--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -1,4 +1,26 @@
 # ============================================================================
+# Stage 0: Go builder — compile agent and coordinator binaries
+# ============================================================================
+FROM golang:1.25-alpine AS go-builder
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /build
+
+# Copy module files first for Docker layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy Go source
+COPY cmd/ cmd/
+COPY internal/ internal/
+COPY roles/ roles/
+
+# Build both binaries — static, no CGO
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /build/bin/agentex-agent ./cmd/agent/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /build/bin/agentex-coordinator ./cmd/coordinator/
+
+# ============================================================================
 # Stage 1: Builder — Install Node.js with gnupg, then remove gnupg completely
 # ============================================================================
 FROM ubuntu:24.04 AS builder
@@ -127,12 +149,19 @@ RUN git config --system user.name "agentex-bot" \
     && git config --system credential.helper store \
     && git config --system safe.directory '*'
 
-COPY entrypoint.sh /entrypoint.sh
-COPY coordinator.sh /usr/local/bin/coordinator.sh
-COPY planner-loop.sh /usr/local/bin/planner-loop.sh
-COPY identity.sh /agent/identity.sh
-COPY helpers.sh /agent/helpers.sh
+COPY images/runner/entrypoint.sh /entrypoint.sh
+COPY images/runner/coordinator.sh /usr/local/bin/coordinator.sh
+COPY images/runner/planner-loop.sh /usr/local/bin/planner-loop.sh
+COPY images/runner/identity.sh /agent/identity.sh
+COPY images/runner/helpers.sh /agent/helpers.sh
 RUN mkdir -p /agent && chmod +x /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent/identity.sh /agent/helpers.sh && chown -R agentex:agentex /entrypoint.sh /usr/local/bin/coordinator.sh /usr/local/bin/planner-loop.sh /agent
+
+# Go binaries — compiled in go-builder stage, placed alongside bash scripts.
+# Set AGENTEX_USE_GO=true to use the Go agent entrypoint instead of bash.
+# Set AGENTEX_USE_GO_COORDINATOR=true to use the Go coordinator instead of bash.
+COPY --from=go-builder /build/bin/agentex-agent /usr/local/bin/agentex-agent
+COPY --from=go-builder /build/bin/agentex-coordinator /usr/local/bin/agentex-coordinator
+RUN chmod +x /usr/local/bin/agentex-agent /usr/local/bin/agentex-coordinator
 
 USER agentex
 WORKDIR /workspace

--- a/images/runner/coordinator.sh
+++ b/images/runner/coordinator.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -uo pipefail
 
+# ── Go coordinator dispatch ────────────────────────────────────────────────
+# When AGENTEX_USE_GO_COORDINATOR=true, bypass the entire bash coordinator
+# and exec the Go binary. The Go coordinator handles: reconciliation loop,
+# state management, agent lifecycle, health monitoring — all in tested Go.
+if [ "${AGENTEX_USE_GO_COORDINATOR:-false}" = "true" ] && [ -x /usr/local/bin/agentex-coordinator ]; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [coordinator] Dispatching to Go coordinator binary" >&2
+  exec /usr/local/bin/agentex-coordinator --namespace="${NAMESPACE:-agentex}"
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════
 # COORDINATOR — The Civilization's Persistent Brain
 # ═══════════════════════════════════════════════════════════════════════════

--- a/images/runner/entrypoint.sh
+++ b/images/runner/entrypoint.sh
@@ -6,6 +6,15 @@
 # The system never idles. No human needed after initial seed.
 set -euo pipefail
 
+# ── Go agent dispatch ──────────────────────────────────────────────────────
+# When AGENTEX_USE_GO=true, bypass the entire bash entrypoint and exec the
+# Go binary. The Go agent handles: read task, setup git, run OpenCode,
+# post report, spawn successor — all in ~350 lines of tested Go.
+if [ "${AGENTEX_USE_GO:-false}" = "true" ] && [ -x /usr/local/bin/agentex-agent ]; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${AGENT_NAME:-unknown}] Dispatching to Go agent binary" >&2
+  exec /usr/local/bin/agentex-agent
+fi
+
 # Ensure opencode binary is on PATH regardless of npm symlink state (issue #1051)
 # npm install -g on nodesource installs to /usr/lib/node_modules, not /usr/local/lib
 export PATH="/usr/lib/node_modules/opencode-ai/bin:${PATH}"

--- a/manifests/rgds/agent-graph.yaml
+++ b/manifests/rgds/agent-graph.yaml
@@ -16,6 +16,7 @@ spec:
       clusterName: string | default="agentex"
       useSpot: boolean | default=false  # Workers can use spot for ~70% cost reduction (issue #20)
       capacityType: string | default="on-demand"  # "on-demand" or "spot" — controls Karpenter scheduling
+      useGoAgent: string | default="false"  # Set to "true" to use the Go agent entrypoint instead of bash
     status:
       jobName: ${agentJob.metadata.name}
       # completionTime replaced with string proxy — metav1.Time causes kro deep-copy panic
@@ -112,6 +113,8 @@ spec:
                         secretKeyRef:
                           name: agentex-github-token
                           key: token
+                    - name: AGENTEX_USE_GO  # Feature flag: "true" dispatches to Go binary, "false" uses bash entrypoint
+                      value: ${schema.spec.useGoAgent}
                   resources:
                     requests:
                       memory: "512Mi"

--- a/manifests/rgds/coordinator-graph.yaml
+++ b/manifests/rgds/coordinator-graph.yaml
@@ -12,6 +12,7 @@ spec:
       imageTag: string | default="latest"
       imageRegistry: string | default="569190534191.dkr.ecr.us-west-2.amazonaws.com"
       clusterName: string | default="agentex"
+      useGoCoordinator: string | default="false"  # Set to "true" to use the Go coordinator instead of bash
     status:
       configMapName: ${coordinatorState.metadata.name}
       deploymentName: ${coordinatorDeployment.metadata.name}
@@ -110,6 +111,8 @@ spec:
                       value: ${schema.metadata.namespace}
                     - name: GITHUB_TOKEN_FILE
                       value: "/var/secrets/github/token"
+                    - name: AGENTEX_USE_GO_COORDINATOR  # Feature flag: "true" dispatches to Go binary
+                      value: ${schema.spec.useGoCoordinator}
                   resources:
                     requests:
                       memory: "512Mi"


### PR DESCRIPTION
## Summary

Wire the Go agent and coordinator binaries into the runner Docker image alongside existing bash scripts. Feature flags control which entrypoint runs — bash remains default, Go is opt-in.

**Closes #2050**

## Changes

- **Dockerfile**: Add Go build stage (Stage 0) that compiles `agentex-agent` and `agentex-coordinator` static binaries, copied into final image at `/usr/local/bin/`
- **Feature flags**: 
  - `AGENTEX_USE_GO=true` → agent pods use Go entrypoint (350 lines) instead of bash (4,335 lines)
  - `AGENTEX_USE_GO_COORDINATOR=true` → coordinator uses Go binary instead of bash (4,616 lines)
- **RGDs**: Added `useGoAgent` field to `agent-graph` and `useGoCoordinator` field to `coordinator-graph`
- **Dispatch shims**: entrypoint.sh and coordinator.sh check the respective env var at startup — if true and binary exists, `exec` to Go binary immediately
- **CI**: Updated `build-runner.yml` to use repo root as Docker context (Go source access), added Go source path triggers, updated `go-ci.yml` to build both binaries
- **.dockerignore**: Added to keep Docker build context lean

## Gradual Migration Path

1. **Now**: Both binaries are in the image, bash is default, Go is dormant
2. **Test**: Create agent CRs with `useGoAgent: "true"` to test Go entrypoint on individual agents
3. **Validate**: Once Go agents work reliably, flip the default in the RGD
4. **Remove**: After Go is proven, remove bash scripts entirely (reducing 11,309 lines of bash)

## Risk

Zero risk to existing agents — feature flags default to `"false"`, bash behavior is completely unchanged. Go binaries add ~15MB to the runner image.