### PR TITLE
feat: Campaign CRD via KRO + coordinator liveness probe compatibility

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -103,6 +104,9 @@ func (c *Coordinator) tick(ctx context.Context, iteration int) {
 		c.logger.Error("heartbeat failed", "error", err)
 	}
 
+	// Every tick: touch liveness probe file (K8s exec probe compatibility)
+	c.touchLivenessFile()
+
 	// Every tick: cleanup stale assignments
 	if err := c.cleanupStaleAssignments(ctx); err != nil {
 		c.logger.Error("cleanup stale assignments failed", "error", err)
@@ -166,6 +170,16 @@ func (c *Coordinator) loadConstitution(ctx context.Context) error {
 func (c *Coordinator) heartbeat(ctx context.Context) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	return c.stateManager.UpdateField(ctx, "lastHeartbeat", now)
+}
+
+// touchLivenessFile writes /tmp/coordinator-alive for K8s exec-based
+// liveness probes. The coordinator-graph RGD uses an exec probe that
+// checks for this file. This ensures compatibility whether running
+// the bash or Go coordinator.
+func (c *Coordinator) touchLivenessFile() {
+	if err := os.WriteFile("/tmp/coordinator-alive", []byte(time.Now().UTC().Format(time.RFC3339)), 0o644); err != nil {
+		c.logger.Warn("failed to touch liveness file", "error", err)
+	}
 }
 
 // ensureStateFieldsInitialized initializes coordinator-state fields that may

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -60,6 +60,11 @@ var (
 		Version:  KroVersion,
 		Resource: "messages",
 	}
+	CampaignGVR = schema.GroupVersionResource{
+		Group:    KroGroup,
+		Version:  KroVersion,
+		Resource: "campaigns",
+	}
 )
 
 // Client wraps Kubernetes clientset and dynamic client with typed convenience methods.

--- a/manifests/rgds/campaign-graph.yaml
+++ b/manifests/rgds/campaign-graph.yaml
@@ -1,0 +1,43 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: campaign-graph
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Campaign
+    spec:
+      title: string | required=true
+      description: string | default=""
+      owner: string | default=""
+      priority: integer | default=5
+      tasks: string | default="[]"
+      dependencies: string | default="{}"
+    status:
+      configMapName: ${campaignState.metadata.name}
+      phase: ${campaignState.data.phase}
+  resources:
+    # Campaign state ConfigMap — tracks campaign progress, task status,
+    # and dependency resolution. The coordinator's campaign system
+    # (internal/coordinator/campaign.go) manages dynamic fields at runtime.
+    - id: campaignState
+      readyWhen:
+        - ${campaignState.metadata.resourceVersion != ""}
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${schema.metadata.name}-state
+          namespace: ${schema.metadata.namespace}
+          labels:
+            app: agentex-campaign
+            agentex/component: campaign
+            agentex/campaign: ${schema.metadata.name}
+        data:
+          title: ${schema.spec.title}
+          description: ${schema.spec.description}
+          owner: ${schema.spec.owner}
+          priority: ${string(schema.spec.priority)}
+          tasks: ${schema.spec.tasks}
+          dependencies: ${schema.spec.dependencies}
+          phase: "pending"


### PR DESCRIPTION
## Summary

Add a Campaign custom resource definition (via KRO ResourceGraphDefinition) and wire it into the Go codebase. Also add liveness probe file compatibility to the Go coordinator.

**Closes #2051**

## Changes

### Campaign CRD (`manifests/rgds/campaign-graph.yaml`)
New KRO RGD that creates a `Campaign` custom resource. Each Campaign creates a state ConfigMap tracking:
- Title, description, owner, priority
- Task list (JSON array of issue numbers)
- Dependencies (JSON map)
- Phase (pending → active → completed)

This makes campaigns first-class Kubernetes resources, trackable via `kubectl get campaigns`.

### Go integration
- Added `CampaignGVR` to `internal/k8s/client.go` so Go code can create/list/update Campaign CRs
- Added `touchLivenessFile()` to coordinator tick — writes `/tmp/coordinator-alive` every heartbeat cycle, matching the bash coordinator's behavior for K8s exec-based liveness probes

## RGD Inventory After This PR

| RGD | CR Kind | Resources Created |
|-----|---------|-------------------|
| agent-graph | Agent | Job |
| task-graph | Task | ConfigMap |
| thought-graph | Thought | ConfigMap |
| message-graph | Message | ConfigMap |
| report-graph | Report | ConfigMap |
| swarm-graph | Swarm | ConfigMap + Job |
| coordinator-graph | Coordinator | ConfigMap + Deployment |
| planner-loop-graph | PlannerLoop | Deployment |
| **campaign-graph** | **Campaign** | **ConfigMap** (new) |