### PR TITLE
e2e: planning state and swarm memory scenario tests (closes #2078)

### DIFF
--- a/e2e/harness/s3.go
+++ b/e2e/harness/s3.go
@@ -99,6 +99,52 @@ func (c *Cluster) ListS3SwarmMemories(ctx context.Context, t *testing.T, agentNa
 	return keys
 }
 
+// GetS3SharedSwarmMemory reads the shared swarm memory object for the given swarm name.
+// The object is written to "swarm-memories/<swarmName>.json" by mock agents that
+// have FLIGHT_SWARM_NAME set. Multiple agents in the same swarm append themselves
+// to the same object via read-modify-write in s3_behaviors.go.
+func (c *Cluster) GetS3SharedSwarmMemory(ctx context.Context, t *testing.T, swarmName string) *agentexs3.S3SwarmMemory {
+	t.Helper()
+	s3c := c.S3Client()
+	key := fmt.Sprintf("swarm-memories/%s.json", swarmName)
+	var mem agentexs3.S3SwarmMemory
+	if err := s3c.GetJSON(ctx, key, &mem); err != nil {
+		t.Fatalf("get S3 shared swarm memory for swarm %s: %v", swarmName, err)
+	}
+	return &mem
+}
+
+// WaitForS3SharedSwarmMemberCount polls until the shared swarm memory for swarmName
+// has at least wantCount members, or timeout is reached.
+// This is needed because multiple agents write concurrently and there is no
+// guaranteed ordering — the test must wait for all 3 agents to finish writing.
+func (c *Cluster) WaitForS3SharedSwarmMemberCount(ctx context.Context, t *testing.T, swarmName string, wantCount int, timeout time.Duration) {
+	t.Helper()
+	s3c := c.S3Client()
+	key := fmt.Sprintf("swarm-memories/%s.json", swarmName)
+	c.WaitReady(ctx, t, fmt.Sprintf("swarm-memories/%s members >= %d", swarmName, wantCount), timeout, func() (bool, error) {
+		var mem agentexs3.S3SwarmMemory
+		if err := s3c.GetJSON(ctx, key, &mem); err != nil {
+			return false, nil // key may not exist yet — keep polling
+		}
+		return len(mem.Members) >= wantCount, nil
+	})
+}
+
+// CleanupS3SharedSwarmMemory deletes the shared swarm memory object for a swarm name.
+func (c *Cluster) CleanupS3SharedSwarmMemory(ctx context.Context, t *testing.T, swarmName string) {
+	t.Helper()
+	if os.Getenv("E2E_S3_CLEANUP") == "false" {
+		t.Logf("skipping S3 cleanup (E2E_S3_CLEANUP=false)")
+		return
+	}
+	s3c := c.S3Client()
+	key := fmt.Sprintf("swarm-memories/%s.json", swarmName)
+	if err := s3c.DeletePrefix(ctx, key); err != nil {
+		t.Logf("S3 cleanup swarm-memories/%s: %v", swarmName, err)
+	}
+}
+
 // ListS3ChronicleCandidates lists chronicle candidate keys for the given agent.
 func (c *Cluster) ListS3ChronicleCandidates(ctx context.Context, t *testing.T, agentName string) []string {
 	t.Helper()

--- a/e2e/swarm_test.go
+++ b/e2e/swarm_test.go
@@ -1,0 +1,111 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSwarmMemory verifies that 3 mock agents sharing FLIGHT_SWARM_NAME all
+// appear in a single shared S3 swarm-memory object.
+//
+// Scenario:
+//  1. Create 3 mock agents with the same FLIGHT_SWARM_NAME=swarm-e2e-<RunID>.
+//  2. Each agent writes its swarm memory via the shared read-modify-write path
+//     in s3_behaviors.go (writeSharedSwarmMemory).
+//  3. Wait for all 3 Jobs to succeed.
+//  4. Assert S3 object "swarm-memories/swarm-e2e-<RunID>.json" exists.
+//  5. Assert all 3 agent names appear in the members array.
+//  6. Assert keyDecisions is non-empty (at least one decision logged).
+func TestSwarmMemory(t *testing.T) {
+	c, ctx := newCluster(t)
+
+	swarmName := c.Name("swarm-e2e")
+	const agentCount = 3
+	const issueBase = 9030
+
+	// Prepare 3 agents sharing the same swarm name.
+	type agentSpec struct {
+		name        string
+		taskCRName  string
+		issueNumber int
+	}
+	agents := make([]agentSpec, agentCount)
+	for i := 0; i < agentCount; i++ {
+		agents[i] = agentSpec{
+			name:        c.Name(fmt.Sprintf("swarm-agent-%d", i)),
+			taskCRName:  c.Name(fmt.Sprintf("task-swarm-%d", i)),
+			issueNumber: issueBase + i,
+		}
+	}
+
+	// Create Task CRs and inject active assignments.
+	for _, a := range agents {
+		c.CreateMockTaskCR(ctx, t, a.taskCRName, a.issueNumber,
+			fmt.Sprintf("Swarm memory test — agent %s", a.name))
+		c.InjectActiveAssignment(ctx, t, a.name, a.issueNumber)
+	}
+
+	// Launch all 3 Jobs concurrently with the shared swarm name.
+	for _, a := range agents {
+		job := c.BuildFlightJob(a.name, a.taskCRName, "worker", 2, false, map[string]string{
+			"FLIGHT_S3_ENABLED":   "true",
+			"FLIGHT_SWARM_ENABLED": "true",
+			"FLIGHT_SWARM_NAME":   swarmName,
+		})
+		c.CreateCustomJob(ctx, t, job)
+		c.Logf(t, "created swarm agent job %s (swarm=%s)", a.name, swarmName)
+	}
+
+	// Wait for all 3 Jobs to succeed concurrently.
+	var wg sync.WaitGroup
+	for _, a := range agents {
+		a := a // capture
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.WaitForJobStatus(ctx, t, a.name, "succeeded", 120*time.Second)
+			c.Logf(t, "swarm agent job %s succeeded", a.name)
+		}()
+	}
+	wg.Wait()
+
+	// Wait for the shared swarm memory object to reflect all 3 members.
+	// Each agent does a read-modify-write so membership builds up over time.
+	c.WaitForS3SharedSwarmMemberCount(ctx, t, swarmName, agentCount, 60*time.Second)
+
+	// Assert the shared swarm memory object.
+	mem := c.GetS3SharedSwarmMemory(ctx, t, swarmName)
+
+	if mem.SwarmName != swarmName {
+		t.Errorf("swarm memory swarmName=%q, want %q", mem.SwarmName, swarmName)
+	}
+
+	// All 3 agent names must appear in members.
+	memberSet := make(map[string]bool, len(mem.Members))
+	for _, m := range mem.Members {
+		memberSet[m] = true
+	}
+	for _, a := range agents {
+		if !memberSet[a.name] {
+			t.Errorf("agent %q not found in swarm members %v", a.name, mem.Members)
+		}
+	}
+
+	// Decisions must be non-empty.
+	if len(mem.Decisions) == 0 {
+		t.Errorf("swarm memory keyDecisions is empty, expected at least one entry")
+	}
+
+	// Cleanup shared swarm S3 object.
+	c.CleanupS3SharedSwarmMemory(ctx, t, swarmName)
+	// Cleanup per-agent S3 objects.
+	for _, a := range agents {
+		c.CleanupE2ES3Prefix(ctx, t, a.name)
+	}
+
+	c.Logf(t, "TestSwarmMemory passed — %d agents in swarm %s", len(mem.Members), swarmName)
+}

--- a/internal/agent/s3_behaviors.go
+++ b/internal/agent/s3_behaviors.go
@@ -4,7 +4,9 @@ package agent
 //
 // This file implements the S3 write behaviors that real agents perform via helpers.sh:
 //   - write_planning_state  → s3://<bucket>/<prefix>planning/<agent>.json
-//   - write_swarm_memory    → s3://<bucket>/<prefix>swarm/<name>-<ts>.json
+//   - write_swarm_memory    → s3://<bucket>/<prefix>swarm/<name>-<ts>.json  (per-agent)
+//     OR when FLIGHT_SWARM_NAME is set:
+//                           → s3://<bucket>/<prefix>swarm-memories/<swarmName>.json (shared, append)
 //   - update_identity_stats → s3://<bucket>/<prefix>identity/<agent>.json
 //   - post_chronicle_candidate → s3://<bucket>/<prefix>chronicle-candidates/<agent>-<ts>.json
 //
@@ -35,6 +37,12 @@ type S3BehaviorConfig struct {
 	// SwarmEnabled writes a swarm memory JSON to S3 (FLIGHT_SWARM_ENABLED).
 	SwarmEnabled bool
 
+	// SwarmName is the shared swarm name set by FLIGHT_SWARM_NAME.
+	// When non-empty each agent appends itself to
+	// "swarm-memories/<SwarmName>.json" (read-modify-write) rather than
+	// writing an isolated per-agent key under "swarm/".
+	SwarmName string
+
 	// IdentityEnabled writes an identity stats JSON to S3 (FLIGHT_IDENTITY_ENABLED).
 	IdentityEnabled bool
 
@@ -54,6 +62,11 @@ func LoadS3BehaviorConfig() *S3BehaviorConfig {
 		cfg.Enabled = true
 	}
 	if os.Getenv("FLIGHT_SWARM_ENABLED") == "true" {
+		cfg.SwarmEnabled = true
+		cfg.Enabled = true
+	}
+	if v := os.Getenv("FLIGHT_SWARM_NAME"); v != "" {
+		cfg.SwarmName = v
 		cfg.SwarmEnabled = true
 		cfg.Enabled = true
 	}
@@ -91,7 +104,7 @@ func RunS3Behaviors(ctx context.Context, s3Client *agentexs3.Client, agentCfg *A
 	}
 
 	if s3Cfg.SwarmEnabled {
-		if err := writeSwarmMemory(ctx, s3Client, agentCfg, task); err != nil {
+		if err := writeSwarmMemory(ctx, s3Client, agentCfg, s3Cfg, task); err != nil {
 			slog.Warn("s3 behaviors: failed to write swarm memory", "error", err)
 		}
 	}
@@ -133,8 +146,83 @@ func writePlanningState(ctx context.Context, s3Client *agentexs3.Client, cfg *Ag
 }
 
 // writeSwarmMemory writes a swarm memory entry to S3.
+//
+// When s3Cfg.SwarmName is set (FLIGHT_SWARM_NAME), the agent performs a
+// read-modify-write to append itself to the shared swarm memory object at
+// "swarm-memories/<SwarmName>.json". This lets TestSwarmMemory verify that
+// all 3 concurrent agents appear in the same S3 object's members array.
+//
+// When SwarmName is empty, the legacy per-agent write is used:
 // Key: swarm/<agentName>-<timestamp>.json
-func writeSwarmMemory(ctx context.Context, s3Client *agentexs3.Client, cfg *AgentConfig, task *TaskInfo) error {
+func writeSwarmMemory(ctx context.Context, s3Client *agentexs3.Client, cfg *AgentConfig, s3Cfg *S3BehaviorConfig, task *TaskInfo) error {
+	if s3Cfg.SwarmName != "" {
+		return writeSharedSwarmMemory(ctx, s3Client, cfg, s3Cfg.SwarmName, task)
+	}
+	return writePerAgentSwarmMemory(ctx, s3Client, cfg, task)
+}
+
+// writeSharedSwarmMemory appends this agent to a shared swarm memory object.
+// Key: swarm-memories/<swarmName>.json
+// It performs a read-modify-write with a simple retry to handle concurrent writes.
+func writeSharedSwarmMemory(ctx context.Context, s3Client *agentexs3.Client, cfg *AgentConfig, swarmName string, task *TaskInfo) error {
+	key := fmt.Sprintf("swarm-memories/%s.json", swarmName)
+
+	// Retry up to 5 times to handle concurrent writes from multiple agents.
+	const maxRetries = 5
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt*200) * time.Millisecond)
+		}
+
+		// Try to read the existing shared memory.
+		var existing agentexs3.S3SwarmMemory
+		readErr := s3Client.GetJSON(ctx, key, &existing)
+
+		if readErr != nil {
+			// First writer: initialise the object.
+			existing = agentexs3.S3SwarmMemory{
+				SwarmName: swarmName,
+				Goal:      fmt.Sprintf("flight test swarm: %s", swarmName),
+				Members:   []string{},
+				Tasks:     []string{},
+				Decisions: []string{},
+				Origin:    cfg.Name,
+				Timestamp: time.Now().UTC(),
+			}
+		}
+
+		// Append this agent if not already present.
+		alreadyMember := false
+		for _, m := range existing.Members {
+			if m == cfg.Name {
+				alreadyMember = true
+				break
+			}
+		}
+		if !alreadyMember {
+			existing.Members = append(existing.Members, cfg.Name)
+			existing.Tasks = append(existing.Tasks, fmt.Sprintf("issue-%d", task.IssueNumber))
+			existing.Decisions = append(existing.Decisions,
+				fmt.Sprintf("%s (role=%s) joined swarm for issue #%d", cfg.Name, cfg.Role, task.IssueNumber))
+			existing.Timestamp = time.Now().UTC()
+		}
+
+		if err := s3Client.PutJSON(ctx, key, existing); err != nil {
+			if attempt < maxRetries-1 {
+				slog.Warn("s3: shared swarm write conflict, retrying", "attempt", attempt, "error", err)
+				continue
+			}
+			return fmt.Errorf("shared swarm memory %s: %w", key, err)
+		}
+		slog.Info("s3: wrote shared swarm memory", "key", key, "members", len(existing.Members))
+		return nil
+	}
+	return fmt.Errorf("shared swarm memory %s: exceeded max retries", key)
+}
+
+// writePerAgentSwarmMemory writes an individual swarm memory entry.
+// Key: swarm/<agentName>-<timestamp>.json
+func writePerAgentSwarmMemory(ctx context.Context, s3Client *agentexs3.Client, cfg *AgentConfig, task *TaskInfo) error {
 	ts := time.Now().UTC()
 	mem := agentexs3.S3SwarmMemory{
 		SwarmName: fmt.Sprintf("flight-test-swarm-%s", cfg.Name),


### PR DESCRIPTION
## Summary

Adds the missing multi-agent swarm memory scenario test required by issue #2078,
building on the e2e framework from PR #2084.

The existing `planning_test.go` (in PR #2084) already covers `TestPlanningStateWrittenToS3`
and `TestIdentityAndChronicleWrittenToS3`. This PR adds the remaining missing piece:
**`TestSwarmMemory` — 3 agents writing to a shared S3 object**.

## Changes

### `internal/agent/s3_behaviors.go`
- Add `SwarmName string` field to `S3BehaviorConfig` (read from `FLIGHT_SWARM_NAME` env var)
- When `FLIGHT_SWARM_NAME` is set: agents append themselves to a shared
  `swarm-memories/<name>.json` object via read-modify-write (with 5-attempt retry for concurrency)
- When `FLIGHT_SWARM_NAME` is empty: legacy per-agent `swarm/<agent>-<ts>.json` write (unchanged)

### `e2e/harness/s3.go`
- `GetS3SharedSwarmMemory(ctx, t, swarmName)` — reads `swarm-memories/<name>.json`
- `WaitForS3SharedSwarmMemberCount(ctx, t, swarmName, n, timeout)` — polls until ≥N members
- `CleanupS3SharedSwarmMemory(ctx, t, swarmName)` — cleanup

### `e2e/swarm_test.go` (new)
- `TestSwarmMemory`: creates 3 mock agents with `FLIGHT_SWARM_NAME=swarm-e2e-<RunID>`,
  waits concurrently for all 3 Jobs to succeed, then asserts:
  - Shared S3 object `swarm-memories/swarm-e2e-<RunID>.json` exists
  - All 3 agent names appear in `members` array
  - `decisions` is non-empty

## Relationship to PR #2084

This PR targets `feat/e2e-flight-test` (the same base as PR #2084) and adds only the
missing swarm scenario. When #2084 merges to main, this can be rebased onto main.

Closes #2078